### PR TITLE
Support ~ and = operators in version specification

### DIFF
--- a/rustsec/src/osv/unaffected_range.rs
+++ b/rustsec/src/osv/unaffected_range.rs
@@ -208,7 +208,9 @@ impl TryFrom<&semver::VersionReq> for UnaffectedRange {
                     let mut end_version = match (comparator.minor, comparator.patch) {
                         (None, None) => Version::new(major + 1, 0, 0),
                         (Some(minor), _) => Version::new(major, minor + 1, 0),
-                        (None, Some(_)) => unreachable!(),
+                        (None, Some(_)) => {
+                            unreachable!("Comparator specifies patch version but not minor version")
+                        }
                     };
                     // -0 is the lowest possible prerelease.
                     // If we didn't append it, e.g. ~1.2 would match 1.3.0-alpha1

--- a/rustsec/src/osv/unaffected_range.rs
+++ b/rustsec/src/osv/unaffected_range.rs
@@ -172,7 +172,6 @@ impl TryFrom<&semver::VersionReq> for UnaffectedRange {
                     }
                     start = Bound::Inclusive(comp_to_ver(comparator));
                     end = Bound::Inclusive(comp_to_ver(comparator));
-
                 }
                 Op::Caret => {
                     if input.comparators.len() != 1 {

--- a/rustsec/src/osv/unaffected_range.rs
+++ b/rustsec/src/osv/unaffected_range.rs
@@ -103,15 +103,12 @@ impl Display for UnaffectedRange {
     }
 }
 
-/// To keep the algorithm simple, we make several assumptions:
+/// To keep the algorithm simple, we impose several constraints:
 /// 1. There is at most one upper and at most one lower bound in each range.
 ///    Stuff like `>= 1.0, >= 2.0` is nonsense and is not supported.
 /// 2. If the requirement is "1.0" or "^1.0" that defines both the lower and upper bound,
 ///    it is the only one in its range.
-/// If any of those assumptions are violated, an error will be returned.
-//
-// This is fine for the advisory database as of June 2021,
-// and supporting even more complex version specification would probably be detrimental.
+/// If any of those constraints are unmet, an error will be returned.
 impl TryFrom<&semver::VersionReq> for UnaffectedRange {
     type Error = Error;
 


### PR DESCRIPTION
* Add support for `~` operator in version requirements, add tests
* Add support for `=` operator in version requirements, add tests
* Make `^` operator handling spec-compliant, add tests. The spec discrepancy doesn't seem to affect the current DB data.

After this is merged, if we use `~` requirements in the DB, that will work on both very old cargo-audit versions and very new ones, but version 0.15.0 exactly will be broken (it's the only released version with rustsec v0.24 before these changes)