### PR TITLE
tree-wide: update all the dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,22 @@ version = 3
 
 [[package]]
 name = "abscissa_core"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a07677093120a02583717b6dd1ef81d8de1e8d01bd226c83f0f9bdf3e56bb3a"
+checksum = "6750843603bf31a83accd3c8177f9dbf53a7d64275688fc7371e0a4d9f8628b5"
 dependencies = [
  "abscissa_derive",
+ "arc-swap",
  "backtrace",
  "canonical-path",
- "chrono",
- "color-backtrace",
- "generational-arena",
- "gumdrop 0.7.0",
- "libc",
+ "clap 3.1.9",
+ "color-eyre",
+ "fs-err",
  "once_cell",
  "regex",
  "secrecy",
- "semver 0.9.0",
+ "semver",
  "serde",
- "signal-hook",
  "termcolor",
  "toml",
  "tracing",
@@ -32,11 +30,10 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f5722bc48763cb9d81d8427ca05b6aa2842f6632cf8e4c0a29eef9baececcc"
+checksum = "1a3473aa652e90865a06b723102aaa4a54a7d9f2092dbf4582497a61d0537d3f"
 dependencies = [
- "darling 0.10.2",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -70,15 +67,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -93,16 +81,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
+name = "arc-swap"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "askama"
-version = "0.10.5"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d298738b6e47e1034e560e5afe63aa488fea34e25ec11b855a76f0d7b8e73134"
+checksum = "fb98f10f371286b177db5eeb9a6e5396609555686a35e1d4f7b9a9c6d8af0139"
 dependencies = [
  "askama_derive",
  "askama_escape",
@@ -111,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.10.5"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2925c4c290382f9d2fa3d1c1b6a63fa1427099721ecca4749b154cc9c25522"
+checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
 dependencies = [
  "askama_shared",
  "proc-macro2",
@@ -128,12 +116,14 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "askama_shared"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6083ccb191711e9c2b80b22ee24a8381a18524444914c746d4239e21d1afaf"
+checksum = "bf722b94118a07fcbc6640190f247334027685d4e218b794dbfe17c32bf38ed0"
 dependencies = [
  "askama_escape",
  "humansize",
+ "mime",
+ "mime_guess",
  "nom",
  "num-traits",
  "percent-encoding",
@@ -182,7 +172,7 @@ checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide 0.4.4",
  "object",
@@ -209,18 +199,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "block-buffer"
@@ -296,7 +274,7 @@ name = "cargo-audit"
 version = "0.16.0"
 dependencies = [
  "abscissa_core",
- "gumdrop 0.7.0",
+ "clap 3.1.9",
  "home",
  "once_cell",
  "rustsec",
@@ -315,7 +293,7 @@ checksum = "97854a7bc0b53485f1e9554478de1edff143efc29a18f1ad77f1cbf200b301e8"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "clap 3.1.8",
+ "clap 3.1.9",
  "concolor-control",
  "crates-index",
  "dirs-next",
@@ -327,7 +305,7 @@ dependencies = [
  "native-tls",
  "pathdiff",
  "regex",
- "semver 1.0.7",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -342,9 +320,9 @@ dependencies = [
 name = "cargo-lock"
 version = "7.0.1"
 dependencies = [
- "gumdrop 0.8.1",
+ "gumdrop",
  "petgraph",
- "semver 1.0.7",
+ "semver",
  "serde",
  "toml",
  "url",
@@ -367,7 +345,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.7",
+ "semver",
  "serde",
  "serde_json",
 ]
@@ -380,12 +358,6 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -419,7 +391,7 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -430,16 +402,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "6aad2534fad53df1cc12519c5cda696dd3e20e6118a027e24054aea14a0bdcbe"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
  "terminal_size",
@@ -460,14 +432,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "color-backtrace"
-version = "0.3.0"
+name = "clap_lex"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d13f1078cc63c791d0deba0dd43db37c9ec02b311f10bed10b577016f3a957"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
 dependencies = [
- "atty",
+ "os_str_bytes",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebf286c900a6d5867aeff75cfee3192857bb7f24b547d4f0df2ed6baa812c90"
+dependencies = [
  "backtrace",
- "termcolor",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
 ]
 
 [[package]]
@@ -555,7 +538,7 @@ dependencies = [
  "num_cpus",
  "rayon",
  "rustc-hash",
- "semver 1.0.7",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -568,7 +551,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -577,7 +560,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -587,7 +570,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -599,7 +582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -612,7 +595,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -625,36 +608,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
-dependencies = [
- "darling_core 0.10.2",
- "darling_macro 0.10.2",
-]
-
-[[package]]
-name = "darling"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
 dependencies = [
- "darling_core 0.12.4",
- "darling_macro 0.12.4",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.9.3",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -673,22 +632,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
-dependencies = [
- "darling_core 0.10.2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
- "darling_core 0.12.4",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -708,7 +656,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
 dependencies = [
- "darling 0.12.4",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -766,7 +714,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -810,7 +758,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -827,6 +775,16 @@ checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
 dependencies = [
  "log",
  "url",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -856,7 +814,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide 0.5.1",
@@ -900,21 +858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd79fa345a495d3ae89fb7165fec01c0e72f41821d642dda363a1e97975652e"
 
 [[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "generational-arena"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
-dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,7 +882,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -967,31 +910,11 @@ dependencies = [
 
 [[package]]
 name = "gumdrop"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee50908bc1beeac1f2902e0b4e0cd0d844e716f5ebdc6f0cfc1163fe5e10bcde"
-dependencies = [
- "gumdrop_derive 0.7.0",
-]
-
-[[package]]
-name = "gumdrop"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bc700f989d2f6f0248546222d9b4258f5b02a171a431f8285a81c08142629e3"
 dependencies = [
- "gumdrop_derive 0.8.1",
-]
-
-[[package]]
-name = "gumdrop_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "gumdrop_derive",
 ]
 
 [[package]]
@@ -1084,6 +1007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,7 +1028,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1155,19 +1084,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -1236,7 +1152,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1254,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -1266,12 +1182,6 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -1287,6 +1197,28 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1333,15 +1265,12 @@ checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1438,7 +1367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1479,18 +1408,12 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
-name = "owning_ref"
-version = "0.4.1"
+name = "owo-colors"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
+checksum = "5e72e30578e0d0993c8ae20823dd9cff2bc5517d2f586a8aef462a581e8a03eb"
 
 [[package]]
 name = "pathdiff"
@@ -1641,12 +1564,6 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rayon"
@@ -1815,7 +1732,7 @@ dependencies = [
  "humantime-serde",
  "once_cell",
  "platforms",
- "semver 1.0.7",
+ "semver",
  "serde",
  "tempfile",
  "thiserror",
@@ -1831,9 +1748,9 @@ dependencies = [
  "askama",
  "atom_syndication",
  "chrono",
+ "clap 3.1.9",
  "comrak",
  "crates-index",
- "gumdrop 0.7.0",
  "once_cell",
  "rust-embed",
  "rustsec",
@@ -1894,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
@@ -1927,28 +1844,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2000,10 +1901,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2013,32 +1923,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
-name = "signal-hook"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "smallvec"
-version = "0.6.14"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "smartstring"
@@ -2070,12 +1958,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,12 +1968,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"
@@ -2155,18 +2031,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -2232,6 +2102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,9 +2148,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
@@ -2291,11 +2170,11 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2314,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfce9f3241b150f36e8e54bb561a742d5daa1a47b5dd9a5ce369fd4a4db2210"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -2335,17 +2214,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.1.6"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192ca16595cdd0661ce319e8eede9c975f227cdaabc4faaefdc256f43d852e45"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
- "ansi_term 0.11.0",
- "chrono",
+ "ansi_term",
  "lazy_static",
  "matchers",
- "owning_ref",
  "regex",
+ "sharded-slab",
  "smallvec",
+ "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2383,6 +2263,15 @@ name = "unchecked-index"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -2512,7 +2401,7 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -2619,12 +2508,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xdg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-resolver = "2"
 members = [
     "admin",
     "cargo-audit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "admin",
     "cargo-audit",

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -10,9 +10,9 @@ readme      = "README.md"
 edition     = "2018"
 
 [dependencies]
-abscissa_core = "0.5"
-crates-index = "0.18.7"
-gumdrop = "0.7"
+abscissa_core = "0.6"
+crates-index = "0.18"
+clap = "3"
 rustsec = { version = "0.25", path = "../rustsec", features = ["osv-export"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
@@ -20,12 +20,12 @@ termcolor = "1"
 thiserror = "1"
 toml = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-askama = "0.10"
+askama = "0.11"
 rust-embed="6.4"
 comrak = "0.12"
 atom_syndication = "0.11"
 xml-rs = "0.8"
 
 [dev-dependencies]
-abscissa_core = { version = "0.5", features = ["testing"] }
+abscissa_core = { version = "0.6", features = ["testing"] }
 once_cell = "1.5"

--- a/admin/src/commands.rs
+++ b/admin/src/commands.rs
@@ -12,39 +12,54 @@ use self::{
     osv::OsvCmd, version::VersionCmd, web::WebCmd,
 };
 use crate::config::AppConfig;
-use abscissa_core::{Command, Configurable, Help, Options, Runnable};
+use abscissa_core::{Command, Configurable, Runnable};
+use clap::Parser;
 use std::path::PathBuf;
 
 /// `rustsec-admin` CLI subcommands
-#[derive(Command, Debug, Options, Runnable)]
-pub enum AdminCmd {
+#[derive(Command, Debug, Parser, Runnable)]
+pub enum AdminSubCmd {
     /// The `lint` subcommand
-    #[options(help = "lint Advisory DB and ensure is well-formed")]
+    #[clap(about = "lint Advisory DB and ensure is well-formed")]
     Lint(LintCmd),
 
     /// The `web` subcommand
-    #[options(help = "render advisory Markdown files for the rustsec.org web site")]
+    #[clap(about = "render advisory Markdown files for the rustsec.org web site")]
     Web(WebCmd),
 
-    /// The `help` subcommand
-    #[options(help = "get usage information")]
-    Help(Help<Self>),
-
     /// The `version` subcommand
-    #[options(help = "display version information")]
+    #[clap(about = "display version information")]
     Version(VersionCmd),
 
     /// The `assign-id` subcommand
-    #[options(help = "assigning RUSTSEC ids to new vulnerabilities")]
+    #[clap(about = "assigning RUSTSEC ids to new vulnerabilities")]
     AssignId(AssignIdCmd),
 
     /// The `osv` subcommand
-    #[options(help = "export advisories to OSV format")]
+    #[clap(about = "export advisories to OSV format")]
     Osv(OsvCmd),
 
     /// The `version` subcommand
-    #[options(help = "list affected crate versions")]
+    #[clap(about = "list affected crate versions")]
     ListAffectedVersions(ListAffectedVersionsCmd),
+}
+
+/// `rustsec-admin` CLI commands
+#[derive(Command, Debug, Parser)]
+#[clap(author, version, about)]
+pub struct AdminCmd {
+    #[clap(subcommand)]
+    cmd: AdminSubCmd,
+
+    /// Increase verbosity setting
+    #[clap(short = 'v', long, help = "Increase verbosity")]
+    pub verbose: bool,
+}
+
+impl Runnable for AdminCmd {
+    fn run(&self) {
+        self.cmd.run()
+    }
 }
 
 impl Configurable<AppConfig> for AdminCmd {

--- a/admin/src/commands/assign_id.rs
+++ b/admin/src/commands/assign_id.rs
@@ -3,16 +3,19 @@
 //! Assigns RUSTSEC ids to new vulnerabilities
 
 use abscissa_core::{Command, Runnable};
-use gumdrop::Options;
+use clap::Parser;
 use std::path::{Path, PathBuf};
 
 /// `rustsec-admin assign-id` subcommand
-#[derive(Command, Debug, Default, Options)]
+#[derive(Command, Debug, Default, Parser)]
 pub struct AssignIdCmd {
-    #[options(long = "github-actions-output")]
+    #[clap(long = "github-actions-output")]
     github_action_output: bool,
     /// Path to the advisory database
-    #[options(free, help = "filesystem path to the RustSec advisory DB git repo")]
+    #[clap(
+        min_values = 1,
+        help = "filesystem path to the RustSec advisory DB git repo"
+    )]
     path: Vec<PathBuf>,
 }
 
@@ -21,7 +24,7 @@ impl Runnable for AssignIdCmd {
         let repo_path = match self.path.len() {
             0 => Path::new("."),
             1 => self.path[0].as_path(),
-            _ => Self::print_usage_and_exit(&[]),
+            _ => unreachable!(),
         };
         let output_mode = if self.github_action_output {
             crate::assigner::OutputMode::GithubAction

--- a/admin/src/commands/lint.rs
+++ b/admin/src/commands/lint.rs
@@ -2,17 +2,20 @@
 
 use crate::{linter::Linter, prelude::*};
 use abscissa_core::{Command, Runnable};
-use gumdrop::Options;
+use clap::Parser;
 use std::{
     path::{Path, PathBuf},
     process::exit,
 };
 
 /// `rustsec-admin lint` subcommand
-#[derive(Command, Debug, Default, Options)]
+#[derive(Command, Debug, Default, Parser)]
 pub struct LintCmd {
     /// Path to the advisory database
-    #[options(free, help = "filesystem path to the RustSec advisory DB git repo")]
+    #[clap(
+        min_values = 1,
+        help = "filesystem path to the RustSec advisory DB git repo"
+    )]
     path: Vec<PathBuf>,
 }
 
@@ -21,7 +24,7 @@ impl Runnable for LintCmd {
         let repo_path = match self.path.len() {
             0 => Path::new("."),
             1 => self.path[0].as_path(),
-            _ => Self::print_usage_and_exit(&[]),
+            _ => unreachable!(),
         };
 
         let linter = Linter::new(&repo_path).unwrap_or_else(|e| {

--- a/admin/src/commands/list_affected_versions.rs
+++ b/admin/src/commands/list_affected_versions.rs
@@ -11,16 +11,20 @@ use std::{
     process::exit,
 };
 
-use abscissa_core::{Command, Options, Runnable};
+use abscissa_core::{Command, Runnable};
+use clap::Parser;
 
 use crate::list_versions::AffectedVersionLister;
 use crate::prelude::*;
 
 /// `rustsec-admin list-affected-versions` subcommand
-#[derive(Command, Debug, Default, Options)]
+#[derive(Command, Debug, Default, Parser)]
 pub struct ListAffectedVersionsCmd {
     /// Path to the advisory database
-    #[options(free, help = "filesystem path to the RustSec advisory DB git repo")]
+    #[clap(
+        min_values = 1,
+        help = "filesystem path to the RustSec advisory DB git repo"
+    )]
     path: Vec<PathBuf>,
 }
 
@@ -29,7 +33,7 @@ impl Runnable for ListAffectedVersionsCmd {
         let repo_path = match self.path.len() {
             0 => Path::new("."),
             1 => self.path[0].as_path(),
-            _ => Self::print_usage_and_exit(&[]),
+            _ => unreachable!(),
         };
 
         let lister = AffectedVersionLister::new(&repo_path).unwrap_or_else(|e| {

--- a/admin/src/commands/osv.rs
+++ b/admin/src/commands/osv.rs
@@ -8,21 +8,22 @@ use std::{
     process::exit,
 };
 
-use abscissa_core::{status_err, Command, Options, Runnable};
+use abscissa_core::{status_err, Command, Runnable};
+use clap::Parser;
 
 use crate::osv_export::OsvExporter;
 
-#[derive(Command, Debug, Default, Options)]
+#[derive(Command, Debug, Default, Parser)]
 pub struct OsvCmd {
     /// Path to the advisory database
-    #[options(
+    #[clap(
         long = "db",
         help = "filesystem path to the RustSec advisory DB git repo"
     )]
     repo_path: Option<PathBuf>,
     /// Path to the output directory
-    #[options(
-        free,
+    #[clap(
+        min_values = 1,
         help = "filesystem directory where OSV JSON files will be written"
     )]
     path: Vec<PathBuf>,
@@ -33,7 +34,7 @@ impl Runnable for OsvCmd {
         let out_path = match self.path.len() {
             0 => Path::new("."),
             1 => self.path[0].as_path(),
-            _ => Self::print_usage_and_exit(&[]),
+            _ => unreachable!(),
         };
 
         let repo_path: Option<&Path> = self.repo_path.as_deref();

--- a/admin/src/commands/version.rs
+++ b/admin/src/commands/version.rs
@@ -2,16 +2,17 @@
 
 #![allow(clippy::never_loop)]
 
-use super::AdminCmd;
-use abscissa_core::{Command, Options, Runnable};
+use abscissa_core::{Command, Runnable};
+use clap::Parser;
 
 /// `rustsec-admin version` subcommand
-#[derive(Command, Debug, Default, Options)]
+#[derive(Command, Debug, Default, Parser)]
+#[clap(author, version, about)]
 pub struct VersionCmd {}
 
 impl Runnable for VersionCmd {
     /// Print version message
     fn run(&self) {
-        println!("rustsec-admin {}", AdminCmd::version());
+        println!("rustsec-admin {}", env!("CARGO_PKG_VERSION"));
     }
 }

--- a/admin/src/commands/web.rs
+++ b/admin/src/commands/web.rs
@@ -5,13 +5,13 @@
 use std::path::PathBuf;
 
 use abscissa_core::{Command, Runnable};
-use gumdrop::Options;
+use clap::Parser;
 
 /// `rustsec-admin web` subcommand
-#[derive(Command, Debug, Default, Options)]
+#[derive(Command, Debug, Default, Parser)]
 pub struct WebCmd {
-    #[options(
-        free,
+    #[clap(
+        min_values = 1,
         help = "path to output the generated website (defaults to _site/)"
     )]
     path: Vec<PathBuf>,
@@ -22,7 +22,7 @@ impl Runnable for WebCmd {
         let output_folder = match self.path.len() {
             0 => PathBuf::from("_site/"),
             1 => self.path[0].clone(),
-            _ => Self::print_usage_and_exit(&[]),
+            _ => unreachable!(),
         };
         crate::web::render_advisories(output_folder);
     }

--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -476,7 +476,7 @@ mod filters {
     use chrono::NaiveDate;
     use std::convert::TryInto;
 
-    pub fn friendly_date(date: &&rustsec::advisory::Date) -> ::askama::Result<String> {
+    pub fn friendly_date(date: &rustsec::advisory::Date) -> ::askama::Result<String> {
         Ok(
             NaiveDate::from_ymd(date.year().try_into().unwrap(), date.month(), date.day())
                 .format("%B %e, %Y")

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -15,8 +15,8 @@ edition     = "2018"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-abscissa_core = "0.5.2"
-gumdrop = "0.7"
+abscissa_core = "0.6"
+clap = "3"
 home = "0.5"
 rustsec = { version = "0.25", features = ["dependency-tree"], path = "../rustsec" }
 serde = { version = "1", features = ["serde_derive"] }
@@ -29,7 +29,7 @@ tempfile = "3"
 toml = "0.5"
 
 [dev-dependencies.abscissa_core]
-version = "0.5"
+version = "0.6"
 features = ["testing"]
 
 [features]

--- a/cargo-audit/src/application.rs
+++ b/cargo-audit/src/application.rs
@@ -2,12 +2,15 @@
 //!
 //! <https://docs.rs/abscissa_core>
 
+use std::ops::Deref;
+use std::sync::Arc;
+
 use crate::{commands::CargoAuditCommand, config::AuditConfig};
 use abscissa_core::{
     application::{self, AppCell},
-    config,
+    config::{self, CfgCell},
     terminal::ColorChoice,
-    trace, Application, EntryPoint, FrameworkError, StandardPaths,
+    trace, Application, FrameworkError, StandardPaths,
 };
 
 /// Application state
@@ -16,27 +19,27 @@ pub static APPLICATION: AppCell<CargoAuditApplication> = AppCell::new();
 /// Obtain a read-only (multi-reader) lock on the application state.
 ///
 /// Panics if the application state has not been initialized.
-pub fn app_reader() -> application::lock::Reader<CargoAuditApplication> {
-    APPLICATION.read()
+pub fn app_reader() -> &'static CargoAuditApplication {
+    APPLICATION.deref()
 }
 
 /// Obtain an exclusive mutable lock on the application state.
-pub fn app_writer() -> application::lock::Writer<CargoAuditApplication> {
-    APPLICATION.write()
+pub fn app_writer() -> &'static CargoAuditApplication {
+    APPLICATION.deref()
 }
 
 /// Obtain a read-only (multi-reader) lock on the application configuration.
 ///
 /// Panics if the application configuration has not been loaded.
-pub fn app_config() -> config::Reader<CargoAuditApplication> {
-    config::Reader::new(&APPLICATION)
+pub fn app_config() -> config::Reader<AuditConfig> {
+    APPLICATION.config.read()
 }
 
 /// `cargo audit` application
 #[derive(Debug)]
 pub struct CargoAuditApplication {
     /// Application configuration.
-    config: Option<AuditConfig>,
+    config: CfgCell<AuditConfig>,
 
     /// Application state.
     state: application::State<Self>,
@@ -49,7 +52,7 @@ pub struct CargoAuditApplication {
 impl Default for CargoAuditApplication {
     fn default() -> Self {
         Self {
-            config: None,
+            config: CfgCell::default(),
             state: application::State::default(),
         }
     }
@@ -57,7 +60,7 @@ impl Default for CargoAuditApplication {
 
 impl Application for CargoAuditApplication {
     /// Entrypoint command for this application.
-    type Cmd = EntryPoint<CargoAuditCommand>;
+    type Cmd = CargoAuditCommand;
 
     /// Application configuration.
     type Cfg = AuditConfig;
@@ -66,8 +69,8 @@ impl Application for CargoAuditApplication {
     type Paths = StandardPaths;
 
     /// Accessor for application configuration.
-    fn config(&self) -> &AuditConfig {
-        self.config.as_ref().expect("config not loaded")
+    fn config(&self) -> Arc<AuditConfig> {
+        self.config.read()
     }
 
     /// Borrow the application state immutably.
@@ -75,36 +78,27 @@ impl Application for CargoAuditApplication {
         &self.state
     }
 
-    /// Borrow the application state mutably.
-    fn state_mut(&mut self) -> &mut application::State<Self> {
-        &mut self.state
-    }
-
     /// Register all components used by this application.
     fn register_components(&mut self, command: &Self::Cmd) -> Result<(), FrameworkError> {
         let components = self.framework_components(command)?;
-        self.state.components.register(components)
+        self.state.components_mut().register(components)
     }
 
     /// Post-configuration lifecycle callback.
     fn after_config(&mut self, config: Self::Cfg) -> Result<(), FrameworkError> {
         // Configure components
-        self.state.components.after_config(&config)?;
-        self.config = Some(config);
+        self.state.components_mut().after_config(&config)?;
+        self.config.set_once(config);
         Ok(())
     }
 
     /// Color configuration for this application.
-    fn term_colors(&self, entrypoint: &EntryPoint<CargoAuditCommand>) -> ColorChoice {
-        entrypoint
-            .command
-            .as_ref()
-            .and_then(|cmd| cmd.color_config())
-            .unwrap_or(ColorChoice::Auto)
+    fn term_colors(&self, entrypoint: &CargoAuditCommand) -> ColorChoice {
+        entrypoint.color_config().unwrap_or(ColorChoice::Auto)
     }
 
     /// Get tracing configuration from command-line options
-    fn tracing_config(&self, command: &EntryPoint<CargoAuditCommand>) -> trace::Config {
+    fn tracing_config(&self, command: &CargoAuditCommand) -> trace::Config {
         if command.verbose {
             trace::Config::verbose()
         } else {

--- a/cargo-audit/src/commands.rs
+++ b/cargo-audit/src/commands.rs
@@ -77,7 +77,7 @@ impl Deref for CargoAuditCommand {
 
     fn deref(&self) -> &AuditCommand {
         match &self.cmd {
-            CargoAuditSubCommand::Audit(cmd) => &cmd,
+            CargoAuditSubCommand::Audit(cmd) => cmd,
         }
     }
 }

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -2,25 +2,22 @@
 
 use crate::{auditor::Auditor, lockfile, prelude::*};
 use abscissa_core::{Command, Runnable};
-use gumdrop::Options;
+use clap::Parser;
 use rustsec::Fixer;
 use std::{
     path::{Path, PathBuf},
     process::exit,
 };
 
-#[derive(Command, Default, Debug, Options)]
+#[derive(Command, Default, Debug, Parser)]
+#[clap(author, version, about)]
 pub struct FixCommand {
-    /// Get help information
-    #[options(short = "h", long = "help", help = "output help information and exit")]
-    help: bool,
-
     /// Path to `Cargo.lock`
-    #[options(short = "f", long = "file", help = "Cargo lockfile to inspect")]
+    #[clap(short = 'f', long = "file", help = "Cargo lockfile to inspect")]
     file: Option<PathBuf>,
 
     /// Perform a dry run
-    #[options(no_short, long = "dry-run", help = "perform a dry run for the fix")]
+    #[clap(long = "dry-run", help = "perform a dry run for the fix")]
     dry_run: bool,
 }
 
@@ -45,10 +42,6 @@ impl FixCommand {
 
 impl Runnable for FixCommand {
     fn run(&self) {
-        if self.help {
-            Self::print_usage_and_exit(&[]);
-        }
-
         let report = self.auditor().audit(self.cargo_lock_path());
 
         let report = match report {

--- a/platforms/src/error.rs
+++ b/platforms/src/error.rs
@@ -2,6 +2,9 @@
 
 use core::fmt::{self, Display};
 
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
+
 /// Error type
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Error;
@@ -11,3 +14,6 @@ impl Display for Error {
         f.write_str("platforms::Error")
     }
 }
+
+#[cfg(feature = "std")]
+impl StdError for Error {}

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -248,7 +248,7 @@ impl Linter {
                             // Rust identifiers do not allow '-' character but crate names do,
                             // thus "crate-name" would be addressed as "crate_name" in function path
                             let crate_name =
-                                self.advisory.metadata.package.as_str().replace("-", "_");
+                                self.advisory.metadata.package.as_str().replace('-', "_");
                             if function.segments()[0].as_str() != crate_name {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("functions", function.to_string()),


### PR DESCRIPTION
This is a relatively large pull request that upgrades all the dependencies to their latest version. Due to breaking changes in the `abscissa_core` crate, a lot of framework-related changes are made.

The changes could be summarized as follows:

### Changes related to `abscissa_core`

- Use `clap` instead of `gumdrop`. `abscissa_core` no longer bundles a command-line parser, and the upstream project recommends `clap` 3.x for this task.
- As a result of the last change, the command-line parser has been rewritten. To make `clap` happy, a new parsing error was added in `platforms/src/error.rs`
- The base framework has been adapted to the new structure in `abscissa_core`.

### Changes related to `askama`

- Fixed some reference passing issues in `admin/src/web.rs`.
