### PR TITLE
platforms v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,7 +1100,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 name = "markdown-table-gen"
 version = "0.0.0"
 dependencies = [
- "platforms 2.0.0-pre",
+ "platforms",
 ]
 
 [[package]]
@@ -1344,16 +1344,7 @@ checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "platforms"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "platforms"
-version = "2.0.0-pre"
+version = "2.0.0"
 dependencies = [
  "serde",
 ]
@@ -1621,7 +1612,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "once_cell",
- "platforms 1.1.0",
+ "platforms",
  "semver 1.0.4",
  "serde",
  "tempfile",

--- a/platforms/CHANGELOG.md
+++ b/platforms/CHANGELOG.md
@@ -5,70 +5,63 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 (2021-11-15)
+### Added
+- New tier 3 targets ([#357])
+
+### Changed
+- Sync with Rust platform support documentation ([#353])
+- Follow `upper_case_acronyms` conventions ([#473])
+- Make tier modules non-`pub` ([#483])
+- Make `Platform::ALL` an inherent constant ([#484])
+
+[#353]: https://github.com/rustsec/rustsec/pull/353
+[#357]: https://github.com/rustsec/rustsec/pull/357
+[#473]: https://github.com/rustsec/rustsec/pull/473
+[#483]: https://github.com/rustsec/rustsec/pull/483
+[#484]: https://github.com/rustsec/rustsec/pull/484
+
 ## 1.1.0 (2020-12-28)
 ### Added
-- `aarch64-apple-darwin` platform definition ([#32])
-
-[#32]: https://github.com/RustSec/platforms-crate/pull/32
+- `aarch64-apple-darwin` platform definition
 
 ## 1.0.3 (2020-10-29)
 ### Changed
 - Source `Platform::guess_current` from `$TARGET` environment variable when
-  available ([#29])
-
-[#29]: https://github.com/RustSec/platforms-crate/pull/29
+  available
 
 ## 1.0.2 (2020-09-14)
 ### Removed
-- `const fn` on `Platforms::all` ([#27])
-
-[#27]: https://github.com/RustSec/platforms-crate/pull/27
+- `const fn` on `Platforms::all`
 
 ## 1.0.1 (2020-09-14) [YANKED]
 ### Changed
-- Make `Platform::all()` a `const fn` ([#24])
-- Refactor `Platform::find` and `::guess_current` ([#23])
-- Rename `ALL_PLATFORMS` to `Platform::all()` ([#22])
-
-[#24]: https://github.com/RustSec/platforms-crate/pull/24
-[#23]: https://github.com/RustSec/platforms-crate/pull/23
-[#22]: https://github.com/RustSec/platforms-crate/pull/22
+- Make `Platform::all()` a `const fn`
+- Refactor `Platform::find` and `::guess_current`
+- Rename `ALL_PLATFORMS` to `Platform::all()`
 
 ## 1.0.0 (2020-09-13) [YANKED]
 ### Added
-- Ensure all types have `FromStr`, `Display`, and `serde` impls ([#20])
-- `aarch64-pc-windows-msvc` platform ([#17])
+- Ensure all types have `FromStr`, `Display`, and `serde` impls
+- `aarch64-pc-windows-msvc` platform
 
 ### Changed
-- Make extensible enums `non_exhaustive`; MSRV 1.40+ ([#18])
-
-[#20]: https://github.com/RustSec/platforms-crate/pull/20
-[#18]: https://github.com/RustSec/platforms-crate/pull/18
-[#17]: https://github.com/RustSec/platforms-crate/pull/17
+- Make extensible enums `non_exhaustive`; MSRV 1.40+
 
 ## 0.2.1 (2019-09-24)
 
-- Initial GitHub Actions config ([#12])
-- Properly set up `target::os::TARGET_OS` const for unknown OS ([#11])
-
-[#12]: https://github.com/RustSec/platforms-crate/pull/12
-[#11]: https://github.com/RustSec/platforms-crate/pull/11
+- Initial GitHub Actions config
+- Properly set up `target::os::TARGET_OS` const for unknown OS
 
 ## 0.2.0 (2019-01-13)
 
-- Update platforms to match RustForge ([#9])
-- Update to Rust 2018 edition ([#8])
-
-[#9]: https://github.com/RustSec/platforms-crate/pull/9
-[#8]: https://github.com/RustSec/platforms-crate/pull/8
+- Update platforms to match RustForge
+- Update to Rust 2018 edition
 
 ## 0.1.4 (2018-07-29)
 
-- `x86_64-apple-darwin`: fix typo in target triple name ([#6])
-- Have markdown-table-gen output links to Platform structs on docs.rs ([#5])
-
-[#6]: https://github.com/RustSec/platforms-crate/pull/6
-[#5]: https://github.com/RustSec/platforms-crate/pull/5
+- `x86_64-apple-darwin`: fix typo in target triple name
+- Have markdown-table-gen output links to Platform structs on docs.rs
 
 ## 0.1.3 (2018-07-28)
 
@@ -76,23 +69,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.2 (2018-07-27)
 
-- Add table of supported platforms to README.md using Markdown generator ([#4])
-
-[#4]: https://github.com/RustSec/platforms-crate/pull/4
+- Add table of supported platforms to README.md using Markdown generator
 
 ## 0.1.1 (2018-07-27)
 
-- Impl `Display` and `std::error::Error` traits for `packages::Error` ([#3])
-
-[#3]: https://github.com/RustSec/platforms-crate/pull/3
+- Impl `Display` and `std::error::Error` traits for `packages::Error`
 
 ## 0.1.0 (2018-07-26)
 
-- Add `guess_current()` ([#2])
-- Optional serde support ([#1])
-
-[#2]: https://github.com/RustSec/platforms-crate/pull/2
-[#1]: https://github.com/RustSec/platforms-crate/pull/1
+- Add `guess_current()`
+- Optional serde support
 
 ## 0.0.1 (2018-07-26)
 

--- a/platforms/Cargo.toml
+++ b/platforms/Cargo.toml
@@ -4,11 +4,11 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from Rust Forge.
 """
-version    = "2.0.0-pre" # Also update html_root_url in lib.rs when bumping this
+version    = "2.0.0" # Also update html_root_url in lib.rs when bumping this
 authors    = ["Tony Arcieri <bascule@gmail.com>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://rustsec.org"
-repository = "https://github.com/RustSec/rustsec/tree/main/platforms"
+repository = "https://github.com/rustsec/rustsec/tree/main/platforms"
 readme     = "README.md"
 categories = ["development-tools", "no-std"]
 keywords   = ["architectures", "cpu", "platforms", "os", "targets"]

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -20,7 +20,7 @@ git2 = { version = "0.13", optional = true }
 home = { version = "0.5", optional = true }
 humantime = { version = "2", optional = true }
 humantime-serde = { version = "1", optional = true }
-platforms = { version = "1", features = ["serde"] }
+platforms = { version = "2", features = ["serde"], path = "../platforms" }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"


### PR DESCRIPTION
### Added
- New tier 3 targets ([#357])

### Changed
- Sync with Rust platform support documentation ([#353])
- Follow `upper_case_acronyms` conventions ([#473])
- Make tier modules non-`pub` ([#483])
- Make `Platform::ALL` an inherent constant ([#484])

[#353]: https://github.com/rustsec/rustsec/pull/353
[#357]: https://github.com/rustsec/rustsec/pull/357
[#473]: https://github.com/rustsec/rustsec/pull/473
[#483]: https://github.com/rustsec/rustsec/pull/483
[#484]: https://github.com/rustsec/rustsec/pull/484