### PR TITLE
Fix cargo-audit JSON deserialization issue

### DIFF
--- a/cargo-audit/tests/acceptance.rs
+++ b/cargo-audit/tests/acceptance.rs
@@ -10,7 +10,9 @@
 use abscissa_core::testing::prelude::*;
 use once_cell::sync::Lazy;
 use std::{io::BufRead, path::PathBuf};
+use std::fs::File;
 use tempfile::TempDir;
+use rustsec::Report;
 
 /// Directory containing the advisory database.
 ///
@@ -169,4 +171,15 @@ fn advisories_found_but_ignored_json() {
             .unwrap(),
         0
     );
+}
+
+#[test]
+fn parse_affected_from_json() {
+    let path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "tests", "support", "json", "audit.json"]
+        .iter()
+        .collect();
+    let file = File::open(path)
+        .expect("cannot open file");
+    let report = serde_json::from_reader::<_, Report>(file);
+    assert!(report.is_ok())
 }

--- a/cargo-audit/tests/support/json/audit.json
+++ b/cargo-audit/tests/support/json/audit.json
@@ -1,0 +1,122 @@
+{
+	"database": {
+		"advisory-count": 123,
+		"last-commit": "812e7ad54c1af98bd8a7caqwe997222e2a5b14",
+		"last-updated": "2021-11-18T14:04:01Z"
+	},
+	"lockfile": {
+		"dependency-count": 123
+	},
+	"settings": {
+		"target_arch": null,
+		"target_os": null,
+		"severity": null,
+		"ignore": [],
+		"informational_warnings": ["unmaintained"],
+		"package_scope": null
+	},
+	"vulnerabilities": {
+		"found": true,
+		"count": 1,
+		"list": [{
+			"advisory": {
+				"id": "RUSTSEC-2020-0071",
+				"package": "time",
+				"title": "Potential segfault in the time crate",
+				"description": "### Impact\n\nUnix-like operating systems may segfault due to dereferencing a dangling pointer in specific circumstances. This requires an environment variable to be set in a different thread than the affected functions. This may occur without the user's knowledge, notably in a third-party library.\n\nThe affected functions from time 0.2.7 through 0.2.22 are:\n\n- `time::UtcOffset::local_offset_at`\n- `time::UtcOffset::try_local_offset_at`\n- `time::UtcOffset::current_local_offset`\n- `time::UtcOffset::try_current_local_offset`\n- `time::OffsetDateTime::now_local`\n- `time::OffsetDateTime::try_now_local`\n\nThe affected functions in time 0.1 (all versions) are:\n\n- `at`\n- `at_utc`\n- `now`\n\nNon-Unix targets (including Windows and wasm) are unaffected.\n\n### Patches\n\nPending a proper fix, the internal method that determines the local offset has been modified to always return `None` on the affected operating systems. This has the effect of returning an `Err` on the `try_*` methods and `UTC` on the non-`try_*` methods.\n\nUsers and library authors with time in their dependency tree should perform `cargo update`, which will pull in the updated, unaffected code.\n\nUsers of time 0.1 do not have a patch and should upgrade to an unaffected version: time 0.2.23 or greater or the 0.3 series.\n\n### Workarounds\n\nNo workarounds are known.\n\n### References\n\ntime-rs/time#293",
+				"date": "2020-11-18",
+				"aliases": ["CVE-2020-26235"],
+				"related": [],
+				"collection": "crates",
+				"categories": ["code-execution", "memory-corruption"],
+				"keywords": ["segfault"],
+				"cvss": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+				"informational": null,
+				"url": "https://github.com/time-rs/time/issues/293",
+				"references": [],
+				"withdrawn": null
+			},
+			"versions": {
+				"patched": [">=0.2.23"],
+				"unaffected": ["=0.2.0", "=0.2.1", "=0.2.2", "=0.2.3", "=0.2.4", "=0.2.5", "=0.2.6"]
+			},
+			"affected": {
+				"arch": ["x86", "aarch64"],
+				"os": ["linux", "unknown", "unknown", "android", "ios", "macos", "netbsd", "openbsd", "unknown", "freebsd"],
+				"functions": {
+					"time::OffsetDateTime::now_local": ["<0.2.23"],
+					"time::OffsetDateTime::try_now_local": ["<0.2.23"],
+					"time::UtcOffset::current_local_offset": ["<0.2.23"],
+					"time::UtcOffset::local_offset_at": ["<0.2.23"],
+					"time::UtcOffset::try_current_local_offset": ["<0.2.23"],
+					"time::UtcOffset::try_local_offset_at": ["<0.2.23"],
+					"time::at": ["^0.1"],
+					"time::at_utc": ["^0.1"],
+					"time::now": ["^0.1"]
+				}
+			},
+			"package": {
+				"name": "time",
+				"version": "0.1.43",
+				"source": "registry+https://github.com/rust-lang/crates.io-index",
+				"checksum": "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438",
+				"dependencies": [{
+					"name": "libc",
+					"version": "0.2.107",
+					"source": "registry+https://github.com/rust-lang/crates.io-index"
+				}, {
+					"name": "winapi",
+					"version": "0.3.9",
+					"source": null
+				}],
+				"replace": null
+			}
+		}]
+	},
+	"warnings": {
+		"unmaintained": [{
+			"kind": "unmaintained",
+			"package": {
+				"name": "net2",
+				"version": "0.2.37",
+				"source": "registry+https://github.com/rust-lang/crates.io-index",
+				"checksum": "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae",
+				"dependencies": [{
+					"name": "cfg-if",
+					"version": "0.1.10",
+					"source": null
+				}, {
+					"name": "libc",
+					"version": "0.2.107",
+					"source": "registry+https://github.com/rust-lang/crates.io-index"
+				}, {
+					"name": "winapi",
+					"version": "0.3.9",
+					"source": null
+				}],
+				"replace": null
+			},
+			"advisory": {
+				"id": "RUSTSEC-2020-0016",
+				"package": "net2",
+				"title": "`net2` crate has been deprecated; use `socket2` instead",
+				"description": "The [`net2`](https://crates.io/crates/net2) crate has been deprecated\nand users are encouraged to considered [`socket2`](https://crates.io/crates/socket2) instead.",
+				"date": "2020-05-01",
+				"aliases": [],
+				"related": [],
+				"collection": "crates",
+				"categories": [],
+				"keywords": [],
+				"cvss": null,
+				"informational": "unmaintained",
+				"url": "https://github.com/deprecrated/net2-rs/commit/3350e3819adf151709047e93f25583a5df681091",
+				"references": [],
+				"withdrawn": null
+			},
+			"versions": {
+				"patched": [],
+				"unaffected": []
+			}
+		}]
+	}
+}

--- a/platforms/src/target/arch.rs
+++ b/platforms/src/target/arch.rs
@@ -2,6 +2,7 @@
 
 use crate::error::Error;
 use core::{fmt, str::FromStr};
+use std::string::String;
 
 #[cfg(feature = "serde")]
 use serde::{de, ser, Deserialize, Serialize};
@@ -142,7 +143,7 @@ impl Serialize for Arch {
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Arch {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(<&str>::deserialize(deserializer)?
+        Ok(String::deserialize(deserializer)?
             .parse()
             .unwrap_or(Arch::Unknown))
     }
@@ -234,3 +235,26 @@ pub const TARGET_ARCH: Arch = Arch::X86_64;
 )))]
 /// `target_arch` when building this crate: unknown!
 pub const TARGET_ARCH: Arch = Arch::Unknown;
+
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::target::Arch;
+
+    #[test]
+    fn valid_os_tests() {
+        assert!(Arch::from_str("aarch64").is_ok());
+        assert!(Arch::from_str("x86").is_ok());
+    }
+
+    #[test]
+    fn invalid_os_tests() {
+        assert!(Arch::from_str("").is_err());
+        assert!(Arch::from_str(" ").is_err());
+        assert!(Arch::from_str("derp").is_err());
+        assert!(Arch::from_str("***").is_err());
+        assert!(Arch::from_str("unknown").is_err());
+    }
+}

--- a/platforms/src/target/env.rs
+++ b/platforms/src/target/env.rs
@@ -2,6 +2,7 @@
 
 use crate::error::Error;
 use core::{fmt, str::FromStr};
+use std::string::String;
 
 #[cfg(feature = "serde")]
 use serde::{de, ser, Deserialize, Serialize};
@@ -80,7 +81,7 @@ impl Serialize for Env {
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Env {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(<&str>::deserialize(deserializer)?
+        Ok(String::deserialize(deserializer)?
             .parse()
             .unwrap_or(Env::Unknown))
     }
@@ -118,3 +119,26 @@ pub const TARGET_ENV: Option<Env> = Some(Env::UClibc);
 )))]
 /// `target_env` when building this crate: none
 pub const TARGET_ENV: Option<Env> = None;
+
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::target::Env;
+
+    #[test]
+    fn valid_os_tests() {
+        assert!(Env::from_str("gnu").is_ok());
+        assert!(Env::from_str("uclibc").is_ok());
+    }
+
+    #[test]
+    fn invalid_os_tests() {
+        assert!(Env::from_str("").is_err());
+        assert!(Env::from_str(" ").is_err());
+        assert!(Env::from_str("derp").is_err());
+        assert!(Env::from_str("***").is_err());
+        assert!(Env::from_str("unknown").is_err());
+    }
+}

--- a/platforms/src/target/os.rs
+++ b/platforms/src/target/os.rs
@@ -2,6 +2,7 @@
 
 use crate::error::Error;
 use core::{fmt, str::FromStr};
+use std::string::String;
 
 #[cfg(feature = "serde")]
 use serde::{de, ser, Deserialize, Serialize};
@@ -154,7 +155,7 @@ impl Serialize for OS {
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for OS {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(<&str>::deserialize(deserializer)?
+        Ok(String::deserialize(deserializer)?
             .parse()
             .unwrap_or(OS::Unknown))
     }
@@ -266,3 +267,27 @@ pub const TARGET_OS: OS = OS::VxWorks;
 )))]
 /// `target_os` when building this crate: unknown!
 pub const TARGET_OS: OS = OS::Unknown;
+
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::target::OS;
+
+    #[test]
+    fn valid_os_tests() {
+        assert!(OS::from_str("linux").is_ok());
+        assert!(OS::from_str("ios").is_ok());
+        assert!(OS::from_str("windows").is_ok());
+    }
+
+    #[test]
+    fn invalid_os_tests() {
+        assert!(OS::from_str("").is_err());
+        assert!(OS::from_str(" ").is_err());
+        assert!(OS::from_str("derp").is_err());
+        assert!(OS::from_str("***").is_err());
+        assert!(OS::from_str("unknown").is_err());
+    }
+}


### PR DESCRIPTION
- update OS/Arch/Env deserializer type to String instead of borrowed string
- add unit and acceptance tests

Resolves #492 