### PR TITLE
rustsec-admin v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec-admin"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "abscissa_core",
  "askama",

--- a/admin/CHANGELOG.md
+++ b/admin/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.5.3 (2021-10-22)
+- Bump `rust-embed` from 5.9.0 to 6.2.0 ([#437])
+- Add information about CVSS score and metrics ([#452])
+- Add severity tag for informational advisories ([#458])
+- Index pages by keyword and category ([#459])
+
+[#437]: https://github.com/RustSec/rustsec/pull/437
+[#452]: https://github.com/RustSec/rustsec/pull/452
+[#458]: https://github.com/RustSec/rustsec/pull/458
+[#459]: https://github.com/RustSec/rustsec/pull/459
+
+## 0.5.2 (2021-09-12)
+- Update `atom_syndication` to 0.10 ([#390])
+- Don't label OSV feature as unstable, since OSV 1.0 has shipped ([#434])
+
+[#390]: https://github.com/RustSec/rustsec/pull/390
+[#434]: https://github.com/RustSec/rustsec/pull/434
+
 ## 0.5.1 (2021-07-03)
 - Bump `rustsec` to v0.24.1 ([#394])
 

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec-admin"
 description = "Admin utility for maintaining the RustSec Advisory Database"
-version     = "0.5.2"
+version     = "0.5.3"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"


### PR DESCRIPTION
- Bump `rust-embed` from 5.9.0 to 6.2.0 ([#437])
- Add information about CVSS score and metrics ([#452])
- Add severity tag for informational advisories ([#458])
- Index pages by keyword and category ([#459])

[#437]: https://github.com/RustSec/rustsec/pull/437
[#452]: https://github.com/RustSec/rustsec/pull/452
[#458]: https://github.com/RustSec/rustsec/pull/458
[#459]: https://github.com/RustSec/rustsec/pull/459