### PR TITLE
cvss: flattens module structure

### DIFF
--- a/cvss/src/lib.rs
+++ b/cvss/src/lib.rs
@@ -16,13 +16,12 @@
 
 // TODO(tarcieri): other CVSS versions, CVSS v3.1 Temporal and Environmental Groups
 
-pub mod severity;
-
 #[cfg(feature = "v3")]
 pub mod v3;
 
 mod error;
 mod metric;
+mod severity;
 
 pub use crate::{
     error::{Error, Result},

--- a/cvss/src/v3.rs
+++ b/cvss/src/v3.rs
@@ -5,6 +5,7 @@
 // TODO(tarcieri): Environmental and Temporal Metrics
 
 pub mod base;
-pub mod score;
+
+mod score;
 
 pub use self::{base::Base, score::Score};

--- a/cvss/src/v3/base.rs
+++ b/cvss/src/v3/base.rs
@@ -1,13 +1,13 @@
 //! CVSS v3.1 Base Metric Group
 
-pub mod a;
-pub mod ac;
-pub mod av;
-pub mod c;
-pub mod i;
-pub mod pr;
-pub mod s;
-pub mod ui;
+mod a;
+mod ac;
+mod av;
+mod c;
+mod i;
+mod pr;
+mod s;
+mod ui;
 
 pub use self::{
     a::Availability, ac::AttackComplexity, av::AttackVector, c::Confidentiality, i::Integrity,

--- a/rustsec/tests/advisories.rs
+++ b/rustsec/tests/advisories.rs
@@ -79,17 +79,14 @@ fn parse_cvss_vector_string() {
     );
 
     let cvss = advisory.metadata.cvss.unwrap();
-    assert_eq!(cvss.av.unwrap(), cvss::v3::base::av::AttackVector::Network);
-    assert_eq!(cvss.ac.unwrap(), cvss::v3::base::ac::AttackComplexity::Low);
-    assert_eq!(
-        cvss.pr.unwrap(),
-        cvss::v3::base::pr::PrivilegesRequired::None
-    );
-    assert_eq!(cvss.ui.unwrap(), cvss::v3::base::ui::UserInteraction::None);
-    assert_eq!(cvss.s.unwrap(), cvss::v3::base::s::Scope::Changed);
-    assert_eq!(cvss.c.unwrap(), cvss::v3::base::c::Confidentiality::High);
-    assert_eq!(cvss.i.unwrap(), cvss::v3::base::i::Integrity::High);
-    assert_eq!(cvss.a.unwrap(), cvss::v3::base::a::Availability::High);
+    assert_eq!(cvss.av.unwrap(), cvss::v3::base::AttackVector::Network);
+    assert_eq!(cvss.ac.unwrap(), cvss::v3::base::AttackComplexity::Low);
+    assert_eq!(cvss.pr.unwrap(), cvss::v3::base::PrivilegesRequired::None);
+    assert_eq!(cvss.ui.unwrap(), cvss::v3::base::UserInteraction::None);
+    assert_eq!(cvss.s.unwrap(), cvss::v3::base::Scope::Changed);
+    assert_eq!(cvss.c.unwrap(), cvss::v3::base::Confidentiality::High);
+    assert_eq!(cvss.i.unwrap(), cvss::v3::base::Integrity::High);
+    assert_eq!(cvss.a.unwrap(), cvss::v3::base::Availability::High);
     assert_eq!(cvss.score().value(), 10.0);
 }
 


### PR DESCRIPTION
Removes `pub` from all modules which contain only one type which is re-exported through the parent module.