### PR TITLE
Remove chrono dependency from rustsec crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,6 @@ version = "0.24.3"
 dependencies = [
  "cargo-edit",
  "cargo-lock",
- "chrono",
  "crates-index",
  "cvss",
  "fs-err",

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -20,7 +20,6 @@ git2 = { version = "0.13", optional = true }
 home = { version = "0.5", optional = true }
 humantime = { version = "2", optional = true }
 humantime-serde = { version = "1", optional = true }
-chrono = { version = "0.4", optional = true }
 platforms = { version = "1", features = ["serde"], path = "../platforms" }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
@@ -46,7 +45,7 @@ git = ["crates-index", "git2", "home", "humantime", "humantime-serde"]
 dependency-tree = ["cargo-lock/dependency-tree"]
 vendored-libgit2 = ["git2/vendored-libgit2"]
 vendored-openssl = ["git2/vendored-openssl"]
-osv-export = ["git", "chrono"]
+osv-export = ["git"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Fortunately I have thought that dropping chrono would be desirable back when I was adding it, so I made sure it doesn't leak into the public API. As a result, this change is not semver-breaking.

It does change the generated timestamp from ending with `+00:00` to ending with `Z`, but that's exactly what the OSV format specifies, so now we're more compliant if anything.