### PR TITLE
cargo-lock v7.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "7.0.1"
+version = "7.1.0"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 7.1.0 (2022-04-23)
+### Added
+- `SourceId::default()` ([#536])
+
+### Changed
+- MSRV is now 1.49 ([#524])
+
+### Fixed
+- V3 lockfile handling and tests ([#535])
+
+[#524]: https://github.com/RustSec/rustsec/pull/524
+[#535]: https://github.com/RustSec/rustsec/pull/535
+[#536]: https://github.com/RustSec/rustsec/pull/536
+
 ## 7.0.1 (2021-07-05)
 ### Changed
 - Bump `petgraph` dependency from 0.5.1 to 0.6.0 ([#396])

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-lock"
 description = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version = "7.0.1"
+version = "7.1.0"
 authors = ["Tony Arcieri <bascule@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/cargo-lock/LICENSE-MIT
+++ b/cargo-lock/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2021 The RustSec Project Developers
+Copyright (c) 2019-2022 The RustSec Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/cargo-lock/src/lib.rs
+++ b/cargo-lock/src/lib.rs
@@ -168,10 +168,7 @@
 //! [`cargo-tree`]: https://github.com/sfackler/cargo-tree
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-lock/7.0.1"
-)]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Added
- `SourceId::default()` ([#536])

### Changed
- MSRV is now 1.49 ([#524])

### Fixed
- V3 lockfile handling and tests ([#535])

[#524]: https://github.com/RustSec/rustsec/pull/524
[#535]: https://github.com/RustSec/rustsec/pull/535
[#536]: https://github.com/RustSec/rustsec/pull/536