### PR TITLE
cargo-audit v0.16.0

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         platform:
           - ubuntu-latest
-          #- macos-latest # TODO(tarcieri): re-enable macOS tests
-          #- windows-latest # TODO(tarcieri): re-enable Windows tests
+          - macos-latest
+          - windows-latest
         toolchain:
           - 1.52.0 # MSRV
           - stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "abscissa_core",
  "gumdrop 0.7.0",

--- a/cargo-audit/CHANGELOG.md
+++ b/cargo-audit/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 (2021-11-15)
+### Changed
+- Bump `rustsec` dependency to v0.25; MSRV 1.52 ([#480])
+
+### Fixed
+- Parse `--color=auto` correctly ([#436])
+
+[#436]: https://github.com/rustsec/rustsec/pull/436
+[#480]: https://github.com/rustsec/rustsec/pull/480
+
 ## 0.15.2 (2021-09-11)
 ### Added
 - `vendored-libgit2` feature ([#432])
@@ -56,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON serialization ([#277])
 
 [#278]: https://github.com/RustSec/cargo-audit/pull/278
-[#277]: https://github.com/RustSec/cargo-audit/pull/277
+[#a277]: https://github.com/RustSec/cargo-audit/pull/277
 
 ## 0.13.0 (2020-10-26) [YANKED]
 ### Added

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.15.2"
+version     = "0.16.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/cargo-audit/src/lib.rs
+++ b/cargo-audit/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.15.2"
+    html_root_url = "https://docs.rs/cargo-audit/0.16.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Bump `rustsec` dependency to v0.25; MSRV 1.52 ([#480])

### Fixed
- Parse `--color=auto` correctly ([#436])

[#436]: https://github.com/rustsec/rustsec/pull/436
[#480]: https://github.com/rustsec/rustsec/pull/480