### PR TITLE
ci: fix other extract version uses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,14 +110,14 @@ jobs:
         if: '! startsWith(matrix.name, ''windows-'')'
         shell: bash
         run: |
-          version=$(echo "${{ github.ref }}" | cut -d/ -f3)
+          version=$(echo "${{ github.ref }}" | cut -d/ -f4)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           tar cavf "$dst.tgz" "$dst"
       - name: Archive (zip)
         if: startsWith(matrix.name, 'windows-')
         shell: bash
         run: |
-          version=$(echo "${{ github.ref }}" | cut -d/ -f3)
+          version=$(echo "${{ github.ref }}" | cut -d/ -f4)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           7z a "$dst.zip" "$dst"
       - uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae


### PR DESCRIPTION
Same thing as in #445. These are not the cause of the binaries failing to be archived. The cause is path confusion between the actions-rs/cargo compile step and the packaging step. I will submit another PR for that
