### PR TITLE
cargo-audit: Abscissa v0.6 cleanups

### DIFF
--- a/cargo-audit/src/application.rs
+++ b/cargo-audit/src/application.rs
@@ -2,38 +2,18 @@
 //!
 //! <https://docs.rs/abscissa_core>
 
-use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::{commands::CargoAuditCommand, config::AuditConfig};
 use abscissa_core::{
     application::{self, AppCell},
-    config::{self, CfgCell},
+    config::CfgCell,
     terminal::ColorChoice,
     trace, Application, FrameworkError, StandardPaths,
 };
 
 /// Application state
-pub static APPLICATION: AppCell<CargoAuditApplication> = AppCell::new();
-
-/// Obtain a read-only (multi-reader) lock on the application state.
-///
-/// Panics if the application state has not been initialized.
-pub fn app_reader() -> &'static CargoAuditApplication {
-    APPLICATION.deref()
-}
-
-/// Obtain an exclusive mutable lock on the application state.
-pub fn app_writer() -> &'static CargoAuditApplication {
-    APPLICATION.deref()
-}
-
-/// Obtain a read-only (multi-reader) lock on the application configuration.
-///
-/// Panics if the application configuration has not been loaded.
-pub fn app_config() -> config::Reader<AuditConfig> {
-    APPLICATION.config.read()
-}
+pub static APP: AppCell<CargoAuditApplication> = AppCell::new();
 
 /// `cargo audit` application
 #[derive(Debug)]

--- a/cargo-audit/src/bin/cargo-audit/main.rs
+++ b/cargo-audit/src/bin/cargo-audit/main.rs
@@ -3,8 +3,8 @@
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
 
-use cargo_audit::application::APPLICATION;
+use cargo_audit::application::APP;
 
 fn main() {
-    abscissa_core::boot(&APPLICATION);
+    abscissa_core::boot(&APP);
 }

--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -244,7 +244,6 @@ impl Runnable for AuditCommand {
 impl AuditCommand {
     /// Initialize `Auditor`
     pub fn auditor(&self) -> Auditor {
-        let config = app_config();
-        Auditor::new(config.as_ref())
+        Auditor::new(&APP.config())
     }
 }

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -24,8 +24,7 @@ pub struct FixCommand {
 impl FixCommand {
     /// Initialize `Auditor`
     pub fn auditor(&self) -> Auditor {
-        let config = app_config();
-        Auditor::new(&config)
+        Auditor::new(&APP.config())
     }
 
     /// Locate `Cargo.toml`

--- a/cargo-audit/src/prelude.rs
+++ b/cargo-audit/src/prelude.rs
@@ -4,5 +4,5 @@
 /// Abscissa core prelude
 pub use abscissa_core::prelude::*;
 
-/// Application state accessors
-pub use crate::application::{app_config, app_reader, app_writer};
+/// Application state
+pub use crate::application::APP;


### PR DESCRIPTION
Removes legacy accessor functions and accesses application state through the `APP` constant exclusively, which matches the upstream Abscissa application boilerplate.