### PR TITLE
ci: extract version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           ext=""
           [[ "${{ matrix.name }}" == windows-* ]] && ext=".exe"
           bin="target/${{ matrix.target }}/release/cargo-audit${ext}"
-          version=$(echo "${{ github.ref }}" | cut -d/ -f3)
+          version=$(echo "${{ github.ref }}" | cut -d/ -f4)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           mkdir "$dst"
           mv "$bin" "$dst/"


### PR DESCRIPTION
This may relate to why the action failed. The prior index extracted `cargo-audit` instead of the version. Relates to #66
