### PR TITLE
Clippy fixes for 1.52

### DIFF
--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -45,11 +45,13 @@ pub struct AuditConfig {
 impl AuditConfig {
     /// Get audit report settings from the configuration
     pub fn report_settings(&self) -> report::Settings {
-        let mut settings = rustsec::report::Settings::default();
-        settings.ignore = self.advisories.ignore.clone();
-        settings.severity = self.advisories.severity_threshold;
-        settings.target_arch = self.target.arch;
-        settings.target_os = self.target.os;
+        let mut settings = rustsec::report::Settings {
+            ignore: self.advisories.ignore.clone(),
+            severity: self.advisories.severity_threshold,
+            target_arch: self.target.arch,
+            target_os: self.target.os,
+            ..Default::default()
+        };
 
         if let Some(source) = &self.packages.source {
             settings.package_scope = Some(source.clone().into());

--- a/rustsec/src/advisory/date.rs
+++ b/rustsec/src/advisory/date.rs
@@ -1,9 +1,11 @@
 //! Advisory dates
 
 use crate::error::{Error, ErrorKind};
-
 use serde::{de, Deserialize, Serialize};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
 
 /// Minimum allowed year on advisory dates
 pub(crate) const YEAR_MIN: u32 = 2000;
@@ -45,17 +47,15 @@ impl Date {
     }
 }
 
-impl<'de> Deserialize<'de> for Date {
-    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use de::Error;
-        let string = String::deserialize(deserializer)?;
-        string.parse().map_err(D::Error::custom)
-    }
-}
-
 impl AsRef<str> for Date {
     fn as_ref(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl Display for Date {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -69,9 +69,12 @@ impl FromStr for Date {
     }
 }
 
-impl Into<String> for Date {
-    fn into(self) -> String {
-        self.0
+impl<'de> Deserialize<'de> for Date {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(D::Error::custom)
     }
 }
 

--- a/rustsec/src/advisory/id.rs
+++ b/rustsec/src/advisory/id.rs
@@ -123,7 +123,7 @@ impl Default for Id {
 
 impl Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.string.fmt(f)
+        f.write_str(self.as_str())
     }
 }
 
@@ -152,12 +152,6 @@ impl FromStr for Id {
     }
 }
 
-impl Into<String> for Id {
-    fn into(self) -> String {
-        self.string
-    }
-}
-
 impl Serialize for Id {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.string)
@@ -166,8 +160,7 @@ impl Serialize for Id {
 
 impl<'de> Deserialize<'de> for Id {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Self::from_str(&String::deserialize(deserializer)?)
-            .map_err(|e| D::Error::custom(format!("{}", e)))
+        Self::from_str(&String::deserialize(deserializer)?).map_err(D::Error::custom)
     }
 }
 

--- a/rustsec/src/osv/osv_advisory.rs
+++ b/rustsec/src/osv/osv_advisory.rs
@@ -92,12 +92,13 @@ impl From<Url> for OsvReference {
     }
 }
 
-#[allow(dead_code)] // we don't (yet) construct all the variants
 #[derive(Debug, Clone, Serialize)]
 pub enum OsvReferenceKind {
     ADVISORY,
+    #[allow(dead_code)]
     ARTICLE,
     REPORT,
+    #[allow(dead_code)]
     FIX,
     PACKAGE,
     WEB,

--- a/rustsec/src/repository/git/authentication.rs
+++ b/rustsec/src/repository/git/authentication.rs
@@ -131,8 +131,7 @@ where
     // call our callback, `f`, in a loop here.
     if ssh_username_requested {
         debug_assert!(res.is_err());
-        let mut attempts = Vec::new();
-        attempts.push("git".to_string());
+        let mut attempts = vec!["git".to_owned()];
         if let Ok(s) = env::var("USER").or_else(|_| env::var("USERNAME")) {
             attempts.push(s);
         }


### PR DESCRIPTION
In preparation for bumping MSRV to 1.52, this commit fixes all of the clippy nits presently surfaced by the version included with the Rust 1.52 distribution.