### PR TITLE
Unpin thiserror and smol_str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,6 @@ dependencies = [
  "platforms",
  "semver 1.0.4",
  "serde",
- "smol_str",
  "tempfile",
  "thiserror",
  "toml",
@@ -2172,15 +2171,6 @@ checksum = "31aa6a31c0c2b21327ce875f7e8952322acfcfd0c27569a6e18a647281352c9b"
 dependencies = [
  "serde",
  "static_assertions",
-]
-
-[[package]]
-name = "smol_str"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d15c83e300cce35b7c8cd39ff567c1ef42dde6d4a1a38dbdbf9a59902261bd"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -23,8 +23,7 @@ humantime-serde = { version = "1", optional = true }
 platforms = { version = "1", features = ["serde"], path = "../platforms" }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
-smol_str = "=0.1.21" # Pinned to avoid MSRV breakages
-thiserror = "=1.0.25" # Pinned to avoid MSRV breakages
+thiserror = "1.0.25"
 toml = "0.5"
 url = { version = "2", features = ["serde"] }
 


### PR DESCRIPTION
Pinning makes the dependency graph brittle and hard to integrate with
other crates and their dependencies.

As far as MSRV goes, `thiserror` seems like a non-issue since it has always had an MSRV of 1.31.
 `smol_str` is no longer needed so can be removed.