### PR TITLE
cargo-lock: flatten API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "7.1.0"
+version = "8.0.0-pre"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -1,7 +1,7 @@
 //! Core auditing functionality
 
 use crate::{config::AuditConfig, lockfile, prelude::*, presenter::Presenter};
-use rustsec::{lockfile::Lockfile, registry, report, warning, Error, ErrorKind, Warning};
+use rustsec::{registry, report, warning, Error, ErrorKind, Lockfile, Warning};
 use std::{
     collections::btree_map as map,
     io::{self, Read},

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-lock"
 description = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version = "7.1.0"
+version = "8.0.0-pre"
 authors = ["Tony Arcieri <bascule@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2018"

--- a/cargo-lock/README.md
+++ b/cargo-lock/README.md
@@ -32,6 +32,9 @@ done with a minor version bump.
 - The `cargo lock` CLI interface is not considered to have a stable interface
   and is also exempted from SemVer. We reserve the right to make substantial
   changes to it at any time (for now)
+- The `dependency-tree` feature depends on the pre-1.0 `petgraph` crate.
+  We reserve the right to update `petgraph`, however when we do it will be
+  accompanied by a minor version bump.
 
 ## Command Line Interface
 

--- a/cargo-lock/src/lib.rs
+++ b/cargo-lock/src/lib.rs
@@ -173,19 +173,20 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[macro_use]
-pub mod error;
+mod error;
 
 pub mod dependency;
-pub mod lockfile;
-pub mod metadata;
 pub mod package;
-pub mod patch;
+
+mod lockfile;
+mod metadata;
+mod patch;
 
 pub use self::{
     dependency::Dependency,
     error::{Error, ErrorKind},
     lockfile::{Lockfile, ResolveVersion},
-    metadata::Metadata,
+    metadata::{Metadata, MetadataKey, MetadataValue},
     package::{Checksum, Name, Package, SourceId, Version},
     patch::Patch,
 };

--- a/cargo-lock/src/lockfile/encoding.rs
+++ b/cargo-lock/src/lockfile/encoding.rs
@@ -116,13 +116,16 @@ impl From<&Lockfile> for EncodableLockfile {
 
         for package in &lockfile.packages {
             let mut raw_pkg = EncodablePackage::from(package);
-            let checksum_key = metadata::Key::for_checksum(&Dependency::from(package));
+            let checksum_key = metadata::MetadataKey::for_checksum(&Dependency::from(package));
 
             if lockfile.version == ResolveVersion::V1 {
                 // In the V1 format, we need to remove the checksum from
                 // packages and add it to metadata
                 if let Some(checksum) = raw_pkg.checksum.take() {
-                    let value = checksum.to_string().parse::<metadata::Value>().unwrap();
+                    let value = checksum
+                        .to_string()
+                        .parse::<metadata::MetadataValue>()
+                        .unwrap();
                     metadata.insert(checksum_key, value);
                 }
             } else {

--- a/cargo-lock/src/metadata.rs
+++ b/cargo-lock/src/metadata.rs
@@ -16,16 +16,16 @@ use std::{
 const CHECKSUM_PREFIX: &str = "checksum ";
 
 /// Package metadata
-pub type Metadata = Map<Key, Value>;
+pub type Metadata = Map<MetadataKey, MetadataValue>;
 
 /// Keys for the `[metadata]` table
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct Key(String);
+pub struct MetadataKey(String);
 
-impl Key {
+impl MetadataKey {
     /// Create a metadata key for a checksum for the given dependency
     pub fn for_checksum(dep: &Dependency) -> Self {
-        Key(format!("{}{}", CHECKSUM_PREFIX, dep))
+        MetadataKey(format!("{}{}", CHECKSUM_PREFIX, dep))
     }
 
     /// Is this metadata key a checksum entry?
@@ -39,30 +39,30 @@ impl Key {
     }
 }
 
-impl AsRef<str> for Key {
+impl AsRef<str> for MetadataKey {
     fn as_ref(&self) -> &str {
         &self.0
     }
 }
 
-impl fmt::Display for Key {
+impl fmt::Display for MetadataKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl FromStr for Key {
+impl FromStr for MetadataKey {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
-        Ok(Key(s.to_owned()))
+        Ok(MetadataKey(s.to_owned()))
     }
 }
 
-impl TryFrom<&Key> for Dependency {
+impl TryFrom<&MetadataKey> for Dependency {
     type Error = Error;
 
-    fn try_from(key: &Key) -> Result<Dependency, Error> {
+    fn try_from(key: &MetadataKey) -> Result<Dependency, Error> {
         if !key.is_checksum() {
             fail!(
                 ErrorKind::Parse,
@@ -75,7 +75,7 @@ impl TryFrom<&Key> for Dependency {
     }
 }
 
-impl<'de> Deserialize<'de> for Key {
+impl<'de> Deserialize<'de> for MetadataKey {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
         let s = String::deserialize(deserializer)?;
@@ -83,7 +83,7 @@ impl<'de> Deserialize<'de> for Key {
     }
 }
 
-impl Serialize for Key {
+impl Serialize for MetadataKey {
     fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.to_string().serialize(serializer)
     }
@@ -91,44 +91,44 @@ impl Serialize for Key {
 
 /// Values in the `[metadata]` table
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Value(String);
+pub struct MetadataValue(String);
 
-impl Value {
+impl MetadataValue {
     /// Get the associated checksum for this value (if applicable)
     pub fn checksum(&self) -> Result<Checksum, Error> {
         self.try_into()
     }
 }
 
-impl AsRef<str> for Value {
+impl AsRef<str> for MetadataValue {
     fn as_ref(&self) -> &str {
         &self.0
     }
 }
 
-impl fmt::Display for Value {
+impl fmt::Display for MetadataValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl FromStr for Value {
+impl FromStr for MetadataValue {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
-        Ok(Value(s.to_owned()))
+        Ok(MetadataValue(s.to_owned()))
     }
 }
 
-impl TryFrom<&Value> for Checksum {
+impl TryFrom<&MetadataValue> for Checksum {
     type Error = Error;
 
-    fn try_from(value: &Value) -> Result<Checksum, Error> {
+    fn try_from(value: &MetadataValue) -> Result<Checksum, Error> {
         value.as_ref().parse()
     }
 }
 
-impl<'de> Deserialize<'de> for Value {
+impl<'de> Deserialize<'de> for MetadataValue {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use de::Error;
         let s = String::deserialize(deserializer)?;
@@ -136,7 +136,7 @@ impl<'de> Deserialize<'de> for Value {
     }
 }
 
-impl Serialize for Value {
+impl Serialize for MetadataValue {
     fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.to_string().serialize(serializer)
     }

--- a/cargo-lock/src/package.rs
+++ b/cargo-lock/src/package.rs
@@ -1,8 +1,8 @@
 //! Rust packages enumerated in `Cargo.lock`
 
-pub mod checksum;
-pub mod name;
-pub mod source;
+mod checksum;
+mod name;
+mod source;
 
 pub use self::{
     checksum::Checksum,

--- a/cargo-lock/src/package/checksum.rs
+++ b/cargo-lock/src/package/checksum.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, ErrorKind};
 use serde::{de, ser, Deserialize, Serialize};
-pub use std::{convert::TryFrom, fmt, str::FromStr};
+use std::{fmt, str::FromStr};
 
 /// Cryptographic checksum (SHA-256) for a package
 #[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]

--- a/cargo-lock/tests/lockfile.rs
+++ b/cargo-lock/tests/lockfile.rs
@@ -2,7 +2,7 @@
 
 // TODO(tarcieri): add more example `Cargo.lock` files which cover more scenarios
 
-use cargo_lock::{metadata, Lockfile, ResolveVersion, Version};
+use cargo_lock::{Lockfile, MetadataKey, ResolveVersion, Version};
 
 /// Path to a V1 `Cargo.lock` file.
 const V1_LOCKFILE_PATH: &str = "tests/examples/Cargo.lock.v1";
@@ -26,7 +26,7 @@ fn load_example_v1_lockfile() {
     assert_eq!(package.name.as_ref(), "adler32");
     assert_eq!(package.version, Version::parse("1.0.4").unwrap());
 
-    let metadata_key: metadata::Key =
+    let metadata_key: MetadataKey =
         "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
             .parse()
             .unwrap();

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -13,7 +13,7 @@ edition      = "2021"
 rust-version = "1.57"
 
 [dependencies]
-cargo-lock = { version = "7", default-features = false, path = "../cargo-lock" }
+cargo-lock = { version = "=8.0.0-pre", default-features = false, path = "../cargo-lock" }
 crates-index = { version = "0.18.7", optional = true }
 cvss = { version = "2", features = ["serde"], path = "../cvss" }
 fs-err = "2.5"

--- a/rustsec/src/database.rs
+++ b/rustsec/src/database.rs
@@ -14,8 +14,8 @@ use crate::{
     collection::Collection,
     error::Error,
     fs,
-    lockfile::Lockfile,
     vulnerability::Vulnerability,
+    Lockfile,
 };
 use std::path::Path;
 

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -21,7 +21,7 @@ mod fixer;
 #[cfg(feature = "git")]
 pub mod registry;
 
-pub use cargo_lock::{self, lockfile, package};
+pub use cargo_lock::{self, package, Lockfile};
 pub use fs_err as fs;
 pub use platforms;
 pub use semver::{self, Version, VersionReq};

--- a/rustsec/src/report.rs
+++ b/rustsec/src/report.rs
@@ -6,12 +6,11 @@
 use crate::{
     advisory,
     database::{scope, Database, Query},
-    lockfile::Lockfile,
     map,
     platforms::target::{Arch, OS},
     vulnerability::Vulnerability,
     warning::{self, Warning},
-    Map,
+    Lockfile, Map,
 };
 use serde::{Deserialize, Serialize};
 

--- a/rustsec/tests/integration.rs
+++ b/rustsec/tests/integration.rs
@@ -3,8 +3,7 @@
 #![warn(rust_2018_idioms, unused_qualifications)]
 
 use rustsec::{
-    advisory, database::Query, lockfile::Lockfile, repository::git, Collection, Database,
-    VersionReq,
+    advisory, database::Query, repository::git, Collection, Database, Lockfile, VersionReq,
 };
 use tempfile::tempdir;
 


### PR DESCRIPTION
Removes superfluous modules (e.g. ones which contain only one type) from the public API, re-exporting such types from the parent module. This makes the API easier to browse via rustdoc.

This is a breaking change, so the version is bumped to v8.0.0-pre.