### PR TITLE
rustsec: update to 2021 edition

### DIFF
--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
-name        = "rustsec"
-description = "Client library for the RustSec security advisory database"
-version     = "0.25.2" # Also update html_root_url in lib.rs when bumping this
-authors     = ["Tony Arcieri <bascule@gmail.com>"]
-license     = "Apache-2.0 OR MIT"
-homepage    = "https://rustsec.org"
-repository  = "https://github.com/RustSec/rustsec/tree/main/rustsec"
-readme      = "README.md"
-categories  = ["api-bindings", "development-tools"]
-keywords    = ["audit", "rustsec", "security", "advisory", "vulnerability"]
-edition     = "2018"
+name         = "rustsec"
+description  = "Client library for the RustSec security advisory database"
+version      = "0.25.2" # Also update html_root_url in lib.rs when bumping this
+authors      = ["Tony Arcieri <bascule@gmail.com>"]
+license      = "Apache-2.0 OR MIT"
+homepage     = "https://rustsec.org"
+repository   = "https://github.com/RustSec/rustsec/tree/main/rustsec"
+readme       = "README.md"
+categories   = ["api-bindings", "development-tools"]
+keywords     = ["audit", "rustsec", "security", "advisory", "vulnerability"]
+edition      = "2021"
+rust-version = "1.57"
 
 [dependencies]
 cargo-lock = { version = "7", default-features = false, path = "../cargo-lock" }

--- a/rustsec/README.md
+++ b/rustsec/README.md
@@ -33,8 +33,8 @@ done with a minor version bump.
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE] or https://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT] or https://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <https://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT] or <https://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/rustsec/src/advisory/versions.rs
+++ b/rustsec/src/advisory/versions.rs
@@ -1,11 +1,8 @@
 //! The `[versions]` subsection of an advisory.
 
-use std::convert::{TryFrom, TryInto};
-
+use crate::{osv, Error};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
-
-use crate::{osv, Error};
 
 /// The `[versions]` subsection of an advisory: future home to information
 /// about which versions are patched and/or unaffected.

--- a/rustsec/src/collection.rs
+++ b/rustsec/src/collection.rs
@@ -6,7 +6,7 @@ use std::{fmt, str::FromStr};
 
 /// Collections of packages (`crates` vs `rust`).
 ///
-/// Advisories are either filed against crates published to https://crates.io
+/// Advisories are either filed against crates published to <https://crates.io>
 /// or packages provided by the Rust language itself (e.g. `std`, `rustdoc`)
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum Collection {

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -1,13 +1,5 @@
-//! `rustsec`: client library for the RustSec Security Advisory Database
-//!
-//! This crate is primarily intended for use with the cargo-audit tool:
-//!
-//! <https://crates.io/crates/cargo-audit>
-
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/rustsec/0.25.2"
-)]
+#![doc = include_str!("../README.md")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 

--- a/rustsec/src/osv.rs
+++ b/rustsec/src/osv.rs
@@ -1,10 +1,11 @@
 //! Provides support for exporting to the interchange format defined by
-//! https://github.com/google/osv
+//! <https://github.com/google/osv>
 //!
 //! We also use OSV-style ranges for version matching in RustSec crate
 //! because it allows handling pre-releases correctly,
 //! which `semver` crate does not allow doing directly.
-//! See https://github.com/dtolnay/semver/issues/172
+//!
+//! See <https://github.com/dtolnay/semver/issues/172>
 
 #[cfg(feature = "osv-export")]
 mod osv_advisory;

--- a/rustsec/src/osv/osv_advisory.rs
+++ b/rustsec/src/osv/osv_advisory.rs
@@ -1,19 +1,18 @@
-use std::{convert::TryInto, ops::Add};
-
-use serde::Serialize;
-use url::Url;
+//! OSV advisories.
 
 use super::ranges_for_advisory;
-
 use crate::{
     advisory::{affected::FunctionPath, Affected, Category, Id, Informational},
     repository::git::{GitModificationTimes, GitPath},
     Advisory,
 };
+use serde::Serialize;
+use std::ops::Add;
+use url::Url;
 
 const ECOSYSTEM: &str = "crates.io";
 
-/// Security advisory in the format defined by https://github.com/google/osv
+/// Security advisory in the format defined by <https://github.com/google/osv>
 #[derive(Debug, Clone, Serialize)]
 pub struct OsvAdvisory {
     id: Id,

--- a/rustsec/src/osv/osv_range.rs
+++ b/rustsec/src/osv/osv_range.rs
@@ -4,7 +4,7 @@ use semver::Version;
 /// If any of the bounds is unspecified, that means ALL versions
 /// in that direction are affected.
 ///
-/// This format is defined by https://github.com/google/osv
+/// This format is defined by <https://github.com/google/osv>
 #[derive(Debug, Clone)]
 pub struct OsvRange {
     /// Inclusive

--- a/rustsec/src/osv/ranges_for_advisory.rs
+++ b/rustsec/src/osv/ranges_for_advisory.rs
@@ -1,14 +1,14 @@
-use std::convert::TryInto;
+//! Ranges for advisories.
 
-use semver::VersionReq;
-use semver::{Prerelease, Version};
-
-use crate::advisory::versions::RawVersions;
-use crate::advisory::Versions;
-use crate::Error;
-
-use super::osv_range::OsvRange;
-use super::unaffected_range::{Bound, UnaffectedRange};
+use super::{
+    osv_range::OsvRange,
+    unaffected_range::{Bound, UnaffectedRange},
+};
+use crate::{
+    advisory::{versions::RawVersions, Versions},
+    Error,
+};
+use semver::{Prerelease, Version, VersionReq};
 
 /// Returns OSV ranges for all affected versions in the given advisory.
 /// OSV ranges are `[start, end)` intervals, and anything included in them is affected.

--- a/rustsec/src/osv/unaffected_range.rs
+++ b/rustsec/src/osv/unaffected_range.rs
@@ -2,11 +2,9 @@
 //! Cargo-style version selectors (`>=`, `^`, `<`, etc) to OSV ranges.
 //! It is an implementation detail and is not exported outside OSV module.
 
-use std::{convert::TryFrom, fmt::Display};
-
-use semver::{Comparator, Op, Prerelease, Version};
-
 use crate::{Error, ErrorKind::BadParam};
+use semver::{Comparator, Op, Prerelease, Version};
+use std::fmt::Display;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub(crate) enum Bound {
@@ -246,11 +244,8 @@ fn comp_to_ver(c: &Comparator) -> Version {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryInto;
-
-    use semver::VersionReq;
-
     use super::*;
+    use semver::VersionReq;
 
     #[test]
     fn both_unbounded() {

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -40,7 +40,7 @@ impl Repository {
         Self::fetch(DEFAULT_URL, Repository::default_path(), true)
     }
 
-    /// Create a new [`GitRepository`] with the given URL and path
+    /// Create a new [`Repository`] with the given URL and path
     pub fn fetch<P: Into<PathBuf>>(
         url: &str,
         into_path: P,


### PR DESCRIPTION
- Bumps `edition` to 2021
- Sets `rust-version` to 1.57
- Removes explicit `TryFrom`/`TryInto` imports
- Uses README.md as the toplevel rustdoc
- Gets rustdoc building clean again