### PR TITLE
cargo-lock v8.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "8.0.0-pre"
+version = "8.0.0"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 8.0.0 (2022-05-08)
+### Added
+- Expose `package::SourceKind` ([#557])
+
+### Changed
+- Flatten API ([#558])
+- 2021 edition upgrade; MSRV 1.56 ([#559])
+- Refactor error handling ([#560])
+
+[#557]: https://github.com/RustSec/rustsec/pull/557
+[#558]: https://github.com/RustSec/rustsec/pull/558
+[#559]: https://github.com/RustSec/rustsec/pull/559
+[#560]: https://github.com/RustSec/rustsec/pull/560
+
 ## 7.1.0 (2022-04-23)
 ### Added
 - `SourceId::default()` ([#536])

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "8.0.0-pre"
+version      = "8.0.0"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -13,7 +13,7 @@ edition      = "2021"
 rust-version = "1.57"
 
 [dependencies]
-cargo-lock = { version = "=8.0.0-pre", default-features = false, path = "../cargo-lock" }
+cargo-lock = { version = "8", default-features = false, path = "../cargo-lock" }
 crates-index = { version = "0.18.7", optional = true }
 cvss = { version = "2", features = ["serde"], path = "../cvss" }
 fs-err = "2.5"


### PR DESCRIPTION
### Added
- Expose `package::SourceKind` ([#557])

### Changed
- Flatten API ([#558])
- 2021 edition upgrade; MSRV 1.56 ([#559])
- Refactor error handling ([#560])

[#557]: https://github.com/RustSec/rustsec/pull/557
[#558]: https://github.com/RustSec/rustsec/pull/558
[#559]: https://github.com/RustSec/rustsec/pull/559
[#560]: https://github.com/RustSec/rustsec/pull/560