### PR TITLE
rustsec-admin v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec-admin"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "abscissa_core",
  "askama",

--- a/admin/CHANGELOG.md
+++ b/admin/CHANGELOG.md
@@ -1,70 +1,47 @@
-## 0.4.2 (2021-05-03)
-- web: Add back an Atom feed for advisories ([#140])
+## 0.4.3 (2021-05-22)
+- Use crates index instead of crates.io api ([#372])
 
-[#140]: https://github.com/RustSec/rustsec-admin/pull/140
+[#372]: https://github.com/RustSec/rustsec/pull/372
+
+## 0.4.2 (2021-05-03)
+- web: Add back an Atom feed for advisories
 
 ## 0.4.1 (2021-04-30)
-- Display more information on the website ([#133])
-
-[#133]: https://github.com/RustSec/rustsec-admin/pull/133
+- Display more information on the website
 
 ## 0.4.0 (2021-03-06)
-- Use a fully Rust based solution for rendering web page ([#115])
-- Use rust-embed for static assets ([#122])
-- Add argument to change where website is outputted ([#123])
-
-[#115]: https://github.com/RustSec/rustsec-admin/pull/115
-[#122]: https://github.com/RustSec/rustsec-admin/pull/122
-[#123]: https://github.com/RustSec/rustsec-admin/pull/123
+- Use a fully Rust based solution for rendering web page
+- Use rust-embed for static assets
+- Add argument to change where website is outputted
 
 ## 0.3.5 (2021-03-06) [YANKED]
 
 ## 0.3.4 (2021-01-26)
-- Bump `rustsec` crate to v0.23 ([#112])
-
-[#112]: https://github.com/RustSec/rustsec-admin/pull/112
+- Bump `rustsec` crate to v0.23
 
 ## 0.3.3 (2021-01-04)
-- assigner: fix "new year's" bug ([#102])
-
-[#102]: https://github.com/RustSec/rustsec-admin/pull/102
+- assigner: fix "new year's" bug
 
 ## 0.3.2 (2020-11-23) 
-- Bump `rustsec` crate to v0.23.0-pre ([#96])
-
-[#96]: https://github.com/RustSec/rustsec-admin/pull/96
+- Bump `rustsec` crate to v0.23.0-pre
 
 ## 0.3.1 (2020-10-27)
-- Bump `rustsec` crate to v0.22.2 ([#88])
-
-[#88]: https://github.com/RustSec/rustsec-admin/pull/88
+- Bump `rustsec` crate to v0.22.2
 
 ## 0.3.0 (2020-10-26)
-- Bump `rustsec` crate dependency to v0.22 ([#83])
-- `assign-id`: fix command after V3 advisory format migration ([#79], [#81])
-
-[#83]: https://github.com/RustSec/rustsec-admin/pull/83
-[#81]: https://github.com/RustSec/rustsec-admin/pull/81
-[#79]: https://github.com/RustSec/rustsec-admin/pull/79
+- Bump `rustsec` crate dependency to v0.22
+- `assign-id`: fix command after V3 advisory format migration
 
 ## 0.2.1 (2020-07-24)
-- Output mode for use with the production github action ([#62])
-
-[#62]: https://github.com/RustSec/rustsec-admin/pull/62
+- Output mode for use with the production github action
 
 ## 0.2.0 (2020-06-29)
-- linter: refactor into `Linter` struct; check all files ([#55])
-- Bump `rustsec` crate to v0.21.0 ([#52])
-- `assign-id` subcommand ([#41])
-
-[#55]: https://github.com/RustSec/rustsec-admin/pull/55
-[#52]: https://github.com/RustSec/rustsec-admin/pull/52
-[#41]: https://github.com/RustSec/rustsec-admin/pull/41
+- linter: refactor into `Linter` struct; check all files
+- Bump `rustsec` crate to v0.21.0
+- `assign-id` subcommand
 
 ## 0.1.1 (2019-10-07)
-- Bump `rustsec` crate to v0.15.1 ([#7])
-
-[#7]: https://github.com/RustSec/rustsec-admin/pull/7
+- Bump `rustsec` crate to v0.15.1
 
 ## 0.1.0 (2019-09-21)
 - Initial release

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec-admin"
 description = "Admin utility for maintaining the RustSec Advisory Database"
-version     = "0.4.2"
+version     = "0.4.3"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"


### PR DESCRIPTION
- Use crates index instead of crates.io api ([#372])

[#372]: https://github.com/RustSec/rustsec/pull/372