### PR TITLE
Add severity tag for informational advisories

### DIFF
--- a/admin/src/web/static/css/basic.css
+++ b/admin/src/web/static/css/basic.css
@@ -164,3 +164,7 @@ header span.subtitle p {
 .low {
   background: #b5b500;
 }
+
+.info {
+  background: #190079;
+}

--- a/admin/src/web/templates/advisories.html
+++ b/admin/src/web/templates/advisories.html
@@ -29,6 +29,9 @@
             {% when Some with (severity) %}
             <span class="tag {{ severity }}">{{ advisory.severity().unwrap() | upper }}</span>
             {% when None %}
+              {% if advisory.metadata.informational.is_some() %}
+                <span class="tag info">INFO</span>
+              {% endif %}
           {% endmatch %}
           <a href="/advisories/{{ advisory.id() }}.html">
             {{ advisory_title_type }}

--- a/admin/src/web/templates/package-advisories.html
+++ b/admin/src/web/templates/package-advisories.html
@@ -24,6 +24,14 @@
         (withdrawn advisory)
         {% else %}
         <h3>
+          {% match advisory.severity() %}
+            {% when Some with (severity) %}
+            <span class="tag {{ severity }}">{{ advisory.severity().unwrap() | upper }}</span>
+            {% when None %}
+              {% if advisory.metadata.informational.is_some() %}
+                <span class="tag info">INFO</span>
+              {% endif %}
+          {% endmatch %}
           <a href="/advisories/{{ advisory.id() }}.html">
             {{ advisory_title_type }}
           </a>


### PR DESCRIPTION
![info](https://user-images.githubusercontent.com/329388/138001004-c4108898-ff00-4292-ae9d-4ff1b9aa2ce3.png)

Make informational advisories more visible in the lists.