### PR TITLE
CI: gate workflow execution for PRs on changed files

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,7 +1,11 @@
 name: admin
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - "admin/**"
+      - "rustsec/**"
+      - "Cargo.*"
   push:
     branches: main
 

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,7 +1,11 @@
 name: cargo-audit
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - "cargo-audit/**"
+      - "rustsec/**"
+      - "Cargo.*"
   push:
     branches: main
 

--- a/.github/workflows/cargo-lock.yml
+++ b/.github/workflows/cargo-lock.yml
@@ -1,7 +1,10 @@
 name: cargo-lock
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - "cargo-lock/**"
+      - "Cargo.*"
   push:
     branches: main
 

--- a/.github/workflows/cvss.yml
+++ b/.github/workflows/cvss.yml
@@ -1,7 +1,10 @@
 name: cvss
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - "cvss/**"
+      - "Cargo.*"
   push:
     branches: main
 

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -1,7 +1,10 @@
 name: platforms
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - "platforms/**"
+      - "Cargo.*"
   push:
     branches: main
 

--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -1,7 +1,13 @@
 name: rustsec
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - "cargo-lock/**"
+      - "cvss/**"
+      - "platforms/**"
+      - "rustsec/**"
+      - "Cargo.*"
   push:
     branches: main
 


### PR DESCRIPTION
Avoids running all workflows on all changes, instead running workflows for PRs that change files that could cause breakages.

The `push` triggers are still unconditional, meaning if a change does cause a breakage and this behavior masks it, it will still be caught after merge.