### PR TITLE
Add new exit status for errors

### DIFF
--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -237,9 +237,18 @@ impl Runnable for AuditCommand {
         let lockfile_path = self.file.as_deref();
         let report = self.auditor().audit(lockfile_path);
 
-        if report.vulnerabilities.found {
-            exit(1)
-        }
+        match report {
+            Ok(report) => {
+                if report.vulnerabilities.found {
+                    exit(1);
+                }
+                exit(0);
+            }
+            Err(e) => {
+                status_err!("{}", e);
+                exit(2);
+            }
+        };
     }
 }
 

--- a/cargo-audit/tests/support/empty/README
+++ b/cargo-audit/tests/support/empty/README
@@ -1,0 +1,1 @@
+This is an empty directory.

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -114,6 +114,12 @@ impl From<cargo_edit::Error> for Error {
     }
 }
 
+impl From<cargo_lock::Error> for Error {
+    fn from(other: cargo_lock::Error) -> Self {
+        format_err!(ErrorKind::Io, &other)
+    }
+}
+
 impl From<fmt::Error> for Error {
     fn from(other: fmt::Error) -> Self {
         format_err!(ErrorKind::Io, &other)


### PR DESCRIPTION
Use a new exit status (2) when an error is triggered (e.g., when finding or parsing the lockfile). Update the audit() and generate() definitions to propagate the error.

`crate::error` does not provide a convenient constructor. It is also not used elsewhere. Instead, rely on `rustsec::error` to build the error.