### PR TITLE
rustsec-admin v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec-admin"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "abscissa_core",
  "askama",

--- a/admin/CHANGELOG.md
+++ b/admin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.0 (2021-06-28)
+- OSV export ([#366])
+- Bump `rustsec` to v0.24.0 ([#388])
+
+[#366]: https://github.com/RustSec/rustsec/pull/366
+[#388]: https://github.com/RustSec/rustsec/pull/388
+
 ## 0.4.3 (2021-05-22)
 - Use crates index instead of crates.io api ([#372])
 

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec-admin"
 description = "Admin utility for maintaining the RustSec Advisory Database"
-version     = "0.4.3"
+version     = "0.5.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"


### PR DESCRIPTION
- OSV export ([#366])
- Bump `rustsec` to v0.24.0 ([#388])

[#366]: https://github.com/RustSec/rustsec/pull/366
[#388]: https://github.com/RustSec/rustsec/pull/388