### PR TITLE
.cargo/audit.toml: remove patched vulns

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,6 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2019-0036", # `failure` unsoundness (used by `cargo-edit`)
-    "RUSTSEC-2020-0016", # `net2` unmaintained (need to update to Tokio 1.0)
-    "RUSTSEC-2020-0036", # `failure` unmaintained (used by `cargo-edit`)
-    "RUSTSEC-2020-0053", # `dirs` unmaintained (used by `cargo-edit`)
     "RUSTSEC-2020-0071", # `time` localtime_r segfault
-    "RUSTSEC-2021-0078", # `hyper` request smuggling (used by `cargo-edit`)
-    "RUSTSEC-2021-0079", # `hyper` data loss (used by `cargo-edit`)
     "RUSTSEC-2020-0159", # `chrono` localtime_r segfault
 ]
 


### PR DESCRIPTION
Removes all vulns patched by the `cargo-edit` upgrade from the allowed list in audit.toml