### PR TITLE
rustsec-admin v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec-admin"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "abscissa_core",
  "askama",

--- a/admin/CHANGELOG.md
+++ b/admin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0 (2021-11-13)
+- Update `rustsec` crate to v0.25 ([#480])
+- Update `atom_syndication` to 0.11 ([#481])
+
+[#480]: https://github.com/RustSec/rustsec/pull/480
+[#481]: https://github.com/RustSec/rustsec/pull/481
+
 ## 0.5.3 (2021-10-22)
 - Bump `rust-embed` from 5.9.0 to 6.2.0 ([#437])
 - Add information about CVSS score and metrics ([#452])

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec-admin"
 description = "Admin utility for maintaining the RustSec Advisory Database"
-version     = "0.5.3"
+version     = "0.6.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"
@@ -13,7 +13,7 @@ edition     = "2018"
 abscissa_core = "0.5"
 crates-index = "0.17"
 gumdrop = "0.7"
-rustsec = { version = "0.25.0", path = "../rustsec", features = ["osv-export"] }
+rustsec = { version = "0.25", path = "../rustsec", features = ["osv-export"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 termcolor = "1"
@@ -21,7 +21,7 @@ thiserror = "1"
 toml = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 askama = "0.10"
-rust-embed="6.2.0"
+rust-embed="6.2"
 comrak = "0.12"
 atom_syndication = "0.11"
 xml-rs = "0.8"

--- a/admin/README.md
+++ b/admin/README.md
@@ -39,7 +39,7 @@ additional terms or conditions.
 [build-link]: https://github.com/RustSec/rustsec/actions/workflows/admin.yml
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.52+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rust-lang.zulipchat.com/#narrow/stream/146229-wg-secure-code/


### PR DESCRIPTION
- Update `rustsec` crate to v0.25 ([#480])
- Update `atom_syndication` to 0.11 ([#481])

[#480]: https://github.com/RustSec/rustsec/pull/480
[#481]: https://github.com/RustSec/rustsec/pull/481