### PR TITLE
rustsec v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
- "zeroize",
 ]
 
 [[package]]
@@ -1610,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -13,7 +13,7 @@ edition     = "2018"
 abscissa_core = "0.5"
 crates-index = "0.17"
 gumdrop = "0.7"
-rustsec = { version = "0.24.3", path = "../rustsec", features = ["osv-export"] }
+rustsec = { version = "0.25.0", path = "../rustsec", features = ["osv-export"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 termcolor = "1"

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -19,11 +19,10 @@ abscissa_core = "0.5.2"
 gumdrop = "0.7"
 home = "0.5"
 lazy_static = "1"
-rustsec = { version = "0.24.3", features = ["dependency-tree"], path = "../rustsec" }
+rustsec = { version = "0.25", features = ["dependency-tree"], path = "../rustsec" }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 thiserror = "1"
-zeroize = ">= 1, < 1.4"
 
 [dev-dependencies]
 once_cell = "1.5"

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.25.0 (2021-11-12)
+### Changed
+- Bump cargo-edit from 0.7.0 to 0.8.0 ([#439])
+- Make `advisory::id::Kind` lowercase ([#471])
+- Bump MSRV to 1.52 ([#476])
+- Flatten API: make modules with one type non-`pub`; re-export type from parent ([#478])
+
+[#439]: https://github.com/RustSec/rustsec/pull/439
+[#471]: https://github.com/RustSec/rustsec/pull/471
+[#476]: https://github.com/RustSec/rustsec/pull/476
+[#478]: https://github.com/RustSec/rustsec/pull/478
+
 ## 0.24.3 (2021-09-11)
 ### Added
 - `vendored-libgit2` feature ([#432])

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.24.3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.25.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.24.3"
+    html_root_url = "https://docs.rs/rustsec/0.25.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `cargo-edit` dependency from 0.7.0 to 0.8.0 ([#439])
- Make `advisory::id::Kind` lowercase ([#471])
- Bump MSRV to 1.52 ([#476])
- Flatten API: make modules with one type non-`pub`; re-export type from parent ([#478])

[#439]: https://github.com/RustSec/rustsec/pull/439
[#471]: https://github.com/RustSec/rustsec/pull/471
[#476]: https://github.com/RustSec/rustsec/pull/476
[#478]: https://github.com/RustSec/rustsec/pull/478