### PR TITLE
rustsec: add `doc_cfg` annotations when building on docs.rs

### DIFF
--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -14,13 +14,8 @@ rust-version = "1.57"
 
 [dependencies]
 cargo-lock = { version = "8", default-features = false, path = "../cargo-lock" }
-crates-index = { version = "0.18", optional = true }
 cvss = { version = "2", features = ["serde"], path = "../cvss" }
 fs-err = "2.5"
-git2 = { version = "0.14", optional = true }
-home = { version = "0.5", optional = true }
-humantime = { version = "2", optional = true }
-humantime-serde = { version = "1", optional = true }
 platforms = { version = "3", features = ["serde"], path = "../platforms" }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
@@ -28,11 +23,13 @@ thiserror = "1"
 toml = "0.5"
 url = { version = "2", features = ["serde"] }
 
-[dependencies.cargo-edit]
-version = "0.9"
-optional = true
-default-features = false
-features = ["upgrade"]
+# optional dependencies
+cargo-edit = { version = "0.9", optional = true, default-features = false,  features = ["upgrade"] }
+crates-index = { version = "0.18", optional = true }
+git2 = { version = "0.14", optional = true }
+home = { version = "0.5", optional = true }
+humantime = { version = "2", optional = true }
+humantime-serde = { version = "1", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -49,3 +46,4 @@ osv-export = ["git"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -76,6 +76,7 @@ pub enum ErrorKind {
 
     /// Error performing an automatic fix
     #[cfg(feature = "fix")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "fix")))]
     #[error("fix failed")]
     Fix,
 
@@ -111,6 +112,7 @@ impl From<Utf8Error> for Error {
 }
 
 #[cfg(feature = "fix")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fix")))]
 impl From<cargo_edit::Error> for Error {
     fn from(other: cargo_edit::Error) -> Self {
         format_err!(ErrorKind::Fix, &other)
@@ -130,6 +132,7 @@ impl From<fmt::Error> for Error {
 }
 
 #[cfg(feature = "git")]
+#[cfg_attr(docsrs, doc(cfg(feature = "git")))]
 impl From<git2::Error> for Error {
     fn from(other: git2::Error) -> Self {
         format_err!(ErrorKind::Repo, &other)
@@ -143,6 +146,7 @@ impl From<io::Error> for Error {
 }
 
 #[cfg(feature = "git")]
+#[cfg_attr(docsrs, doc(cfg(feature = "git")))]
 impl From<crates_index::Error> for Error {
     fn from(other: crates_index::Error) -> Self {
         format_err!(ErrorKind::Registry, "{}", other)

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -8,6 +8,7 @@ use semver::VersionReq;
 use std::path::Path;
 
 /// Auto-fixer for vulnerable dependencies
+#[cfg_attr(docsrs, doc(cfg(feature = "fix")))]
 pub struct Fixer {
     manifest: cargo_edit::LocalManifest,
 }

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
@@ -19,6 +20,7 @@ pub mod warning;
 mod fixer;
 
 #[cfg(feature = "git")]
+#[cfg_attr(docsrs, doc(cfg(feature = "git")))]
 pub mod registry;
 
 pub use cargo_lock::{self, package, Lockfile, SourceId};

--- a/rustsec/src/osv.rs
+++ b/rustsec/src/osv.rs
@@ -8,17 +8,18 @@
 //! See <https://github.com/dtolnay/semver/issues/172>
 
 #[cfg(feature = "osv-export")]
-mod osv_advisory;
+mod advisory;
+
 #[cfg(feature = "osv-export")]
-pub use osv_advisory::OsvAdvisory;
+pub use advisory::OsvAdvisory;
 
 // The rest are enabled unconditionally because the OSV range format
 // is used for determining whether a given version is affected or not
 
-mod osv_range;
+mod range;
 mod ranges_for_advisory;
 mod unaffected_range;
 
-pub use osv_range::OsvRange;
+pub use range::OsvRange;
 pub use ranges_for_advisory::ranges_for_advisory;
 pub(crate) use ranges_for_advisory::ranges_for_unvalidated_advisory;

--- a/rustsec/src/osv/advisory.rs
+++ b/rustsec/src/osv/advisory.rs
@@ -14,6 +14,7 @@ const ECOSYSTEM: &str = "crates.io";
 
 /// Security advisory in the format defined by <https://github.com/google/osv>
 #[derive(Debug, Clone, Serialize)]
+#[cfg_attr(docsrs, doc(cfg(feature = "osv-export")))]
 pub struct OsvAdvisory {
     id: Id,
     modified: String,  // maybe add an rfc3339 newtype?

--- a/rustsec/src/osv/range.rs
+++ b/rustsec/src/osv/range.rs
@@ -1,6 +1,7 @@
 use semver::Version;
 
 /// A range of affected versions.
+///
 /// If any of the bounds is unspecified, that means ALL versions
 /// in that direction are affected.
 ///

--- a/rustsec/src/osv/ranges_for_advisory.rs
+++ b/rustsec/src/osv/ranges_for_advisory.rs
@@ -1,7 +1,7 @@
 //! Ranges for advisories.
 
 use super::{
-    osv_range::OsvRange,
+    range::OsvRange,
     unaffected_range::{Bound, UnaffectedRange},
 };
 use crate::{
@@ -11,6 +11,7 @@ use crate::{
 use semver::{Prerelease, Version, VersionReq};
 
 /// Returns OSV ranges for all affected versions in the given advisory.
+///
 /// OSV ranges are `[start, end)` intervals, and anything included in them is affected.
 /// Panics if the ranges are malformed or range specification syntax is not supported,
 /// since that has been validated on deserialization.
@@ -19,6 +20,7 @@ pub fn ranges_for_advisory(versions: &Versions) -> Vec<OsvRange> {
 }
 
 /// Returns OSV ranges for all affected versions in the given advisory.
+///
 /// OSV ranges are `[start, end)` intervals, and anything included in them is affected.
 /// Errors if the ranges are malformed or range specification syntax is not supported.
 pub(crate) fn ranges_for_unvalidated_advisory(
@@ -28,6 +30,7 @@ pub(crate) fn ranges_for_unvalidated_advisory(
 }
 
 /// Converts a list of unaffected ranges to a range of affected OSV ranges.
+///
 /// Since OSV ranges are a negation of the UNaffected ranges that RustSec stores,
 /// the entire list has to be passed at once, both patched and unaffected ranges.
 fn unaffected_to_osv_ranges(

--- a/rustsec/src/report.rs
+++ b/rustsec/src/report.rs
@@ -22,6 +22,7 @@ use std::time::SystemTime;
 pub struct Report {
     /// Information about the advisory database
     #[cfg(feature = "git")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "git")))]
     pub database: DatabaseInfo,
 
     /// Information about the audited lockfile
@@ -103,6 +104,7 @@ impl Settings {
 
 /// Information about the advisory database
 #[cfg(feature = "git")]
+#[cfg_attr(docsrs, doc(cfg(feature = "git")))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DatabaseInfo {
     /// Number of advisories in the database

--- a/rustsec/src/repository/git.rs
+++ b/rustsec/src/repository/git.rs
@@ -2,7 +2,9 @@
 
 mod authentication;
 mod commit;
+#[cfg(feature = "osv-export")]
 mod gitpath;
+#[cfg(feature = "osv-export")]
 mod modification_time;
 mod repository;
 

--- a/rustsec/src/repository/git/authentication.rs
+++ b/rustsec/src/repository/git/authentication.rs
@@ -32,6 +32,7 @@ use std::env;
 /// credentials until we give it a reason to not do so. To ensure we don't
 /// just sit here looping forever we keep track of authentications we've
 /// attempted and we don't try the same ones again.
+#[cfg_attr(docsrs, doc(cfg(feature = "git")))]
 pub fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F) -> Result<T, Error>
 where
     F: FnMut(&mut git2::Credentials<'_>) -> Result<T, Error>,

--- a/rustsec/src/repository/git/commit.rs
+++ b/rustsec/src/repository/git/commit.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 const STALE_AFTER: Duration = Duration::from_secs(90 * 86400);
 
 /// Information about a commit to the Git repository
+#[cfg_attr(docsrs, doc(cfg(feature = "git")))]
 #[derive(Debug)]
 pub struct Commit {
     /// ID (i.e. SHA-1 hash) of the latest commit

--- a/rustsec/src/repository/git/gitpath.rs
+++ b/rustsec/src/repository/git/gitpath.rs
@@ -1,13 +1,11 @@
-#![cfg(feature = "osv-export")]
-
+use super::Repository;
+use crate::{Error, ErrorKind};
 use std::path::Path;
 
-use crate::{Error, ErrorKind};
-
-use super::Repository;
-
 /// A path *relative to the root of the git repository* that is guaranteed to be tracked by Git.
+///
 /// This type is immutable.
+#[cfg_attr(docsrs, doc(cfg(feature = "osv-export")))]
 pub struct GitPath<'a> {
     repo: &'a Repository,
     path: &'a Path,

--- a/rustsec/src/repository/git/modification_time.rs
+++ b/rustsec/src/repository/git/modification_time.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "osv-export")]
-
 use crate::error::Error;
 use git2::Time;
 use std::{cmp::max, collections::HashMap, path::PathBuf};
@@ -7,6 +5,7 @@ use std::{cmp::max, collections::HashMap, path::PathBuf};
 use super::GitPath;
 
 /// Tracks the time of latest modification of files in git.
+#[cfg_attr(docsrs, doc(cfg(feature = "osv-export")))]
 pub struct GitModificationTimes {
     mtimes: HashMap<PathBuf, Time>,
 }

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -16,7 +16,8 @@ const LOCAL_REF: &str = "refs/heads/main";
 /// Ref for the `main` branch in the remote repository
 const REMOTE_REF: &str = "refs/remotes/origin/main";
 
-/// Git repository for a Rust advisory DB
+/// Git repository for a Rust advisory DB.
+#[cfg_attr(docsrs, doc(cfg(feature = "git")))]
 pub struct Repository {
     /// Path to the Git repository
     pub(super) path: PathBuf,


### PR DESCRIPTION
Adds information about what cargo features must be enabled in order for various types to be available.

This is a nightly-only feature, but fortunately docs.rs uses nightly to build documentation, so we can take advantage of it.