### PR TITLE
platforms: use owned `String` for serde deserializers

### DIFF
--- a/platforms/platforms-data-gen/templates/arch_footer.rs
+++ b/platforms/platforms-data-gen/templates/arch_footer.rs
@@ -12,14 +12,10 @@ impl Serialize for Arch {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for Arch {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_arch", string)))?)
-        } else {
-            Ok(string.parse().map_err(|_| D::Error::custom("Unrecognized value for target_arch"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_arch", string)))
     }
 }

--- a/platforms/platforms-data-gen/templates/bits_footer.rs
+++ b/platforms/platforms-data-gen/templates/bits_footer.rs
@@ -37,14 +37,10 @@ impl Serialize for PointerWidth {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for PointerWidth {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_pointer_width", string)))?)
-        } else {
-            Ok(string.parse().map_err(|_| D::Error::custom("Unrecognized value for target_pointer_width"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_pointer_width", string)))
     }
 }

--- a/platforms/platforms-data-gen/templates/endian_footer.rs
+++ b/platforms/platforms-data-gen/templates/endian_footer.rs
@@ -12,14 +12,10 @@ impl Serialize for Endian {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for Endian {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_endian", string)))?)
-        } else {
-            Ok(string.parse().map_err(|_| D::Error::custom("Unrecognized value for target_endian"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_endian", string)))
     }
 }

--- a/platforms/platforms-data-gen/templates/env_footer.rs
+++ b/platforms/platforms-data-gen/templates/env_footer.rs
@@ -12,14 +12,10 @@ impl Serialize for Env {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for Env {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_env", string)))?)
-        } else {
-            Ok(string.parse().map_err(|_| D::Error::custom("Unrecognized value for target_env"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_env", string)))
     }
 }

--- a/platforms/platforms-data-gen/templates/os_footer.rs
+++ b/platforms/platforms-data-gen/templates/os_footer.rs
@@ -12,14 +12,10 @@ impl Serialize for OS {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for OS {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_os", string)))?)
-        } else {
-            Ok(string.parse().map_err(|_| D::Error::custom("Unrecognized value for target_os"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| D::Error::custom(std::format!("Unrecognized value '{}' for target_os", string)))
     }
 }

--- a/platforms/src/platform/tier.rs
+++ b/platforms/src/platform/tier.rs
@@ -105,11 +105,11 @@ impl Serialize for Tier {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for Tier {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
-        <&str>::deserialize(deserializer)?
+        std::string::String::deserialize(deserializer)?
             .parse()
             .map_err(D::Error::custom)
     }

--- a/platforms/src/target/arch.rs
+++ b/platforms/src/target/arch.rs
@@ -150,21 +150,15 @@ impl Serialize for Arch {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for Arch {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| {
-                D::Error::custom(std::format!(
-                    "Unrecognized value '{}' for target_arch",
-                    string
-                ))
-            })?)
-        } else {
-            Ok(string
-                .parse()
-                .map_err(|_| D::Error::custom("Unrecognized value for target_arch"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| {
+            D::Error::custom(std::format!(
+                "Unrecognized value '{}' for target_arch",
+                string
+            ))
+        })
     }
 }

--- a/platforms/src/target/endian.rs
+++ b/platforms/src/target/endian.rs
@@ -55,21 +55,15 @@ impl Serialize for Endian {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for Endian {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| {
-                D::Error::custom(std::format!(
-                    "Unrecognized value '{}' for target_endian",
-                    string
-                ))
-            })?)
-        } else {
-            Ok(string
-                .parse()
-                .map_err(|_| D::Error::custom("Unrecognized value for target_endian"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| {
+            D::Error::custom(std::format!(
+                "Unrecognized value '{}' for target_endian",
+                string
+            ))
+        })
     }
 }

--- a/platforms/src/target/env.rs
+++ b/platforms/src/target/env.rs
@@ -98,21 +98,15 @@ impl Serialize for Env {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for Env {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| {
-                D::Error::custom(std::format!(
-                    "Unrecognized value '{}' for target_env",
-                    string
-                ))
-            })?)
-        } else {
-            Ok(string
-                .parse()
-                .map_err(|_| D::Error::custom("Unrecognized value for target_env"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| {
+            D::Error::custom(std::format!(
+                "Unrecognized value '{}' for target_env",
+                string
+            ))
+        })
     }
 }

--- a/platforms/src/target/os.rs
+++ b/platforms/src/target/os.rs
@@ -187,21 +187,15 @@ impl Serialize for OS {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for OS {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| {
-                D::Error::custom(std::format!(
-                    "Unrecognized value '{}' for target_os",
-                    string
-                ))
-            })?)
-        } else {
-            Ok(string
-                .parse()
-                .map_err(|_| D::Error::custom("Unrecognized value for target_os"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| {
+            D::Error::custom(std::format!(
+                "Unrecognized value '{}' for target_os",
+                string
+            ))
+        })
     }
 }

--- a/platforms/src/target/pointerwidth.rs
+++ b/platforms/src/target/pointerwidth.rs
@@ -86,21 +86,15 @@ impl Serialize for PointerWidth {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature = "std"))]
 impl<'de> Deserialize<'de> for PointerWidth {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let string = <&str>::deserialize(deserializer)?;
-        if cfg!(feature = "std") {
-            Ok(string.parse().map_err(|_| {
-                D::Error::custom(std::format!(
-                    "Unrecognized value '{}' for target_pointer_width",
-                    string
-                ))
-            })?)
-        } else {
-            Ok(string
-                .parse()
-                .map_err(|_| D::Error::custom("Unrecognized value for target_pointer_width"))?)
-        }
+        let string = std::string::String::deserialize(deserializer)?;
+        string.parse().map_err(|_| {
+            D::Error::custom(std::format!(
+                "Unrecognized value '{}' for target_pointer_width",
+                string
+            ))
+        })
     }
 }


### PR DESCRIPTION
Closes #493 and #492

Deserializes into an owned `String` type, which allows deserialization in cases where a `&str` can't be borrowed.