### PR TITLE
cargo-lock v7.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,10 +306,10 @@ dependencies = [
 [[package]]
 name = "cargo-lock"
 version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f16e7adc20969298b1e137ac21ab3a7e7a9412fec71f963ff2fdc41663d70f"
 dependencies = [
- "gumdrop 0.8.0",
- "petgraph",
- "semver 1.0.0",
+ "semver 0.11.0",
  "serde",
  "toml",
  "url",
@@ -317,11 +317,11 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "6.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f16e7adc20969298b1e137ac21ab3a7e7a9412fec71f963ff2fdc41663d70f"
+version = "7.0.0"
 dependencies = [
- "semver 0.11.0",
+ "gumdrop 0.8.0",
+ "petgraph",
+ "semver 1.0.0",
  "serde",
  "toml",
  "url",
@@ -1762,7 +1762,7 @@ name = "rustsec"
 version = "0.23.3"
 dependencies = [
  "cargo-edit",
- "cargo-lock 6.0.1",
+ "cargo-lock 7.0.0",
  "crates-index",
  "cvss 1.0.2",
  "fs-err",
@@ -1787,7 +1787,7 @@ version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ca2e5b11f379d6f091b029f4efbcf77c2e5ce61628a3512944ac1718eafba5"
 dependencies = [
- "cargo-lock 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 6.0.1",
  "crates-index",
  "cvss 1.0.1",
  "fs-err",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,94 +4,64 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 7.0.0 (2021-05-27)
+### Added
+- Support for V3 lockfile format ([#363])
+
+### Changed
+- Bump `semver` to v1.0.0 ([#378])
+
+[#363]: https://github.com/RustSec/rustsec/pull/363
+[#378]: https://github.com/RustSec/rustsec/pull/378
+
 ## 6.0.1 (2021-01-25)
 ### Changed
--  Rename default branch to `main` ([#94])
-
-[#94]: https://github.com/RustSec/cargo-lock/pull/94
+-  Rename default branch to `main`
 
 ## 6.0.0 (2020-09-25)
-- Bump semver from 0.10.0 to 0.11.0 ([#83])
-
-[#83]: https://github.com/RustSec/cargo-lock/pull/83
+- Bump semver from 0.10.0 to 0.11.0
 
 ## 5.0.0 (2020-09-23)
-- CLI: support for listing a single dependency ([#77])
-- Cargo-compatible serializer ([#76])
-- CLI: add `--dependencies` and `--sources` flags to `cargo lock list` ([#75])
-- CLI: implement `cargo lock tree` without arguments ([#74])
-- Add `dependency::Tree::roots()` method ([#73])
-- CLI: make `list` the default command ([#72])
-- Make `cli` feature non-default ([#70])
-- WASM support; MSRV 1.41+ ([#69])
-- Bump `semver` dependency from v0.9 to v0.10 ([#57])
-
-[#77]: https://github.com/RustSec/cargo-lock/pull/77
-[#76]: https://github.com/RustSec/cargo-lock/pull/76
-[#75]: https://github.com/RustSec/cargo-lock/pull/75
-[#74]: https://github.com/RustSec/cargo-lock/pull/74
-[#73]: https://github.com/RustSec/cargo-lock/pull/73
-[#72]: https://github.com/RustSec/cargo-lock/pull/72
-[#70]: https://github.com/RustSec/cargo-lock/pull/70
-[#69]: https://github.com/RustSec/cargo-lock/pull/69
-[#57]: https://github.com/RustSec/cargo-lock/pull/57
+- CLI: support for listing a single dependency
+- Cargo-compatible serializer
+- CLI: add `--dependencies` and `--sources` flags to `cargo lock list`
+- CLI: implement `cargo lock tree` without arguments
+- Add `dependency::Tree::roots()` method
+- CLI: make `list` the default command
+- Make `cli` feature non-default
+- WASM support; MSRV 1.41+
+- Bump `semver` dependency from v0.9 to v0.10
 
 ## 4.0.1 (2020-01-22)
-- CLI: fix executable name ([#45])
-
-[#45]: https://github.com/RustSec/cargo-lock/pull/46
+- CLI: fix executable name
 
 ## 4.0.0 (2020-01-22)
-- Command line interface ([#40], [#42], [#43])
-- Add helper methods for working with checksum metadata ([#38])
-- Use minified version of Cargo's `SourceId` type ([#36])
-- Overhaul encoding: use serde_derive, proper V1/V2 support ([#35])
-- Add support Cargo.lock `patch` and `root` ([#33])
-- Detect V1 vs V2 Cargo.lock files ([#31])
-- Update `petgraph` requirement from 0.4 to 0.5 ([#28])
-- Add `package::Checksum` ([#29])
-
-[#43]: https://github.com/RustSec/cargo-lock/pull/43
-[#42]: https://github.com/RustSec/cargo-lock/pull/42
-[#40]: https://github.com/RustSec/cargo-lock/pull/40
-[#38]: https://github.com/RustSec/cargo-lock/pull/38
-[#36]: https://github.com/RustSec/cargo-lock/pull/36
-[#35]: https://github.com/RustSec/cargo-lock/pull/35
-[#33]: https://github.com/RustSec/cargo-lock/pull/33
-[#31]: https://github.com/RustSec/cargo-lock/pull/31
-[#29]: https://github.com/RustSec/cargo-lock/pull/29
-[#28]: https://github.com/RustSec/cargo-lock/pull/28
+- Command line interface
+- Add helper methods for working with checksum metadata
+- Use minified version of Cargo's `SourceId` type
+- Overhaul encoding: use serde_derive, proper V1/V2 support
+- Add support Cargo.lock `patch` and `root`
+- Detect V1 vs V2 Cargo.lock files
+- Update `petgraph` requirement from 0.4 to 0.5
+- Add `package::Checksum`
 
 ## 3.0.0 (2019-10-01)
-- Support `[package.dependencies]` without versions ([#23])
-
-[#23]: https://github.com/RustSec/cargo-lock/pull/23
+- Support `[package.dependencies]` without versions
 
 ## 2.0.0 (2019-09-25)
-- Use two-pass dependency tree computation ([#20])
-- Remove `Lockfile::root_package()` ([#18])
-
-[#20]: https://github.com/RustSec/cargo-lock/pull/20
-[#18]: https://github.com/RustSec/cargo-lock/pull/18
+- Use two-pass dependency tree computation
+- Remove `Lockfile::root_package()`
 
 ## 1.0.0 (2019-09-24)
-- dependency/tree: Render trees to an `io::Write` ([#16])
-- metadata: Generalize into `Key` and `Value` types ([#14])
-- Refactor dependency handling ([#11])
-
-[#16]: https://github.com/RustSec/cargo-lock/pull/16
-[#14]: https://github.com/RustSec/cargo-lock/pull/14
-[#11]: https://github.com/RustSec/cargo-lock/pull/11
+- dependency/tree: Render trees to an `io::Write`
+- metadata: Generalize into `Key` and `Value` types
+- Refactor dependency handling
 
 ## 0.2.1 (2019-09-21)
-- Allow empty `[metadata]` in Cargo.lock files ([#9])
-
-[#9]: https://github.com/RustSec/cargo-lock/pull/9
+- Allow empty `[metadata]` in Cargo.lock files
 
 ## 0.2.0 (2019-09-21)
-- dependency_graph: Move `petgraph` types into a module ([#7])
-
-[#7]: https://github.com/RustSec/cargo-lock/pull/7
+- dependency_graph: Move `petgraph` types into a module
 
 ## 0.1.0 (2019-09-21)
 - Initial release

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-lock"
 description = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version = "6.0.1"
+version = "7.0.0"
 authors = ["Tony Arcieri <bascule@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/cargo-lock/src/lib.rs
+++ b/cargo-lock/src/lib.rs
@@ -170,7 +170,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-lock/6.0.1"
+    html_root_url = "https://docs.rs/cargo-lock/7.0.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -12,7 +12,7 @@ keywords    = ["audit", "rustsec", "security", "advisory", "vulnerability"]
 edition     = "2018"
 
 [dependencies]
-cargo-lock = { version = "6", default-features = false, path = "../cargo-lock" }
+cargo-lock = { version = "7", default-features = false, path = "../cargo-lock" }
 crates-index = { version = "0.16", optional = true }
 cvss = { version = "1", features = ["serde"], path = "../cvss" }
 fs-err = "2.5"


### PR DESCRIPTION
### Added
- Support for V3 lockfile format ([#363])

### Changed
- Bump `semver` to v1.0.0 ([#378])

[#363]: https://github.com/RustSec/rustsec/pull/363
[#378]: https://github.com/RustSec/rustsec/pull/378