### PR TITLE
cargo-audit: remove unused lazy_static from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,6 @@ dependencies = [
  "abscissa_core",
  "gumdrop 0.7.0",
  "home",
- "lazy_static",
  "once_cell",
  "rustsec",
  "serde",

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -18,7 +18,6 @@ maintenance = { status = "actively-developed" }
 abscissa_core = "0.5.2"
 gumdrop = "0.7"
 home = "0.5"
-lazy_static = "1"
 rustsec = { version = "0.25", features = ["dependency-tree"], path = "../rustsec" }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"

--- a/cargo-audit/tests/acceptance.rs
+++ b/cargo-audit/tests/acceptance.rs
@@ -20,10 +20,11 @@ static ADVISORY_DB_DIR: Lazy<TempDir> = Lazy::new(|| TempDir::new().unwrap());
 
 /// Executes target binary via `cargo run`.
 ///
-/// Storing this value in a `lazy_static!` ensures that all instances of
-/// the runner acquire a mutex when executing commands and inspecting
-/// exit statuses, serializing what would otherwise be multithreaded
-/// invocations as `cargo test` executes tests in parallel by default.
+/// Storing this value in a `once_cell::sync::Lazy` ensures that all
+/// instances of the runner acquire a mutex when executing commands
+/// and inspecting exit statuses, serializing what would otherwise
+/// be multithreaded invocations as `cargo test` executes tests in
+/// parallel by default.
 pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| {
     let mut runner = CmdRunner::default();
     runner.arg("audit").arg("--db").arg(ADVISORY_DB_DIR.path());


### PR DESCRIPTION
This pull request removes unused lazy_static from dependencies in cargo-audit and updates doc comment in its tests.