### PR TITLE
rustsec: fix the fixer function in the `cargo-audit`

### DIFF
--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -15,7 +15,8 @@ pub struct Fixer {
 impl Fixer {
     /// Create a new [`Fixer`] for the given `Cargo.toml` file
     pub fn new(cargo_toml: impl AsRef<Path>) -> Result<Self, Error> {
-        let manifest = cargo_edit::LocalManifest::try_new(cargo_toml.as_ref())?;
+        let manifest =
+            cargo_edit::LocalManifest::try_new(cargo_toml.as_ref().canonicalize()?.as_ref())?;
         Ok(Self { manifest })
     }
 


### PR DESCRIPTION
The `cargo-edit` crate had a behaviour change that now requires the absolute path to the toml file. 
Otherwise cargo-audit will panic with the message "Absolute path needed, got: ".

For the record, an example of the panic:

```
The application panicked (crashed).
Message:  Absolute path needed, got: 
Location: /root/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-edit-0.8.0/src/dependency.rs:199

Run with RUST_BACKTRACE=full to include source snippets.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                          (7 post panic frames hidden)                          
 7: cargo_edit::dependency::Dependency::to_toml::had52f650d1c415e3
    at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-edit-0.8.0/src/dependency.rs:199
 8: cargo_edit::manifest::LocalManifest::update_table_named_entry::hb94bbf93581eedf3
    at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-edit-0.8.0/src/manifest.rs:406
 9: cargo_edit::manifest::LocalManifest::upgrade::h4557b69a75eb0759
    at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-edit-0.8.0/src/manifest.rs:336
10: rustsec::fixer::Fixer::fix::he754fac854116a03
    at /root/rustsec/rustsec/src/fixer.rs:37
11: <cargo_audit::commands::audit::fix::FixCommand as abscissa_core::runnable::Runnable>::run::h15c4e7c564ca6eea
    at /root/rustsec/cargo-audit/src/commands/audit/fix.rs:87
12: <cargo_audit::commands::audit::AuditCommand as abscissa_core::runnable::Runnable>::run::hf3cfc901cfd537c2
    at /root/rustsec/cargo-audit/src/commands/audit.rs:223
13: cargo_audit::commands::_DERIVE_Runnable_FOR_CargoAuditCommand::<impl abscissa_core::runnable::Runnable for cargo_audit::commands::CargoAuditCommand>::run::hf87936b155bcc448
    at /root/rustsec/cargo-audit/src/commands.rs:16
14: <abscissa_core::command::entrypoint::EntryPoint<Cmd> as abscissa_core::runnable::Runnable>::run::hf952800895f4a805
    at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/abscissa_core-0.5.2/src/command/entrypoint.rs:52
15: abscissa_core::application::Application::run::ha0e7998f6bc68012
    at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/abscissa_core-0.5.2/src/application.rs:64
16: abscissa_core::application::boot::h7a8d9caaeeb5ae9b
    at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/abscissa_core-0.5.2/src/application.rs:196
17: cargo_audit::main::hd692728e55a3698d
    at /root/rustsec/cargo-audit/src/bin/cargo-audit/main.rs:9
18: core::ops::function::FnOnce::call_once::h3b0636b407048223
    at /var/cache/acbs/build/acbs.punbruq3/rustc-1.57.0-src/library/core/src/ops/function.rs:227
19: std::sys_common::backtrace::__rust_begin_short_backtrace::h939a7c0a2f93ec25
    at /var/cache/acbs/build/acbs.punbruq3/rustc-1.57.0-src/library/std/src/sys_common/backtrace.rs:123
                         (6 runtime init frames hidden)                         
```