### PR TITLE
Do not lint year in CVE IDs

### DIFF
--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -110,16 +110,21 @@ impl Linter {
                                 message: Some("unknown advisory ID type"),
                             });
                         } else if let Some(y1) = self.advisory.metadata.id.year() {
-                            if let Some(y2) = year {
-                                if y1 != y2 {
-                                    self.errors.push(Error {
-                                        kind: ErrorKind::value("id", value.to_string()),
-                                        section: Some("advisory"),
-                                        message: Some("year in advisory ID does not match date"),
-                                    });
+                            // Exclude CVE IDs, since the year from CVE ID may not match the report date
+                            if !self.advisory.metadata.id.is_cve() {
+                                if let Some(y2) = year {
+                                    if y1 != y2 {
+                                        self.errors.push(Error {
+                                            kind: ErrorKind::value("id", value.to_string()),
+                                            section: Some("advisory"),
+                                            message: Some(
+                                                "year in advisory ID does not match date",
+                                            ),
+                                        });
+                                    }
+                                } else {
+                                    year = Some(y1);
                                 }
-                            } else {
-                                year = Some(y1);
                             }
                         }
                     }


### PR DESCRIPTION
The year part of a CVE ID may be different from the reported year as discovered in RustSec/advisory-db#946. This PR softens the linting for CVE IDs as suggested in the [comment](https://github.com/RustSec/advisory-db/pull/946#issuecomment-872698576).