### PR TITLE
Support OSV v0.8

### DIFF
--- a/rustsec/src/osv/osv_advisory.rs
+++ b/rustsec/src/osv/osv_advisory.rs
@@ -205,7 +205,7 @@ fn guess_url_kind(url: &Url) -> OsvReferenceKind {
     }
 }
 
-/// Generates the timeline of the bug being introduced and fixed for the 
+/// Generates the timeline of the bug being introduced and fixed for the
 /// [`affected[].ranges[].events`](https://github.com/ossf/osv-schema/blob/main/schema.md#affectedrangesevents-fields) field.
 fn timeline_for_advisory(versions: &crate::advisory::Versions) -> OsvJsonRange {
     let ranges = ranges_for_advisory(versions);

--- a/rustsec/src/osv/osv_advisory.rs
+++ b/rustsec/src/osv/osv_advisory.rs
@@ -218,6 +218,7 @@ fn timeline_for_advisory(versions: &crate::advisory::Versions) -> OsvJsonRange {
                 semver::Version::parse("0.0.0-0").unwrap(),
             )),
         }
+        #[allow(clippy::single_match)]
         match range.fixed {
             Some(ver) => timeline.push(OsvTimelineEvent::Fixed(ver)),
             None => (), // "everything after 'introduced' is affected" is implicit in OSV

--- a/rustsec/src/osv/osv_advisory.rs
+++ b/rustsec/src/osv/osv_advisory.rs
@@ -205,7 +205,8 @@ fn guess_url_kind(url: &Url) -> OsvReferenceKind {
     }
 }
 
-/// Assumes that the input has already been validated; panics if passed an invalid advisory.
+/// Generates the timeline of the bug being introduced and fixed for the 
+/// [`affected[].ranges[].events`](https://github.com/ossf/osv-schema/blob/main/schema.md#affectedrangesevents-fields) field.
 fn timeline_for_advisory(versions: &crate::advisory::Versions) -> OsvJsonRange {
     let ranges = ranges_for_advisory(versions);
     assert!(!ranges.is_empty()); // zero ranges means nothing is affected, so why even have an advisory?
@@ -219,7 +220,7 @@ fn timeline_for_advisory(versions: &crate::advisory::Versions) -> OsvJsonRange {
         }
         match range.fixed {
             Some(ver) => timeline.push(OsvTimelineEvent::Fixed(ver)),
-            None => (), // "everything past this point is affected" is implicit in OSV
+            None => (), // "everything after 'introduced' is affected" is implicit in OSV
         }
     }
     OsvJsonRange {


### PR DESCRIPTION
Mirror the changes done in https://github.com/ossf/osv-schema/pull/1

Marking this as draft because OSV upstream is not yet prepared to pull in v0.8, but I believe the code on our side is complete.

I have raised some concerns about the v0.8 changes privately, but they mostly concern parsing and various edge cases we don't exercise, so future revisions are unlikely to affect us.

~~Curiously, the new structure lets us also encode the version ranges we've put on affected functions. I'm not sure it's a good idea to keep those around - but now if we want to, we can!~~