### PR TITLE
rustsec v0.24.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rustsec"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.2 (2021-07-20)
+### Changed
+- Support `~` and `=` operators in version specification ([#402])
+- Bump `crates-index` from 0.16.7 to 0.17.0 ([#403])
+
+[#402]: https://github.com/RustSec/rustsec-crate/pull/402
+[#403]: https://github.com/RustSec/rustsec-crate/pull/403
+
 ## 0.24.1 (2021-07-02)
 ### Changed
 - Do not lint year in CVE IDs ([#393])

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.24.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.24.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.24.1"
+    html_root_url = "https://docs.rs/rustsec/0.24.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Support `~` and `=` operators in version specification ([#402])
- Bump `crates-index` from 0.16.7 to 0.17.0 ([#403])

[#402]: https://github.com/RustSec/rustsec-crate/pull/402
[#403]: https://github.com/RustSec/rustsec-crate/pull/403