### PR TITLE
rustsec v0.25.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.25.0 (2021-11-12)
+## 0.25.1 (2021-11-15)
 ### Changed
-- Bump cargo-edit from 0.7.0 to 0.8.0 ([#439])
+- Bump `platforms` dependency to v2.0.0 ([#485])
+
+[#485]: https://github.com/RustSec/rustsec/pull/485
+
+## 0.25.0 (2021-11-12) [YANKED]
+### Changed
+- Bump `cargo-edit` dependency from 0.7.0 to 0.8.0 ([#439])
 - Make `advisory::id::Kind` lowercase ([#471])
 - Bump MSRV to 1.52 ([#476])
 - Flatten API: make modules with one type non-`pub`; re-export type from parent ([#478])

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec"
 description = "Client library for the RustSec security advisory database"
-version     = "0.25.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.25.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.25.0"
+    html_root_url = "https://docs.rs/rustsec/0.25.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `platforms` dependency to v2.0.0 ([#485])

[#485]: https://github.com/RustSec/rustsec/pull/485