### PR TITLE
cargo-lock v7.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "gumdrop 0.8.0",
  "petgraph",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 7.0.0 (2021-05-27)
+## 7.0.1 (2021-07-05)
+### Changed
+- Bump `petgraph` dependency from 0.5.1 to 0.6.0 ([#396])
+
+[#396]: https://github.com/RustSec/rustsec/pull/396
+
+## 7.0.0 (2021-05-27) [YANKED]
 ### Added
 - Support for V3 lockfile format ([#363])
 

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-lock"
 description = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version = "7.0.0"
+version = "7.0.1"
 authors = ["Tony Arcieri <bascule@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/cargo-lock/src/lib.rs
+++ b/cargo-lock/src/lib.rs
@@ -170,7 +170,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-lock/7.0.0"
+    html_root_url = "https://docs.rs/cargo-lock/7.0.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `petgraph` dependency from 0.5.1 to 0.6.0 ([#396])

[#396]: https://github.com/RustSec/rustsec/pull/396