### PR TITLE
cargo-lock v8.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 8.0.0 (2022-05-08)
+## 8.0.1 (2022-05-21)
+### Fixed
+- Dependency source extraction for V2+ lockfiles ([#568])
+
+[#568]: https://github.com/RustSec/rustsec/pull/568
+
+## 8.0.0 (2022-05-08) [YANKED]
+NOTE: yanked due to bug fixed in v8.0.1.
+
 ### Added
 - Expose `package::SourceKind` ([#557])
 

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "8.0.0"
+version      = "8.0.1"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"

--- a/cargo-lock/src/lockfile/encoding.rs
+++ b/cargo-lock/src/lockfile/encoding.rs
@@ -334,9 +334,9 @@ impl EncodableDependency {
     /// prevent merge conflicts
     pub fn resolve(&self, packages: &[EncodablePackage]) -> Result<Dependency> {
         for pkg in packages {
-            // TODO(tarcieri): validate source?
             if pkg.name == self.name
                 && (self.version.is_none() || self.version.as_ref() == Some(&pkg.version))
+                && self.source.is_none()
             {
                 return Ok(Dependency {
                     name: pkg.name.clone(),


### PR DESCRIPTION
### Fixed
- Dependency source extraction for V2+ lockfiles ([#568])

[#568]: https://github.com/RustSec/rustsec/pull/568