### PR TITLE
rustsec: flatten `warnings` module; rename `WarningKind`

### DIFF
--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -1,14 +1,12 @@
 //! The `~/.cargo/audit.toml` configuration file
 
-use rustsec::warning;
 use rustsec::{
     advisory,
     platforms::target::{Arch, OS},
-    report, Error, ErrorKind,
+    report, Error, ErrorKind, WarningKind,
 };
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 /// `cargo audit` configuration:
 ///
@@ -186,12 +184,12 @@ impl DenyOption {
         ]
     }
     /// Get the warning::Kind that corresponds to self, if applicable
-    pub fn get_warning_kind(self) -> Option<warning::Kind> {
+    pub fn get_warning_kind(self) -> Option<WarningKind> {
         match self {
             DenyOption::Warnings => None,
-            DenyOption::Unmaintained => Some(warning::Kind::Unmaintained),
-            DenyOption::Unsound => Some(warning::Kind::Unsound),
-            DenyOption::Yanked => Some(warning::Kind::Yanked),
+            DenyOption::Unmaintained => Some(WarningKind::Unmaintained),
+            DenyOption::Unsound => Some(WarningKind::Unsound),
+            DenyOption::Yanked => Some(WarningKind::Yanked),
         }
     }
 }

--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -8,14 +8,15 @@ use abscissa_core::terminal::{
     self,
     Color::{self, Red, Yellow},
 };
-use rustsec::cargo_lock::{
-    dependency::{self, graph::EdgeDirection, Dependency},
-    Lockfile, Package,
+use rustsec::{
+    cargo_lock::{
+        dependency::{self, graph::EdgeDirection, Dependency},
+        Lockfile, Package,
+    },
+    WarningKind,
 };
 use std::{collections::BTreeSet as Set, io, path::Path};
-
-use std::io::Write as _;
-use std::string::ToString as _;
+use std::{io::Write as _, string::ToString as _};
 
 /// Vulnerability information presenter
 #[derive(Clone, Debug)]
@@ -25,7 +26,7 @@ pub struct Presenter {
     displayed_packages: Set<Dependency>,
 
     /// Keep track of the warning kinds that correspond to deny-warnings options
-    deny_warning_kinds: Set<rustsec::warning::Kind>,
+    deny_warning_kinds: Set<WarningKind>,
 
     /// Output configuration
     config: OutputConfig,

--- a/rustsec/src/advisory/informational.rs
+++ b/rustsec/src/advisory/informational.rs
@@ -61,11 +61,11 @@ impl Informational {
     }
 
     /// Get a warning kind for this informational type (if applicable)
-    pub fn warning_kind(&self) -> Option<warning::Kind> {
+    pub fn warning_kind(&self) -> Option<warning::WarningKind> {
         match self {
-            Self::Notice => Some(warning::Kind::Notice),
-            Self::Unmaintained => Some(warning::Kind::Unmaintained),
-            Self::Unsound => Some(warning::Kind::Unsound),
+            Self::Notice => Some(warning::WarningKind::Notice),
+            Self::Unmaintained => Some(warning::WarningKind::Unmaintained),
+            Self::Unsound => Some(warning::WarningKind::Unsound),
             Self::Other(_) => None,
         }
     }

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -14,7 +14,7 @@ pub mod osv;
 pub mod report;
 pub mod repository;
 mod vulnerability;
-pub mod warning;
+mod warning;
 
 #[cfg(feature = "fix")]
 mod fixer;
@@ -35,7 +35,7 @@ pub use crate::{
     error::{Error, ErrorKind, Result},
     report::Report,
     vulnerability::Vulnerability,
-    warning::Warning,
+    warning::{Warning, WarningKind},
 };
 
 #[cfg(feature = "fix")]

--- a/rustsec/src/registry.rs
+++ b/rustsec/src/registry.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::{Error, ErrorKind},
-    package,
+    package::{self, Package},
 };
 
 /// Crates.io registry index (local copy)
@@ -53,6 +53,29 @@ impl Index {
             })?;
 
         Ok(IndexPackage::from(crate_release))
+    }
+
+    /// Is the given package yanked?
+    pub fn is_yanked(&self, package: &Package) -> Result<bool, Error> {
+        // TODO(tarcieri): check source matches what we expect
+        Ok(self.find(&package.name, &package.version)?.is_yanked)
+    }
+
+    /// Iterate over the provided packages, returning a vector of the
+    /// packages which have been yanked.
+    pub fn find_yanked<'a, I>(&self, packages: I) -> Result<Vec<&'a Package>, Error>
+    where
+        I: IntoIterator<Item = &'a Package>,
+    {
+        let mut yanked = Vec::new();
+
+        for package in packages {
+            if self.is_yanked(package)? {
+                yanked.push(package);
+            }
+        }
+
+        Ok(yanked)
     }
 }
 

--- a/rustsec/src/report.rs
+++ b/rustsec/src/report.rs
@@ -174,7 +174,7 @@ impl VulnerabilityInfo {
 }
 
 /// Information about warnings
-pub type WarningInfo = Map<warning::Kind, Vec<Warning>>;
+pub type WarningInfo = Map<warning::WarningKind, Vec<Warning>>;
 
 /// Find warnings from the given advisory [`Database`] and [`Lockfile`]
 pub fn find_warnings(db: &Database, lockfile: &Lockfile, settings: &Settings) -> WarningInfo {

--- a/rustsec/src/warning.rs
+++ b/rustsec/src/warning.rs
@@ -9,7 +9,7 @@ use std::{fmt, str::FromStr};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Warning {
     /// Kind of warning
-    pub kind: Kind,
+    pub kind: WarningKind,
 
     /// Name of the dependent package
     pub package: Package,
@@ -24,7 +24,7 @@ pub struct Warning {
 impl Warning {
     /// Create `Warning` of the given kind
     pub fn new(
-        kind: Kind,
+        kind: WarningKind,
         package: &Package,
         advisory: Option<advisory::Metadata>,
         versions: Option<advisory::Versions>,
@@ -39,29 +39,29 @@ impl Warning {
 
     /// Is this a warning a `notice` about a crate?
     pub fn is_notice(&self) -> bool {
-        self.kind == Kind::Notice
+        self.kind == WarningKind::Notice
     }
 
     /// Is this a warning about an `unmaintained` crate?
     pub fn is_unmaintained(&self) -> bool {
-        self.kind == Kind::Unmaintained
+        self.kind == WarningKind::Unmaintained
     }
 
     /// Is this a warning about an `unsound` crate?
     pub fn is_unsound(&self) -> bool {
-        self.kind == Kind::Unsound
+        self.kind == WarningKind::Unsound
     }
 
     /// Is this a warning about a yanked crate?
     pub fn is_yanked(&self) -> bool {
-        self.kind == Kind::Yanked
+        self.kind == WarningKind::Yanked
     }
 }
 
 /// Kinds of warnings
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize, Ord)]
 #[non_exhaustive]
-pub enum Kind {
+pub enum WarningKind {
     /// Informational notices about packages
     #[serde(rename = "notice")]
     Notice,
@@ -79,8 +79,8 @@ pub enum Kind {
     Yanked,
 }
 
-impl Kind {
-    /// Get a `str` representing an warning [`Kind`]
+impl WarningKind {
+    /// Get a `str` representing an warning [`WarningKind`]
     pub fn as_str(&self) -> &str {
         match self {
             Self::Notice => "notice",
@@ -91,21 +91,21 @@ impl Kind {
     }
 }
 
-impl FromStr for Kind {
+impl FromStr for WarningKind {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
         Ok(match s {
-            "notice" => Kind::Notice,
-            "unmaintained" => Kind::Unmaintained,
-            "unsound" => Kind::Unsound,
-            "yanked" => Kind::Yanked,
+            "notice" => WarningKind::Notice,
+            "unmaintained" => WarningKind::Unmaintained,
+            "unsound" => WarningKind::Unsound,
+            "yanked" => WarningKind::Yanked,
             other => fail!(ErrorKind::Parse, "invalid warning type: {}", other),
         })
     }
 }
 
-impl fmt::Display for Kind {
+impl fmt::Display for WarningKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }


### PR DESCRIPTION
- Makes `warnings` non-`pub`
- Exports the former `warning::Kind` as `WarningKind`
- Begins extracting yanked crate checks into the `rustsec` crate