### PR TITLE
Proposed fix for #398 

### DIFF
--- a/cvss/src/v3/base.rs
+++ b/cvss/src/v3/base.rs
@@ -99,10 +99,10 @@ impl Base {
         let iss_scoped = if !self.is_scope_changed() {
             6.42 * iss
         } else {
-            (7.52 * (iss - 0.029).abs()) - (3.25 * (iss - 0.02).abs().powf(15.0))
+            (7.52 * (iss - 0.029)) - (3.25 * (iss - 0.02).powf(15.0))
         };
 
-        let score = if iss_scoped < 0.0 {
+        let score = if iss_scoped <= 0.0 {
             0.0
         } else if !self.is_scope_changed() {
             (iss_scoped + exploitability).min(10.0)

--- a/cvss/tests/base.rs
+++ b/cvss/tests/base.rs
@@ -212,6 +212,7 @@ fn cve_2012_5376() {
 /// No impact scope changed
 #[test]
 fn no_impact_scope_changed() {
+    // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N => 0.0
     let cvss_for_no_impact_scope_changed = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N";
     let base = cvss::v3::Base::from_str(cvss_for_no_impact_scope_changed).unwrap();
     assert_eq!(&base.to_string(), cvss_for_no_impact_scope_changed);
@@ -221,8 +222,27 @@ fn no_impact_scope_changed() {
 /// No impact scope unchanged
 #[test]
 fn no_impact_scope_unchanged() {
-    let cvss_for_no_impact_scope_changed = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N";
+    // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N => 0.0
+    let cvss_for_no_impact_scope_unchanged = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N";
     let base = cvss::v3::Base::from_str(cvss_for_no_impact_scope_unchanged).unwrap();
     assert_eq!(&base.to_string(), cvss_for_no_impact_scope_unchanged);
     assert_eq!(base.score().value(), 0.0);
+}
+
+#[test]
+fn low_scope_unchanged() {
+    // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L => 1.6
+    let cvss_for_low_scope_unchanged = "CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L";
+    let base = cvss::v3::Base::from_str(cvss_for_low_scope_unchanged).unwrap();
+    assert_eq!(&base.to_string(), cvss_for_low_scope_unchanged);
+    assert_eq!(base.score().value(), 1.6);
+}
+
+#[test]
+fn low_scope_changed() {
+    // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:C/C:N/I:N/A:L => 1.8
+    let cvss_for_low_scope_changed = "CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:C/C:N/I:N/A:L";
+    let base = cvss::v3::Base::from_str(cvss_for_low_scope_changed).unwrap();
+    assert_eq!(&base.to_string(), cvss_for_low_scope_changed);
+    assert_eq!(base.score().value(), 1.8);
 }

--- a/cvss/tests/base.rs
+++ b/cvss/tests/base.rs
@@ -208,3 +208,21 @@ fn cve_2012_5376() {
     assert_eq!(&base.to_string(), cvss_for_cve_2012_5376);
     assert_eq!(base.score().value(), 9.6);
 }
+
+/// No impact scope changed
+#[test]
+fn no_impact_scope_changed() {
+    let cvss_for_no_impact_scope_changed = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N";
+    let base = cvss::v3::Base::from_str(cvss_for_no_impact_scope_changed).unwrap();
+    assert_eq!(&base.to_string(), cvss_for_no_impact_scope_changed);
+    assert_eq!(base.score().value(), 0.0);
+}
+
+/// No impact scope unchanged
+#[test]
+fn no_impact_scope_unchanged() {
+    let cvss_for_no_impact_scope_changed = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N";
+    let base = cvss::v3::Base::from_str(cvss_for_no_impact_scope_changed).unwrap();
+    assert_eq!(&base.to_string(), cvss_for_no_impact_scope_changed);
+    assert_eq!(base.score().value(), 0.0);
+}

--- a/cvss/tests/base.rs
+++ b/cvss/tests/base.rs
@@ -222,7 +222,7 @@ fn no_impact_scope_changed() {
 #[test]
 fn no_impact_scope_unchanged() {
     let cvss_for_no_impact_scope_changed = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N";
-    let base = cvss::v3::Base::from_str(cvss_for_no_impact_scope_changed).unwrap();
-    assert_eq!(&base.to_string(), cvss_for_no_impact_scope_changed);
+    let base = cvss::v3::Base::from_str(cvss_for_no_impact_scope_unchanged).unwrap();
+    assert_eq!(&base.to_string(), cvss_for_no_impact_scope_unchanged);
     assert_eq!(base.score().value(), 0.0);
 }


### PR DESCRIPTION
'no impact' => all of C, I, A are set to N

Two changes were needed:
1) the call to .abs() lead to a non negative  iss_scoped score 
in the problematic case, removed that call

2) the iss_scoped needs to be inferior or equal to 0   for the
resulting score to be set to 0,
else the exploitability gets factored in for the final score


This is  my first ever pull request, Sorry if I missed something! 
Thanks