### PR TITLE
cargo-audit v0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "abscissa_core",
  "gumdrop 0.7.0",

--- a/cargo-audit/CHANGELOG.md
+++ b/cargo-audit/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.2 (2021-09-11)
+### Added
+- `vendored-libgit2` feature ([#432])
+
+[#432]: https://github.com/rustsec/rustsec/pull/432
+
 ## 0.15.1 (2021-09-10)
 ### Changed
 - Pin `thiserror` and `zeroize` to avoid MSRV breakages ([#415])
 
-[#415]: https://github.com/rustsec/rustsec/pull/415/
+[#415]: https://github.com/rustsec/rustsec/pull/415
 
 ## 0.15.0 (2021-07-01)
 ### Added

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.15.1"
+version     = "0.15.2"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/cargo-audit/src/lib.rs
+++ b/cargo-audit/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.15.1"
+    html_root_url = "https://docs.rs/cargo-audit/0.15.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Added
- `vendored-libgit2` feature ([#432])

[#432]: https://github.com/rustsec/rustsec/pull/432