### PR TITLE
rustsec: flatten `advisory::id` module; rename `IdKind`

### DIFF
--- a/admin/src/assigner.rs
+++ b/admin/src/assigner.rs
@@ -2,7 +2,7 @@
 
 use crate::{error::ErrorKind, prelude::*, Map};
 use rustsec::{
-    advisory::{id::Kind, Parts},
+    advisory::{IdKind, Parts},
     Advisory, Collection,
 };
 use std::{
@@ -57,7 +57,7 @@ pub fn assign_ids(repo_path: &Path, output_mode: OutputMode) {
         let id = metadata.id;
         let year = metadata.date.year();
 
-        if let Kind::RustSec = id.kind() {
+        if let IdKind::RustSec = id.kind() {
             let id_num = id.numerical_part().unwrap();
 
             if let Some(&number) = highest_id.get(&year) {

--- a/rustsec/src/advisory.rs
+++ b/rustsec/src/advisory.rs
@@ -3,7 +3,7 @@
 pub mod affected;
 mod category;
 mod date;
-pub mod id;
+mod id;
 mod informational;
 mod keyword;
 pub mod linter;
@@ -12,8 +12,16 @@ mod parts;
 pub(crate) mod versions;
 
 pub use self::{
-    affected::Affected, category::Category, date::Date, id::Id, informational::Informational,
-    keyword::Keyword, linter::Linter, metadata::Metadata, parts::Parts, versions::Versions,
+    affected::Affected,
+    category::Category,
+    date::Date,
+    id::{Id, IdKind},
+    informational::Informational,
+    keyword::Keyword,
+    linter::Linter,
+    metadata::Metadata,
+    parts::Parts,
+    versions::Versions,
 };
 pub use cvss::Severity;
 


### PR DESCRIPTION
Like #572, flattens the `advisory::id` module, making it non-`pub` and exporting the former `id::Kind` as `IdKind`.