### PR TITLE
ci: fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           set -eux
           ext=""
           [[ "${{ matrix.name }}" == windows-* ]] && ext=".exe"
-          bin="target/${{ matrix.target }}/release/cargo-audit${ext}"
+          bin="../target/${{ matrix.target }}/release/cargo-audit${ext}"
           version=$(echo "${{ github.ref }}" | cut -d/ -f4)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           mkdir "$dst"


### PR DESCRIPTION
The release action was not working because it expected the build step's
`target/` to be in the working directory.

It actually was in the parent directory.

actions-rs/cargo does not support the `working-directory` option which
contributed to the path confusion.

Relates to #66.
