### PR TITLE
cvss v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "cvss"
-version = "2.0.0-pre"
+version = "2.0.0"
 dependencies = [
  "serde",
 ]

--- a/cvss/CHANGELOG.md
+++ b/cvss/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 (2022-05-01)
+### Added
+- `no_std` support ([#549])
+
+### Changed
+- Structured `Error` type ([#546])
+- Upgrade to 2021 edition; MSRV 1.56 ([#547])
+- Flatten module structure ([#548])
+
+### Fixed
+- Computation for "no impact" vectors ([#399])
+
+[#399]: https://github.com/RustSec/rustsec/pull/399
+[#546]: https://github.com/RustSec/rustsec/pull/546
+[#547]: https://github.com/RustSec/rustsec/pull/547
+[#548]: https://github.com/RustSec/rustsec/pull/548
+[#549]: https://github.com/RustSec/rustsec/pull/549
+
 ## 1.0.2 (2021-05-10)
 ### Fixed
 - Dangling link in rustdoc ([#360])

--- a/cvss/Cargo.toml
+++ b/cvss/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cvss"
 description  = "Common Vulnerability Scoring System parser/serializer"
-version      = "2.0.0-pre"
+version      = "2.0.0"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 repository   = "https://github.com/RustSec/rustsec/tree/main/cvss"

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.57"
 [dependencies]
 cargo-lock = { version = "7", default-features = false, path = "../cargo-lock" }
 crates-index = { version = "0.18.7", optional = true }
-cvss = { version = "=2.0.0-pre", features = ["serde"], path = "../cvss" }
+cvss = { version = "2", features = ["serde"], path = "../cvss" }
 fs-err = "2.5"
 git2 = { version = "0.14", optional = true }
 home = { version = "0.5", optional = true }


### PR DESCRIPTION
### Added
- `no_std` support ([#549])

### Changed
- Structured `Error` type ([#546])
- Upgrade to 2021 edition; MSRV 1.56 ([#547])
- Flatten module structure ([#548])

### Fixed
- Computation for "no impact" vectors ([#399])

[#399]: https://github.com/RustSec/rustsec/pull/399
[#546]: https://github.com/RustSec/rustsec/pull/546
[#547]: https://github.com/RustSec/rustsec/pull/547
[#548]: https://github.com/RustSec/rustsec/pull/548
[#549]: https://github.com/RustSec/rustsec/pull/549