### PR TITLE
rustsec-admin v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec-admin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "abscissa_core",
  "askama",

--- a/admin/CHANGELOG.md
+++ b/admin/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1 (2021-07-03)
+- Bump `rustsec` to v0.24.1 ([#394])
+
+[#394]: https://github.com/RustSec/rustsec/pull/394
+
 ## 0.5.0 (2021-06-28)
 - OSV export ([#366])
 - Bump `rustsec` to v0.24.0 ([#388])

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec-admin"
 description = "Admin utility for maintaining the RustSec Advisory Database"
-version     = "0.5.0"
+version     = "0.5.1"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"
@@ -13,7 +13,7 @@ edition     = "2018"
 abscissa_core = "0.5"
 crates-index = "0.16"
 gumdrop = "0.7"
-rustsec = { version = "0.24", path = "../rustsec", features = ["osv-I-know-this-is-unstable"] }
+rustsec = { version = "0.24.1", path = "../rustsec", features = ["osv-I-know-this-is-unstable"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 termcolor = "1"


### PR DESCRIPTION
- Bump `rustsec` to v0.24.1 ([#394])

[#394]: https://github.com/RustSec/rustsec/pull/394