### PR TITLE
cvss: `no_std` support

### DIFF
--- a/cvss/Cargo.toml
+++ b/cvss/Cargo.toml
@@ -15,8 +15,10 @@ rust-version = "1.56"
 serde = { version = "1", optional = true }
 
 [features]
-default = ["v3"]
+default = ["std", "v3"]
 v3 = []
+std = []
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/cvss/src/error.rs
+++ b/cvss/src/error.rs
@@ -1,7 +1,8 @@
 //! Error types
 
 use crate::MetricType;
-use std::fmt;
+use alloc::string::String;
+use core::fmt;
 
 /// Result type with the `cvss` crate's [`Error`] type.
 pub type Result<T> = core::result::Result<T, Error>;
@@ -79,4 +80,6 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}

--- a/cvss/src/lib.rs
+++ b/cvss/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png")]
 #![forbid(unsafe_code)]
@@ -15,6 +17,11 @@
 //! [CVSS v3.1 Specification]: https://www.first.org/cvss/specification-document
 
 // TODO(tarcieri): other CVSS versions, CVSS v3.1 Temporal and Environmental Groups
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "v3")]
 pub mod v3;

--- a/cvss/src/metric.rs
+++ b/cvss/src/metric.rs
@@ -1,7 +1,8 @@
 //! CVSS metrics.
 
 use crate::{Error, Result};
-use std::{
+use alloc::borrow::ToOwned;
+use core::{
     fmt::{self, Debug, Display},
     str::FromStr,
 };

--- a/cvss/src/severity.rs
+++ b/cvss/src/severity.rs
@@ -1,10 +1,14 @@
 //! Qualitative Severity Rating Scale
 
 use crate::{Error, Result};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 #[cfg(feature = "serde")]
-use serde::{de, ser, Deserialize, Serialize};
+use {
+    alloc::string::String,
+    serde::{de, ser, Deserialize, Serialize},
+};
 
 /// Qualitative Severity Rating Scale
 ///
@@ -66,10 +70,11 @@ impl fmt::Display for Severity {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for Severity {
     fn deserialize<D: de::Deserializer<'de>>(
         deserializer: D,
-    ) -> std::result::Result<Self, D::Error> {
+    ) -> core::result::Result<Self, D::Error> {
         String::deserialize(deserializer)?
             .parse()
             .map_err(de::Error::custom)
@@ -77,8 +82,12 @@ impl<'de> Deserialize<'de> for Severity {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for Severity {
-    fn serialize<S: ser::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+    fn serialize<S: ser::Serializer>(
+        &self,
+        serializer: S,
+    ) -> core::result::Result<S::Ok, S::Error> {
         self.as_str().serialize(serializer)
     }
 }

--- a/cvss/src/v3/base/a.rs
+++ b/cvss/src/v3/base/a.rs
@@ -1,7 +1,8 @@
 //! Availability Impact (A)
 
 use crate::{Error, Metric, MetricType, Result};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 /// Availability Impact (A) - CVSS v3.1 Base Metric Group
 ///

--- a/cvss/src/v3/base/ac.rs
+++ b/cvss/src/v3/base/ac.rs
@@ -1,7 +1,8 @@
 //! Attack Complexity (AC)
 
 use crate::{Error, Metric, MetricType, Result};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 /// Attack Complexity (AC) - CVSS v3.1 Base Metric Group
 ///

--- a/cvss/src/v3/base/av.rs
+++ b/cvss/src/v3/base/av.rs
@@ -1,7 +1,8 @@
 //! CVSS v3.1 Base Metric Group - Attack Vector (AV)
 
 use crate::{Error, Metric, MetricType};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 /// Attack Vector (AV) - CVSS v3.1 Base Metric Group
 ///

--- a/cvss/src/v3/base/c.rs
+++ b/cvss/src/v3/base/c.rs
@@ -1,7 +1,8 @@
 //! Confidentiality Impact (C)
 
 use crate::{Error, Metric, MetricType};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 /// Confidentiality Impact (C) - CVSS v3.1 Base Metric Group
 ///

--- a/cvss/src/v3/base/i.rs
+++ b/cvss/src/v3/base/i.rs
@@ -1,7 +1,8 @@
 //! Integrity Impact (I)
 
 use crate::{Error, Metric, MetricType, Result};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 /// Integrity Impact (I) - CVSS v3.1 Base Metric Group
 ///

--- a/cvss/src/v3/base/pr.rs
+++ b/cvss/src/v3/base/pr.rs
@@ -1,7 +1,8 @@
 //! Privileges Required (PR)
 
 use crate::{error::Error, Metric, MetricType};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 /// Privileges Required (PR) - CVSS v3.1 Base Metric Group
 ///

--- a/cvss/src/v3/base/s.rs
+++ b/cvss/src/v3/base/s.rs
@@ -1,7 +1,8 @@
 //! Scope (S)
 
 use crate::{Error, Metric, MetricType, Result};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 /// Scope (S) - CVSS v3.1 Base Metric Group
 ///

--- a/cvss/src/v3/base/ui.rs
+++ b/cvss/src/v3/base/ui.rs
@@ -1,7 +1,8 @@
 //! User Interaction (UI)
 
 use crate::{Error, Metric, MetricType, Result};
-use std::{fmt, str::FromStr};
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
 
 /// User Interaction (UI) - CVSS v3.1 Base Metric Group
 ///

--- a/cvss/src/v3/score.rs
+++ b/cvss/src/v3/score.rs
@@ -24,6 +24,7 @@ impl Score {
     /// CVSS v3.1: Appendix A - Floating Point Rounding.
     ///
     /// <https://www.first.org/cvss/specification-document#t25>
+    #[cfg(feature = "std")]
     pub fn roundup(self) -> Score {
         let score_int = (self.0 * 100_000.0) as u64;
 

--- a/cvss/tests/base.rs
+++ b/cvss/tests/base.rs
@@ -2,7 +2,7 @@
 ///
 /// NOTE: These CVEs are actually `CVSS:3.0` and have been modified for the
 /// purposes of these tests
-use std::str::FromStr;
+use core::str::FromStr;
 
 /// CVE-2013-1937
 #[test]


### PR DESCRIPTION
Adds a `std` feature along with a `no_std`-friendly profile (with a hard dependency on `alloc`).

Also adds annotations to use the `doc_cfg` feature on docs.rs.