### PR TITLE
cargo-lock: refactor error handling

### DIFF
--- a/cargo-audit/src/error.rs
+++ b/cargo-audit/src/error.rs
@@ -81,27 +81,28 @@ impl From<io::Error> for Error {
 }
 
 impl From<rustsec::Error> for Error {
-    fn from(other: rustsec::Error) -> Self {
-        match other.kind() {
+    fn from(err: rustsec::Error) -> Self {
+        match err.kind() {
             rustsec::ErrorKind::Io => ErrorKind::Io,
             rustsec::ErrorKind::Parse => ErrorKind::Parse,
             rustsec::ErrorKind::Repo => ErrorKind::Repo,
             rustsec::ErrorKind::Version => ErrorKind::Version,
             _ => ErrorKind::Other,
         }
-        .context(other)
+        .context(err)
         .into()
     }
 }
 
 impl From<rustsec::cargo_lock::Error> for Error {
-    fn from(other: rustsec::cargo_lock::Error) -> Self {
-        match other.kind() {
-            rustsec::cargo_lock::ErrorKind::Io => ErrorKind::Io,
-            rustsec::cargo_lock::ErrorKind::Parse => ErrorKind::Parse,
-            rustsec::cargo_lock::ErrorKind::Version => ErrorKind::Version,
+    fn from(err: rustsec::cargo_lock::Error) -> Self {
+        match err {
+            rustsec::cargo_lock::Error::Io(_) => ErrorKind::Io,
+            rustsec::cargo_lock::Error::Parse(_) => ErrorKind::Parse,
+            rustsec::cargo_lock::Error::Version(_) => ErrorKind::Version,
+            _ => ErrorKind::Other,
         }
-        .context(other)
+        .context(err)
         .into()
     }
 }

--- a/cargo-lock/src/lib.rs
+++ b/cargo-lock/src/lib.rs
@@ -155,19 +155,17 @@
 //! [`petgraph`]: https://github.com/petgraph/petgraph
 //! [`cargo-tree`]: https://github.com/sfackler/cargo-tree
 
-#[macro_use]
-mod error;
-
 pub mod dependency;
 pub mod package;
 
+mod error;
 mod lockfile;
 mod metadata;
 mod patch;
 
-pub use self::{
+pub use crate::{
     dependency::Dependency,
-    error::{Error, ErrorKind},
+    error::{Error, Result},
     lockfile::{Lockfile, ResolveVersion},
     metadata::{Metadata, MetadataKey, MetadataValue},
     package::{Checksum, Name, Package, SourceId, Version},

--- a/cargo-lock/src/lockfile.rs
+++ b/cargo-lock/src/lockfile.rs
@@ -7,7 +7,7 @@ pub use self::version::ResolveVersion;
 
 use self::encoding::EncodableLockfile;
 use crate::{
-    error::{Error, ErrorKind},
+    error::{Error, Result},
     metadata::Metadata,
     package::Package,
     patch::Patch,
@@ -38,16 +38,8 @@ pub struct Lockfile {
 
 impl Lockfile {
     /// Load lock data from a `Cargo.lock` file
-    pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
-        match fs::read_to_string(path.as_ref()) {
-            Ok(s) => s.parse(),
-            Err(e) => fail!(
-                ErrorKind::Io,
-                "couldn't open {}: {}",
-                path.as_ref().display(),
-                e
-            ),
-        }
+    pub fn load(path: impl AsRef<Path>) -> Result<Self> {
+        fs::read_to_string(path.as_ref())?.parse()
     }
 
     /// Get the dependency tree for this `Lockfile`. Returns an error if the
@@ -55,7 +47,7 @@ impl Lockfile {
     ///
     /// The `dependency-tree` Cargo feature must be enabled to use this.
     #[cfg(feature = "dependency-tree")]
-    pub fn dependency_tree(&self) -> Result<Tree, Error> {
+    pub fn dependency_tree(&self) -> Result<Tree> {
         Tree::new(self)
     }
 }
@@ -63,7 +55,7 @@ impl Lockfile {
 impl FromStr for Lockfile {
     type Err = Error;
 
-    fn from_str(toml_string: &str) -> Result<Self, Error> {
+    fn from_str(toml_string: &str) -> Result<Self> {
         Ok(toml::from_str(toml_string)?)
     }
 }


### PR DESCRIPTION
- Consolidates the `Error` and `ErrorKind` types.
- Replaces macros with plain Rust literals.
- Preserves `semver::Error` when reporting `Error::Version`.
- Marks `Error` enum as `#[non_exhaustive]`.