### PR TITLE
Update atom_syndication to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "atom_syndication"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ef55438c44fce2215bcd0539964a98ab4bcd77007487a0e72a88ffef2286de"
+checksum = "21fb6a0b39c6517edafe46f8137e53c51742425a4dae1c73ee12264a37ad7541"
 dependencies = [
  "chrono",
  "derive_builder",

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", features = ["serde"] }
 askama = "0.10"
 rust-embed="6.2.0"
 comrak = "0.12"
-atom_syndication = "0.10"
+atom_syndication = "0.11"
 xml-rs = "0.8"
 
 [dev-dependencies]

--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -404,7 +404,7 @@ fn render_feed(output_path: &Path, advisories: &[rustsec::Advisory]) {
             rendered_description,
             rendered_title,
         };
-        let html = escape_str_attribute(&advisory_tmpl.render().unwrap()).into_owned();
+        let html = advisory_tmpl.render().unwrap();
         let content = ContentBuilder::default()
             .content_type(Some("html".to_owned()))
             .lang("en".to_owned())


### PR DESCRIPTION
We must not escape the html as it is done automatically by atom_syndication now.