### PR TITLE
platforms: follow `upper_case_acronyms` conventions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 name = "markdown-table-gen"
 version = "0.0.0"
 dependencies = [
- "platforms",
+ "platforms 2.0.0-pre",
 ]
 
 [[package]]
@@ -1641,6 +1641,15 @@ checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 [[package]]
 name = "platforms"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "platforms"
+version = "2.0.0-pre"
 dependencies = [
  "serde",
 ]
@@ -1906,7 +1915,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "once_cell",
- "platforms",
+ "platforms 1.1.0",
  "semver 1.0.4",
  "serde",
  "tempfile",

--- a/platforms/Cargo.toml
+++ b/platforms/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from Rust Forge.
 """
-version    = "1.1.0" # Also update html_root_url in lib.rs when bumping this
+version    = "2.0.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors    = ["Tony Arcieri <bascule@gmail.com>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://rustsec.org"

--- a/platforms/src/lib.rs
+++ b/platforms/src/lib.rs
@@ -13,7 +13,7 @@
 //! done with a minor version bump.
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/platforms/1.1.0")]
+#![doc(html_root_url = "https://docs.rs/platforms/2.0.0-pre")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unused_qualifications, rust_2018_idioms)]
 

--- a/platforms/src/platform/tier1.rs
+++ b/platforms/src/platform/tier1.rs
@@ -19,9 +19,9 @@ use crate::{
 /// `aarch64-unknown-linux-gnu`: ARM64 Linux
 pub const AARCH64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "aarch64-unknown-linux-gnu",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::One,
 };
 
@@ -30,7 +30,7 @@ pub const I686_PC_WINDOWS_GNU: Platform = Platform {
     target_triple: "i686-pc-windows-gnu",
     target_arch: Arch::X86,
     target_os: OS::Windows,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::One,
 };
 
@@ -39,7 +39,7 @@ pub const I686_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "i686-pc-windows-msvc",
     target_arch: Arch::X86,
     target_os: OS::Windows,
-    target_env: Some(Env::MSVC),
+    target_env: Some(Env::Msvc),
     tier: Tier::One,
 };
 
@@ -48,7 +48,7 @@ pub const I686_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "i686-unknown-linux-gnu",
     target_arch: Arch::X86,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::One,
 };
 
@@ -66,7 +66,7 @@ pub const X86_64_PC_WINDOWS_GNU: Platform = Platform {
     target_triple: "x86_64-pc-windows-gnu",
     target_arch: Arch::X86_64,
     target_os: OS::Windows,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::One,
 };
 
@@ -75,7 +75,7 @@ pub const X86_64_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "x86_64-pc-windows-msvc",
     target_arch: Arch::X86_64,
     target_os: OS::Windows,
-    target_env: Some(Env::MSVC),
+    target_env: Some(Env::Msvc),
     tier: Tier::One,
 };
 
@@ -84,6 +84,6 @@ pub const X86_64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "x86_64-unknown-linux-gnu",
     target_arch: Arch::X86_64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::One,
 };

--- a/platforms/src/platform/tier2.rs
+++ b/platforms/src/platform/tier2.rs
@@ -23,7 +23,7 @@ use crate::{
 /// `aarch64-apple-darwin`: Apple Silicon macOS (11+)
 pub const AARCH64_APPLE_DARWIN: Platform = Platform {
     target_triple: "aarch64-apple-darwin",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::MacOS,
     target_env: None,
     tier: Tier::Two,
@@ -32,7 +32,7 @@ pub const AARCH64_APPLE_DARWIN: Platform = Platform {
 /// `aarch64-apple-ios`: ARM64 iOS
 pub const AARCH64_APPLE_IOS: Platform = Platform {
     target_triple: "aarch64-apple-ios",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::iOS,
     target_env: None,
     tier: Tier::Two,
@@ -41,7 +41,7 @@ pub const AARCH64_APPLE_IOS: Platform = Platform {
 /// `aarch64-fuchsia`: ARM64 Fuchsia
 pub const AARCH64_FUCHSIA: Platform = Platform {
     target_triple: "aarch64-fuchsia",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Fuchsia,
     target_env: None,
     tier: Tier::Two,
@@ -50,7 +50,7 @@ pub const AARCH64_FUCHSIA: Platform = Platform {
 /// `aarch64-linux-android`: ARM64 Android
 pub const AARCH64_LINUX_ANDROID: Platform = Platform {
     target_triple: "aarch64-linux-android",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Android,
     target_env: None,
     tier: Tier::Two,
@@ -59,16 +59,16 @@ pub const AARCH64_LINUX_ANDROID: Platform = Platform {
 /// `aarch64-pc-windows-msvc`: ARM64 MSVC (Windows 10)
 pub const AARCH64_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "aarch64-pc-windows-msvc",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Windows,
-    target_env: Some(Env::MSVC),
+    target_env: Some(Env::Msvc),
     tier: Tier::Two,
 };
 
 /// `aarch64-unknown-linux-musl`: ARM64 Linux with MUSL
 pub const AARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "aarch64-unknown-linux-musl",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -77,7 +77,7 @@ pub const AARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
 /// `aarch64-unknown-none`: Bare ARM64, hardfloat
 pub const AARCH64_UNKNOWN_NONE: Platform = Platform {
     target_triple: "aarch64-unknown-none",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -86,7 +86,7 @@ pub const AARCH64_UNKNOWN_NONE: Platform = Platform {
 /// `aarch64-unknown-none-softfloat`: Bare ARM64, softfloat
 pub const AARCH64_UNKNOWN_NONE_SOFTFLOAT: Platform = Platform {
     target_triple: "aarch64-unknown-none-softfloat",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -95,7 +95,7 @@ pub const AARCH64_UNKNOWN_NONE_SOFTFLOAT: Platform = Platform {
 /// `arm-linux-androideabi`: ARMv7 Android
 pub const ARM_LINUX_ANDROIDEABI: Platform = Platform {
     target_triple: "arm-linux-androideabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Android,
     target_env: None,
     tier: Tier::Two,
@@ -104,25 +104,25 @@ pub const ARM_LINUX_ANDROIDEABI: Platform = Platform {
 /// `arm-unknown-linux-gnueabi`: ARMv6 Linux
 pub const ARM_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "arm-unknown-linux-gnueabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `arm-unknown-linux-gnueabihf`: ARMv6 Linux, hardfloat
 pub const ARM_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "arm-unknown-linux-gnueabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `arm-unknown-linux-musleabi`: ARMv6 Linux with MUSL
 pub const ARM_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "arm-unknown-linux-musleabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -131,7 +131,7 @@ pub const ARM_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
 /// `arm-unknown-linux-musleabihf`: ARMv6 Linux, MUSL, hardfloat
 pub const ARM_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     target_triple: "arm-unknown-linux-musleabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -140,7 +140,7 @@ pub const ARM_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
 /// `armebv7r-none-eabi`: Bare ARMv7-R, Big Endian
 pub const ARMEBV7R_NONE_EABI: Platform = Platform {
     target_triple: "armebv7r-none-eabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -149,7 +149,7 @@ pub const ARMEBV7R_NONE_EABI: Platform = Platform {
 /// `armebv7r-none-eabihf`: Bare ARMv7-R, Big Endian, hardfloat
 pub const ARMEBV7R_NONE_EABIHF: Platform = Platform {
     target_triple: "armebv7r-none-eabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -158,16 +158,16 @@ pub const ARMEBV7R_NONE_EABIHF: Platform = Platform {
 /// `armv5te-unknown-linux-gnueabi`: ARMv5TE Linux
 pub const ARMV5TE_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armv5te-unknown-linux-gnueabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `armv5te-unknown-linux-musleabi`: ARMv5TE Linux with MUSL
 pub const ARMV5TE_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "armv5te-unknown-linux-musleabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -176,7 +176,7 @@ pub const ARMV5TE_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
 /// `armv7-linux-androideabi`: ARMv7a Android
 pub const ARMV7_LINUX_ANDROIDEABI: Platform = Platform {
     target_triple: "armv7-linux-androideabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Android,
     target_env: None,
     tier: Tier::Two,
@@ -185,25 +185,25 @@ pub const ARMV7_LINUX_ANDROIDEABI: Platform = Platform {
 /// `armv7-unknown-linux-gnueabi`: ARMv7 Linux
 pub const ARMV7_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armv7-unknown-linux-gnueabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `armv7-unknown-linux-gnueabihf`: ARMv7 Linux, hardfloat
 pub const ARMV7_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "armv7-unknown-linux-gnueabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `armv7-unknown-linux-musleabi`: ARMv7 Linux with MUSL
 pub const ARMV7_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "armv7-unknown-linux-musleabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -212,7 +212,7 @@ pub const ARMV7_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
 /// `armv7-unknown-linux-musleabihf`: ARMv7 Linux with MUSL, hardfloat
 pub const ARMV7_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     target_triple: "armv7-unknown-linux-musleabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -221,7 +221,7 @@ pub const ARMV7_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
 /// `asmjs-unknown-emscripten`: asm.js via Emscripten
 pub const ASMJS_UNKNOWN_EMSCRIPTEN: Platform = Platform {
     target_triple: "asmjs-unknown-emscripten",
-    target_arch: Arch::ASMJS,
+    target_arch: Arch::AsmJs,
     target_os: OS::Emscripten,
     target_env: None,
     tier: Tier::Two,
@@ -232,7 +232,7 @@ pub const I586_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "i586-pc-windows-msvc",
     target_arch: Arch::X86,
     target_os: OS::Windows,
-    target_env: Some(Env::MSVC),
+    target_env: Some(Env::Msvc),
     tier: Tier::Two,
 };
 
@@ -241,7 +241,7 @@ pub const I586_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "i586-unknown-linux-gnu",
     target_arch: Arch::X86,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
@@ -250,7 +250,7 @@ pub const I586_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "i586-unknown-linux-musl",
     target_arch: Arch::X86,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
@@ -284,16 +284,16 @@ pub const I686_UNKNOWN_LINUX_MUSL: Platform = Platform {
 /// `mips-unknown-linux-gnu`: MIPS Linux
 pub const MIPS_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "mips-unknown-linux-gnu",
-    target_arch: Arch::MIPS,
+    target_arch: Arch::Mips,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `mips-unknown-linux-musl`: MIPS Linux with MUSL
 pub const MIPS_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "mips-unknown-linux-musl",
-    target_arch: Arch::MIPS,
+    target_arch: Arch::Mips,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -302,16 +302,16 @@ pub const MIPS_UNKNOWN_LINUX_MUSL: Platform = Platform {
 /// `mips64-unknown-linux-gnuabi64`: MIPS64 Linux, n64 ABI
 pub const MIPS64_UNKNOWN_LINUX_GNUABI64: Platform = Platform {
     target_triple: "mips64-unknown-linux-gnuabi64",
-    target_arch: Arch::MIPS64,
+    target_arch: Arch::Mips64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `mips64-unknown-linux-muslabi64`: MIPS64 Linux, n64 ABI, MUSL
 pub const MIPS64_UNKNOWN_LINUX_MUSLABI64: Platform = Platform {
     target_triple: "mips64-unknown-linux-muslabi64",
-    target_arch: Arch::MIPS64,
+    target_arch: Arch::Mips64,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -320,16 +320,16 @@ pub const MIPS64_UNKNOWN_LINUX_MUSLABI64: Platform = Platform {
 /// `mips64el-unknown-linux-gnuabi64`: MIPS64 (LE) Linux, n64 ABI
 pub const MIPS64EL_UNKNOWN_LINUX_GNUABI64: Platform = Platform {
     target_triple: "mips64el-unknown-linux-gnuabi64",
-    target_arch: Arch::MIPS64,
+    target_arch: Arch::Mips64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `mips64el-unknown-linux-muslabi64`: MIPS64 (LE) Linux, n64 ABI, MUSL
 pub const MIPS64EL_UNKNOWN_LINUX_MUSLABI64: Platform = Platform {
     target_triple: "mips64el-unknown-linux-muslabi64",
-    target_arch: Arch::MIPS64,
+    target_arch: Arch::Mips64,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -338,16 +338,16 @@ pub const MIPS64EL_UNKNOWN_LINUX_MUSLABI64: Platform = Platform {
 /// `mipsel-unknown-linux-gnu`: MIPS (LE) Linux
 pub const MIPSEL_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "mipsel-unknown-linux-gnu",
-    target_arch: Arch::MIPS,
+    target_arch: Arch::Mips,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `mipsel-unknown-linux-musl`: MIPS (LE) Linux with MUSL
 pub const MIPSEL_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "mipsel-unknown-linux-musl",
-    target_arch: Arch::MIPS,
+    target_arch: Arch::Mips,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Two,
@@ -356,7 +356,7 @@ pub const MIPSEL_UNKNOWN_LINUX_MUSL: Platform = Platform {
 /// `nvptx64-nvidia-cuda`: `--emit=asm` generates PTX code that runs on NVIDIA GPUs
 pub const NVPTX64_NVIDIA_CUDA: Platform = Platform {
     target_triple: "nvptx64-nvidia-cuda",
-    target_arch: Arch::NVPTX64,
+    target_arch: Arch::Nvptx64,
     target_os: OS::Cuda,
     target_env: None,
     tier: Tier::Two,
@@ -365,27 +365,27 @@ pub const NVPTX64_NVIDIA_CUDA: Platform = Platform {
 /// `powerpc-unknown-linux-gnu`: PowerPC Linux
 pub const POWERPC_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "powerpc-unknown-linux-gnu",
-    target_arch: Arch::POWERPC,
+    target_arch: Arch::PowerPc,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `powerpc64-unknown-linux-gnu`: PPC64 Linux
 pub const POWERPC64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "powerpc64-unknown-linux-gnu",
-    target_arch: Arch::POWERPC64,
+    target_arch: Arch::PowerPc64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `powerpc64le-unknown-linux-gnu`: PPC64LE Linux
 pub const POWERPC64LE_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "powerpc64le-unknown-linux-gnu",
-    target_arch: Arch::POWERPC64,
+    target_arch: Arch::PowerPc64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
@@ -394,23 +394,23 @@ pub const S390X_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "s390x-unknown-linux-gnu",
     target_arch: Arch::S390X,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `sparc64-unknown-linux-gnu`: SPARC Linux
 pub const SPARC64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "sparc64-unknown-linux-gnu",
-    target_arch: Arch::SPARC64,
+    target_arch: Arch::Sparc64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `sparcv9-sun-solaris`: SPARC Solaris 10/11, illumos
 pub const SPARC64_SUN_SOLARIS: Platform = Platform {
     target_triple: "sparcv9-sun-solaris",
-    target_arch: Arch::SPARC64,
+    target_arch: Arch::Sparc64,
     target_os: OS::Solaris,
     target_env: None,
     tier: Tier::Two,
@@ -419,7 +419,7 @@ pub const SPARC64_SUN_SOLARIS: Platform = Platform {
 /// `thumbv6m-none-eabi`: Bare Cortex-M0, M0+, M1
 pub const THUMBV6M_NONE_EABI: Platform = Platform {
     target_triple: "thumbv6m-none-eabi",
-    target_arch: Arch::THUMBV6,
+    target_arch: Arch::ThumbV6,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -428,7 +428,7 @@ pub const THUMBV6M_NONE_EABI: Platform = Platform {
 /// `thumbv7em-none-eabi`: Bare Cortex-M4, M7
 pub const THUMBV7EM_NONE_EABI: Platform = Platform {
     target_triple: "thumbv7em-none-eabi",
-    target_arch: Arch::THUMBV7,
+    target_arch: Arch::ThumbV7,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -437,7 +437,7 @@ pub const THUMBV7EM_NONE_EABI: Platform = Platform {
 /// `thumbv7em-none-eabihf`: Bare Cortex-M4F, M7F, FPU, hardfloat
 pub const THUMBV7EM_NONE_EABIHF: Platform = Platform {
     target_triple: "thumbv7em-none-eabihf",
-    target_arch: Arch::THUMBV7,
+    target_arch: Arch::ThumbV7,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -446,7 +446,7 @@ pub const THUMBV7EM_NONE_EABIHF: Platform = Platform {
 /// `thumbv7m-none-eabi`: Bare Cortex-M3
 pub const THUMBV7M_NONE_EABI: Platform = Platform {
     target_triple: "thumbv7m-none-eabi",
-    target_arch: Arch::THUMBV7,
+    target_arch: Arch::ThumbV7,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -455,7 +455,7 @@ pub const THUMBV7M_NONE_EABI: Platform = Platform {
 /// `thumbv7neon-linux-androideabi`: Thumb2-mode ARMv7a Android with NEON
 pub const THUMBV7NEON_LINUX_ANDROIDEABI: Platform = Platform {
     target_triple: "thumbv7neon-linux-androideabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Android,
     target_env: None,
     tier: Tier::Two,
@@ -464,16 +464,16 @@ pub const THUMBV7NEON_LINUX_ANDROIDEABI: Platform = Platform {
 /// `thumbv7neon-unknown-linux-gnueabihf`: Thumb2-mode ARMv7a Linux with NEON (kernel 4.4, glibc 2.23)
 pub const THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "thumbv7neon-unknown-linux-gnueabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `wasm32-unknown-unknown`: WebAssembly
 pub const WASM_UNKNOWN_UNKNOWN: Platform = Platform {
     target_triple: "wasm32-unknown-unknown",
-    target_arch: Arch::WASM32,
+    target_arch: Arch::Wasm32,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Two,
@@ -482,7 +482,7 @@ pub const WASM_UNKNOWN_UNKNOWN: Platform = Platform {
 /// `wasm32-unknown-emscripten`: WebAssembly via Emscripten
 pub const WASM_UNKNOWN_EMSCRIPTEN: Platform = Platform {
     target_triple: "wasm32-unknown-emscripten",
-    target_arch: Arch::WASM32,
+    target_arch: Arch::Wasm32,
     target_os: OS::Emscripten,
     target_env: None,
     tier: Tier::Two,
@@ -491,7 +491,7 @@ pub const WASM_UNKNOWN_EMSCRIPTEN: Platform = Platform {
 /// `wasm32-wasi`: WebAssembly with WASI
 pub const WASM_WASI: Platform = Platform {
     target_triple: "wasm32-wasi",
-    target_arch: Arch::WASM32,
+    target_arch: Arch::Wasm32,
     target_os: OS::Wasi,
     target_env: None,
     tier: Tier::Two,
@@ -511,7 +511,7 @@ pub const X86_64_FORTANIX_UNKNOWN_SGX: Platform = Platform {
     target_triple: "x86_64-fortanix-unknown-sgx",
     target_arch: Arch::X86_64,
     target_os: OS::Unknown,
-    target_env: Some(Env::SGX),
+    target_env: Some(Env::Sgx),
     tier: Tier::Two,
 };
 
@@ -565,7 +565,7 @@ pub const X86_64_UNKNOWN_LINUX_GNUX32: Platform = Platform {
     target_triple: "x86_64-unknown-linux-gnux32",
     target_arch: Arch::X86_64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
@@ -616,17 +616,17 @@ pub const X86_64_UNKNOWN_REDOX: Platform = Platform {
 /// `powerpc-unknown-linux-gnuspe`: PowerPC SPE Linux
 pub const POWERPC_UNKNOWN_LINUX_GNUSPE: Platform = Platform {
     target_triple: "powerpc-unknown-linux-gnuspe",
-    target_arch: Arch::POWERPC,
+    target_arch: Arch::PowerPc,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };
 
 /// `sparc-unknown-linux-gnu`: 32-bit SPARC Linux
 pub const SPARC_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "sparc-unknown-linux-gnu",
-    target_arch: Arch::SPARC,
+    target_arch: Arch::Sparc,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Two,
 };

--- a/platforms/src/platform/tier3.rs
+++ b/platforms/src/platform/tier3.rs
@@ -14,7 +14,7 @@ use crate::{
 /// `aarch64-apple-ios-macabi`: Apple Catalyst on ARM64
 pub const AARCH64_APPLE_IOS_MACABI: Platform = Platform {
     target_triple: "aarch64-apple-ios-macabi",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::iOS,
     target_env: None,
     tier: Tier::Three,
@@ -23,7 +23,7 @@ pub const AARCH64_APPLE_IOS_MACABI: Platform = Platform {
 /// `aarch64-apple-ios-sim`: Apple iOS Simulator on ARM64
 pub const AARCH64_APPLE_IOS_SIM: Platform = Platform {
     target_triple: "aarch64-apple-ios-sim",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::iOS,
     target_env: None,
     tier: Tier::Three,
@@ -32,7 +32,7 @@ pub const AARCH64_APPLE_IOS_SIM: Platform = Platform {
 /// `aarch64-apple-tvos`: ARM64 tvOS
 pub const AARCH64_APPLE_TVOS: Platform = Platform {
     target_triple: "aarch64-apple-tvos",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::tvOS,
     target_env: None,
     tier: Tier::Three,
@@ -41,7 +41,7 @@ pub const AARCH64_APPLE_TVOS: Platform = Platform {
 /// `aarch64-unknown-freebsd`: ARM64 FreeBSD
 pub const AARCH64_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "aarch64-unknown-freebsd",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::FreeBSD,
     target_env: None,
     tier: Tier::Three,
@@ -50,7 +50,7 @@ pub const AARCH64_UNKNOWN_FREEBSD: Platform = Platform {
 /// `aarch64-unknown-hermit`
 pub const AARCH64_UNKNOWN_HERMIT: Platform = Platform {
     target_triple: "aarch64-unknown-hermit",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Hermit,
     target_env: None,
     tier: Tier::Three,
@@ -59,16 +59,16 @@ pub const AARCH64_UNKNOWN_HERMIT: Platform = Platform {
 /// `aarch64-unknown-linux-gnu_ilp32`: ARM64 Linux (ILP32 ABI)
 pub const AARCH64_UNKNOWN_LINUX_GNU_ILP32: Platform = Platform {
     target_triple: "aarch64-unknown-linux-gnu_ilp32",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Three,
 };
 
 /// `aarch64-unknown-netbsd`
 pub const AARCH64_UNKNOWN_NETBSD: Platform = Platform {
     target_triple: "aarch64-unknown-netbsd",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::NetBSD,
     target_env: None,
     tier: Tier::Three,
@@ -77,7 +77,7 @@ pub const AARCH64_UNKNOWN_NETBSD: Platform = Platform {
 /// `aarch64-unknown-openbsd`: ARM64 OpenBSD
 pub const AARCH64_UNKNOWN_OPENBSD: Platform = Platform {
     target_triple: "aarch64-unknown-openbsd",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::OpenBSD,
     target_env: None,
     tier: Tier::Three,
@@ -86,7 +86,7 @@ pub const AARCH64_UNKNOWN_OPENBSD: Platform = Platform {
 /// `aarch64-unknown-redox`: ARM64 Redox OS
 pub const AARCH64_UNKNOWN_REDOX: Platform = Platform {
     target_triple: "aarch64-unknown-redox",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Redox,
     target_env: None,
     tier: Tier::Three,
@@ -95,61 +95,61 @@ pub const AARCH64_UNKNOWN_REDOX: Platform = Platform {
 /// `aarch64-uwp-windows-msvc`
 pub const AARCH64_UWP_WINDOWS_MSVC: Platform = Platform {
     target_triple: "aarch64-uwp-windows-msvc",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Windows,
-    target_env: Some(Env::MSVC),
+    target_env: Some(Env::Msvc),
     tier: Tier::Three,
 };
 
 /// `aarch64-wrs-vxworks`
 pub const AARCH64_WRS_VXWORKS: Platform = Platform {
     target_triple: "aarch64-wrs-vxworks",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::VxWorks,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Three,
 };
 
 /// `aarch64_be-unknown-linux-gnu_ilp32`: ARM64 Linux (big-endian, ILP32 ABI)
 pub const AARCH64_BE_UNKNOWN_LINUX_GNU_ILP32: Platform = Platform {
     target_triple: "aarch64_be-unknown-linux-gnu_ilp32",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Three,
 };
 
 /// `aarch64_be-unknown-linux-gnu`: ARM64 Linux (big-endian)
 pub const AARCH64_BE_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "aarch64_be-unknown-linux-gnu",
-    target_arch: Arch::AARCH64,
+    target_arch: Arch::AArch64,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Three,
 };
 
 /// `armv4t-unknown-linux-gnueabi`
 pub const ARMV4T_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armv4t-unknown-linux-gnueabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Three,
 };
 
 /// `armv5te-unknown-linux-uclibceabi`: ARMv5TE Linux with uClibc
 pub const ARMV5T_UNKNOWN_LINUX_UCLIBCEABI: Platform = Platform {
     target_triple: "armv5te-unknown-linux-uclibceabi",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Linux,
-    target_env: Some(Env::uClibc),
+    target_env: Some(Env::UClibc),
     tier: Tier::Three,
 };
 
 /// `armv6-unknown-freebsd`: ARMv6 FreeBSD
 pub const ARMV6_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "armv6-unknown-freebsd",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::FreeBSD,
     target_env: None,
     tier: Tier::Three,
@@ -158,7 +158,7 @@ pub const ARMV6_UNKNOWN_FREEBSD: Platform = Platform {
 /// `armv6-unknown-netbsd-eabihf`
 pub const ARMV6_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     target_triple: "armv6-unknown-netbsd-eabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::NetBSD,
     target_env: None,
     tier: Tier::Three,
@@ -167,7 +167,7 @@ pub const ARMV6_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
 /// `armv7-apple-ios`: ARMv7 iOS, Cortex-a8
 pub const ARMV7_APPLE_IOS: Platform = Platform {
     target_triple: "armv7-apple-ios",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::iOS,
     target_env: None,
     tier: Tier::Three,
@@ -176,7 +176,7 @@ pub const ARMV7_APPLE_IOS: Platform = Platform {
 /// `armv7-unknown-freebsd`: ARMv7 FreeBSD
 pub const ARMV7_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "armv7-unknown-freebsd",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::FreeBSD,
     target_env: None,
     tier: Tier::Three,
@@ -185,7 +185,7 @@ pub const ARMV7_UNKNOWN_FREEBSD: Platform = Platform {
 /// `armv7-unknown-netbsd-eabihf`
 pub const ARMV7_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     target_triple: "armv7-unknown-netbsd-eabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::NetBSD,
     target_env: None,
     tier: Tier::Three,
@@ -194,16 +194,16 @@ pub const ARMV7_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
 /// `armv7-wrs-vxworks-eabihf`
 pub const ARMV7_WRS_VXWORKS_EABIHF: Platform = Platform {
     target_triple: "armv7-wrs-vxworks-eabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::VxWorks,
-    target_env: Some(Env::GNU),
+    target_env: Some(Env::Gnu),
     tier: Tier::Three,
 };
 
 /// `armv7a-none-eabihf`: ARM Cortex-A, hardfloat
 pub const ARMV7A_NONE_EABIHF: Platform = Platform {
     target_triple: "armv7a-none-eabihf",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Three,
@@ -212,7 +212,7 @@ pub const ARMV7A_NONE_EABIHF: Platform = Platform {
 /// `armv7s-apple-ios`: ARMv7 iOS, Cortex-a9
 pub const ARMV7S_APPLE_IOS: Platform = Platform {
     target_triple: "armv7s-apple-ios",
-    target_arch: Arch::ARM,
+    target_arch: Arch::Arm,
     target_os: OS::iOS,
     target_env: None,
     tier: Tier::Three,
@@ -266,25 +266,25 @@ pub const I686_UNKNOWN_OPENBSD: Platform = Platform {
 /// `mips-unknown-linux-uclibc`: MIPS Linux with uClibc
 pub const MIPS_UNKNOWN_LINUX_UCLIBC: Platform = Platform {
     target_triple: "mips-unknown-linux-uclibc",
-    target_arch: Arch::MIPS,
+    target_arch: Arch::Mips,
     target_os: OS::Linux,
-    target_env: Some(Env::uClibc),
+    target_env: Some(Env::UClibc),
     tier: Tier::Three,
 };
 
 /// `mipsel-unknown-linux-uclibc`: MIPS (LE) Linux with uClibc
 pub const MIPSEL_UNKNOWN_LINUX_UCLIBC: Platform = Platform {
     target_triple: "mipsel-unknown-linux-uclibc",
-    target_arch: Arch::MIPS,
+    target_arch: Arch::Mips,
     target_os: OS::Linux,
-    target_env: Some(Env::uClibc),
+    target_env: Some(Env::UClibc),
     tier: Tier::Three,
 };
 
 /// `msp430-none-elf`: 16-bit MSP430 microcontrollers
 pub const MSP430_NONE_ELF: Platform = Platform {
     target_triple: "msp430-none-elf",
-    target_arch: Arch::MSP430,
+    target_arch: Arch::Msp430,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Three,
@@ -293,7 +293,7 @@ pub const MSP430_NONE_ELF: Platform = Platform {
 /// `powerpc-unknown-linux-musl`
 pub const POWERPC_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "powerpc-unknown-linux-musl",
-    target_arch: Arch::POWERPC,
+    target_arch: Arch::PowerPc,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Three,
@@ -302,7 +302,7 @@ pub const POWERPC_UNKNOWN_LINUX_MUSL: Platform = Platform {
 /// `powerpc64-unknown-linux-musl`
 pub const POWERPC64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "powerpc64-unknown-linux-musl",
-    target_arch: Arch::POWERPC64,
+    target_arch: Arch::PowerPc64,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Three,
@@ -311,7 +311,7 @@ pub const POWERPC64_UNKNOWN_LINUX_MUSL: Platform = Platform {
 /// `powerpc64le-unknown-linux-musl`
 pub const POWERPC64LE_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "powerpc64le-unknown-linux-musl",
-    target_arch: Arch::POWERPC64,
+    target_arch: Arch::PowerPc64,
     target_os: OS::Linux,
     target_env: Some(Env::Musl),
     tier: Tier::Three,
@@ -329,7 +329,7 @@ pub const S390X_UNKNOWN_LINUX_MUSL: Platform = Platform {
 /// `sparc64-unknown-netbsd`: NetBSD/sparc64
 pub const SPARC64_UNKNOWN_NETBSD: Platform = Platform {
     target_triple: "sparc64-unknown-netbsd",
-    target_arch: Arch::SPARC64,
+    target_arch: Arch::Sparc64,
     target_os: OS::NetBSD,
     target_env: None,
     tier: Tier::Three,

--- a/platforms/src/target/arch.rs
+++ b/platforms/src/target/arch.rs
@@ -11,52 +11,52 @@ use serde::{de, ser, Deserialize, Serialize};
 #[non_exhaustive]
 pub enum Arch {
     /// `aarch64`: ARMv8 64-bit architecture
-    AARCH64,
+    AArch64,
 
     /// `arm`: 32-bit ARM architecture
-    ARM,
+    Arm,
 
     /// `asm`: asm.js output
-    ASMJS,
+    AsmJs,
 
     /// `mips`: 32-bit MIPS CPU architecture
-    MIPS,
+    Mips,
 
     /// `mips64`: 64-bit MIPS CPU architecture
-    MIPS64,
+    Mips64,
 
     /// `msp430`: 16-bit MSP430 microcontrollers
-    MSP430,
+    Msp430,
 
     /// `nvptx64`: 64-bit NVIDIA PTX
-    NVPTX64,
+    Nvptx64,
 
     /// `powerpc`: 32-bit POWERPC platform
-    POWERPC,
+    PowerPc,
 
     /// `powerpc64`: 64-bit POWERPC platform
-    POWERPC64,
+    PowerPc64,
 
     /// `riscv`: RISC-V CPU architecture
-    RISCV,
+    RiscV,
 
     /// `s390x`: 64-bit IBM z/Architecture
     S390X,
 
     /// `sparc`: 32-bit SPARC CPU architecture
-    SPARC,
+    Sparc,
 
     /// `sparc64`: 64-bit SPARC CPU architecture
-    SPARC64,
+    Sparc64,
 
     /// `thumbv6`: 16-bit ARM CPU architecture subset
-    THUMBV6,
+    ThumbV6,
 
     /// `thumbv7`: 16-bit ARM CPU architecture subset
-    THUMBV7,
+    ThumbV7,
 
     /// `wasm32`: Web Assembly (32-bit)
-    WASM32,
+    Wasm32,
 
     /// `x86`: Generic x86 CPU architecture
     X86,
@@ -72,22 +72,22 @@ impl Arch {
     /// String representing this target architecture which matches `cfg(target_arch)`
     pub fn as_str(self) -> &'static str {
         match self {
-            Arch::AARCH64 => "aarch64",
-            Arch::ARM => "arm",
-            Arch::ASMJS => "asmjs",
-            Arch::MIPS => "mips",
-            Arch::MIPS64 => "mips64",
-            Arch::MSP430 => "msp430",
-            Arch::NVPTX64 => "nvptx64",
-            Arch::POWERPC => "powerpc",
-            Arch::POWERPC64 => "powerpc64",
-            Arch::RISCV => "riscv",
+            Arch::AArch64 => "aarch64",
+            Arch::Arm => "arm",
+            Arch::AsmJs => "asmjs",
+            Arch::Mips => "mips",
+            Arch::Mips64 => "mips64",
+            Arch::Msp430 => "msp430",
+            Arch::Nvptx64 => "nvptx64",
+            Arch::PowerPc => "powerpc",
+            Arch::PowerPc64 => "powerpc64",
+            Arch::RiscV => "riscv",
             Arch::S390X => "s390x",
-            Arch::SPARC => "sparc",
-            Arch::SPARC64 => "sparc64",
-            Arch::THUMBV6 => "thumbv6",
-            Arch::THUMBV7 => "thumbv7",
-            Arch::WASM32 => "wasm32",
+            Arch::Sparc => "sparc",
+            Arch::Sparc64 => "sparc64",
+            Arch::ThumbV6 => "thumbv6",
+            Arch::ThumbV7 => "thumbv7",
+            Arch::Wasm32 => "wasm32",
             Arch::X86 => "x86",
             Arch::X86_64 => "x86_64",
             Arch::Unknown => "unknown",
@@ -101,22 +101,22 @@ impl FromStr for Arch {
     /// Create a new `Arch` from the given string
     fn from_str(arch_name: &str) -> Result<Self, Self::Err> {
         let arch = match arch_name {
-            "aarch64" => Arch::AARCH64,
-            "arm" => Arch::ARM,
-            "asmjs" => Arch::ASMJS,
-            "mips" => Arch::MIPS,
-            "mips64" => Arch::MIPS64,
-            "msp430" => Arch::MSP430,
-            "nvptx64" => Arch::NVPTX64,
-            "powerpc" => Arch::POWERPC,
-            "powerpc64" => Arch::POWERPC64,
-            "riscv" => Arch::RISCV,
+            "aarch64" => Arch::AArch64,
+            "arm" => Arch::Arm,
+            "asmjs" => Arch::AsmJs,
+            "mips" => Arch::Mips,
+            "mips64" => Arch::Mips64,
+            "msp430" => Arch::Msp430,
+            "nvptx64" => Arch::Nvptx64,
+            "powerpc" => Arch::PowerPc,
+            "powerpc64" => Arch::PowerPc64,
+            "riscv" => Arch::RiscV,
             "s390x" => Arch::S390X,
-            "sparc" => Arch::SPARC,
-            "sparc64" => Arch::SPARC64,
-            "thumbv6" => Arch::THUMBV6,
-            "thumbv7" => Arch::THUMBV7,
-            "wasm32" => Arch::WASM32,
+            "sparc" => Arch::Sparc,
+            "sparc64" => Arch::Sparc64,
+            "thumbv6" => Arch::ThumbV6,
+            "thumbv7" => Arch::ThumbV7,
+            "wasm32" => Arch::Wasm32,
             "x86" => Arch::X86,
             "x86_64" => Arch::X86_64,
             _ => return Err(Error),
@@ -153,43 +153,43 @@ impl<'de> Deserialize<'de> for Arch {
 
 #[cfg(target_arch = "aarch64")]
 /// `target_arch` when building this crate: `x86_64`
-pub const TARGET_ARCH: Arch = Arch::AARCH64;
+pub const TARGET_ARCH: Arch = Arch::AArch64;
 
 #[cfg(target_arch = "arm")]
 /// `target_arch` when building this crate: `arm`
-pub const TARGET_ARCH: Arch = Arch::ARM;
+pub const TARGET_ARCH: Arch = Arch::Arm;
 
 #[cfg(target_arch = "asmjs")]
 /// `target_arch` when building this crate: `asmjs`
-pub const TARGET_ARCH: Arch = Arch::ASMJS;
+pub const TARGET_ARCH: Arch = Arch::AsmJs;
 
 #[cfg(target_arch = "mips")]
 /// `target_arch` when building this crate: `mips`
-pub const TARGET_ARCH: Arch = Arch::MIPS;
+pub const TARGET_ARCH: Arch = Arch::Mips;
 
 #[cfg(target_arch = "mips64")]
 /// `target_arch` when building this crate: `mips64`
-pub const TARGET_ARCH: Arch = Arch::MIPS64;
+pub const TARGET_ARCH: Arch = Arch::Mips64;
 
 #[cfg(target_arch = "msp430")]
 /// `target_arch` when building this crate: `msp430`
-pub const TARGET_ARCH: Arch = Arch::MSP430;
+pub const TARGET_ARCH: Arch = Arch::Msp430;
 
 #[cfg(target_arch = "nvptx64")]
 /// `target_arch` when building this crate: `nvptx64`
-pub const TARGET_ARCH: Arch = Arch::NVPTX64;
+pub const TARGET_ARCH: Arch = Arch::Nvptx64;
 
 #[cfg(target_arch = "powerpc")]
 /// `target_arch` when building this crate: `powerpc`
-pub const TARGET_ARCH: Arch = Arch::POWERPC;
+pub const TARGET_ARCH: Arch = Arch::PowerPc;
 
 #[cfg(target_arch = "powerpc64")]
 /// `target_arch` when building this crate: `powerpc64`
-pub const TARGET_ARCH: Arch = Arch::POWERPC64;
+pub const TARGET_ARCH: Arch = Arch::PowerPc64;
 
 #[cfg(target_arch = "riscv")]
 /// `target_arch` when building this crate: `riscv`
-pub const TARGET_ARCH: Arch = Arch::RISCV;
+pub const TARGET_ARCH: Arch = Arch::RiscV;
 
 #[cfg(target_arch = "s390x")]
 /// `target_arch` when building this crate: `s390x`
@@ -197,15 +197,15 @@ pub const TARGET_ARCH: Arch = Arch::S390X;
 
 #[cfg(target_arch = "sparc")]
 /// `target_arch` when building this crate: `sparc`
-pub const TARGET_ARCH: Arch = Arch::SPARC;
+pub const TARGET_ARCH: Arch = Arch::Sparc;
 
 #[cfg(target_arch = "sparc64")]
 /// `target_arch` when building this crate: `sparc64`
-pub const TARGET_ARCH: Arch = Arch::SPARC64;
+pub const TARGET_ARCH: Arch = Arch::Sparc64;
 
 #[cfg(target_arch = "wasm32")]
 /// `target_arch` when building this crate: `wasm32`
-pub const TARGET_ARCH: Arch = Arch::WASM32;
+pub const TARGET_ARCH: Arch = Arch::Wasm32;
 
 #[cfg(target_arch = "x86")]
 /// `target_arch` when building this crate: `x86`

--- a/platforms/src/target/env.rs
+++ b/platforms/src/target/env.rs
@@ -14,20 +14,19 @@ use serde::{de, ser, Deserialize, Serialize};
 #[non_exhaustive]
 pub enum Env {
     /// `gnu`: The GNU C Library (glibc)
-    GNU,
+    Gnu,
 
     /// `msvc`: Microsoft Visual C(++)
-    MSVC,
+    Msvc,
 
     /// `musl`: Clean, efficient, standards-conformant libc implementation.
     Musl,
 
     /// `sgx`: Intel Software Guard Extensions (SGX) Enclave
-    SGX,
+    Sgx,
 
     /// `uclibc`: C library for developing embedded Linux systems
-    #[allow(non_camel_case_types)]
-    uClibc,
+    UClibc,
 
     /// Unknown target environment
     Unknown,
@@ -37,11 +36,11 @@ impl Env {
     /// String representing this environment which matches `#[cfg(target_env)]`
     pub fn as_str(self) -> &'static str {
         match self {
-            Env::GNU => "gnu",
-            Env::MSVC => "msvc",
+            Env::Gnu => "gnu",
+            Env::Msvc => "msvc",
             Env::Musl => "musl",
-            Env::SGX => "sgx",
-            Env::uClibc => "uclibc",
+            Env::Sgx => "sgx",
+            Env::UClibc => "uclibc",
             Env::Unknown => "unknown",
         }
     }
@@ -53,11 +52,11 @@ impl FromStr for Env {
     /// Create a new `Env` from the given string
     fn from_str(env_name: &str) -> Result<Self, Self::Err> {
         let env = match env_name {
-            "gnu" => Env::GNU,
-            "msvc" => Env::MSVC,
+            "gnu" => Env::Gnu,
+            "msvc" => Env::Msvc,
             "musl" => Env::Musl,
-            "sgx" => Env::SGX,
-            "uclibc" => Env::uClibc,
+            "sgx" => Env::Sgx,
+            "uclibc" => Env::UClibc,
             _ => return Err(Error),
         };
 
@@ -92,11 +91,11 @@ impl<'de> Deserialize<'de> for Env {
 
 #[cfg(target_env = "gnu")]
 /// `target_env` when building this crate: `gnu`
-pub const TARGET_ENV: Option<Env> = Some(Env::GNU);
+pub const TARGET_ENV: Option<Env> = Some(Env::Gnu);
 
 #[cfg(target_env = "msvc")]
 /// `target_env` when building this crate: `msvc`
-pub const TARGET_ENV: Option<Env> = Some(Env::MSVC);
+pub const TARGET_ENV: Option<Env> = Some(Env::Msvc);
 
 #[cfg(target_env = "musl")]
 /// `target_env` when building this crate: `musl`
@@ -104,11 +103,11 @@ pub const TARGET_ENV: Option<Env> = Some(Env::Musl);
 
 #[cfg(target_env = "sgx")]
 /// `target_env` when building this crate: `sgx`
-pub const TARGET_ENV: Option<Env> = Some(Env::SGX);
+pub const TARGET_ENV: Option<Env> = Some(Env::Sgx);
 
 #[cfg(target_env = "uclibc")]
 /// `target_env` when building this crate: `uclibc`
-pub const TARGET_ENV: Option<Env> = Some(Env::uClibc);
+pub const TARGET_ENV: Option<Env> = Some(Env::UClibc);
 
 #[cfg(not(any(
     target_env = "gnu",

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -20,7 +20,7 @@ git2 = { version = "0.13", optional = true }
 home = { version = "0.5", optional = true }
 humantime = { version = "2", optional = true }
 humantime-serde = { version = "1", optional = true }
-platforms = { version = "1", features = ["serde"], path = "../platforms" }
+platforms = { version = "1", features = ["serde"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1.0.25"


### PR DESCRIPTION
Changes the `target::Arch` and `target::Env` enums to have variants which pass the `clippy::upper_case_acronyms` lint, replacing all upper case letters with the standard Rust enum capitalization.