### PR TITLE
cargo-audit+rustsec: add `vendored-libgit2` feature

### DIFF
--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -36,4 +36,5 @@ features = ["testing"]
 
 [features]
 fix = ["rustsec/fix"]
+vendored-libgit2 = ["rustsec/vendored-libgit2"]
 vendored-openssl = ["rustsec/vendored-openssl"]

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -44,6 +44,7 @@ default = ["git"]
 fix = ["cargo-edit"]
 git = ["crates-index", "git2", "home", "humantime", "humantime-serde"]
 dependency-tree = ["cargo-lock/dependency-tree"]
+vendored-libgit2 = ["git2/vendored-libgit2"]
 vendored-openssl = ["git2/vendored-openssl"]
 osv-I-know-this-is-unstable = ["git", "chrono"]
 


### PR DESCRIPTION
This should address #431