### PR TITLE
Parse --color=auto correctly

### DIFF
--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -149,6 +149,7 @@ impl AuditCommand {
     pub fn color_config(&self) -> Option<ColorChoice> {
         self.color.as_ref().map(|colors| match colors.as_ref() {
             "always" => ColorChoice::Always,
+            "auto" => ColorChoice::Auto,
             "never" => ColorChoice::Never,
             _ => panic!("invalid color choice setting: {}", &colors),
         })


### PR DESCRIPTION
Currently, `cargo audit --color=auto` (which the `--help` says is the default option) causes a panic. This PR fixes that.