### PR TITLE
cargo-audit: temporarily disable macOS CI

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         platform:
           - ubuntu-latest
-          - macos-latest
+          #- macos-latest # TODO(tarcieri): re-enable macOS tests
           #- windows-latest # TODO(tarcieri): re-enable Windows tests
         toolchain:
           - 1.47.0 # MSRV


### PR DESCRIPTION
These are routinely the slowest builds and annoying when trying to iterate on multiple PRs in a row.

This temporarily disables them, with the goal of re-enabling them prior to the next release.