### PR TITLE
rustsec v0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -11,19 +11,19 @@ edition     = "2018"
 
 [dependencies]
 abscissa_core = "0.6"
-crates-index = "0.18"
+askama = "0.11"
+atom_syndication = "0.11"
+chrono = { version = "0.4", features = ["serde"] }
 clap = "3"
-rustsec = { version = "0.25", path = "../rustsec", features = ["osv-export"] }
+comrak = "0.12"
+crates-index = "0.18"
+rust-embed = "6.4"
+rustsec = { version = "0.26", path = "../rustsec", features = ["osv-export"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 termcolor = "1"
 thiserror = "1"
 toml = "0.5"
-chrono = { version = "0.4", features = ["serde"] }
-askama = "0.11"
-rust-embed="6.4"
-comrak = "0.12"
-atom_syndication = "0.11"
 xml-rs = "0.8"
 
 [dev-dependencies]

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 abscissa_core = "0.6"
 clap = "3"
 home = "0.5"
-rustsec = { version = "0.25", features = ["dependency-tree"], path = "../rustsec" }
+rustsec = { version = "0.26", features = ["dependency-tree"], path = "../rustsec" }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.26.0 (2022-05-21)
+### Added
+- `[advisory.source]` ([#541])
+- `doc_cfg` annotations when building on docs.rs ([#571])
+
+### Changed
+- Bump `git2` dependency to v0.14; MSRV 1.57 ([#524])
+- Bump `platforms` dependency to v3.0 ([#532])
+- Update to 2021 edition ([#538])
+- Use `Query::crate_scope()` as the `Default` ([#544])
+- Bump `cvss` dependency to v2.0 ([#550])
+- Bump `cargo-lock` dependency to v8.0 ([#561])
+- Flatten `warnings` module; rename `WarningKind` ([#572])
+- Flatten `advisory::id` module; rename `IdKind` ([#573])
+
+### Removed
+- Legacy database scopes ([#541])
+
+[#524]: https://github.com/RustSec/rustsec/pull/524
+[#532]: https://github.com/RustSec/rustsec/pull/532
+[#538]: https://github.com/RustSec/rustsec/pull/538
+[#541]: https://github.com/RustSec/rustsec/pull/541
+[#544]: https://github.com/RustSec/rustsec/pull/544
+[#550]: https://github.com/RustSec/rustsec/pull/550
+[#561]: https://github.com/RustSec/rustsec/pull/561
+[#571]: https://github.com/RustSec/rustsec/pull/571
+[#572]: https://github.com/RustSec/rustsec/pull/572
+[#573]: https://github.com/RustSec/rustsec/pull/573
+
 ## 0.25.1 (2021-11-15)
 ### Changed
 - Bump `platforms` dependency to v2.0.0 ([#485])

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "rustsec"
 description  = "Client library for the RustSec security advisory database"
-version      = "0.25.2" # Also update html_root_url in lib.rs when bumping this
+version      = "0.26.0" # Also update html_root_url in lib.rs when bumping this
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"


### PR DESCRIPTION
### Added
- `[advisory.source]` ([#541])
- `doc_cfg` annotations when building on docs.rs ([#571])

### Changed
- Bump `git2` dependency to v0.14; MSRV 1.57 ([#524])
- Bump `platforms` dependency to v3.0 ([#532])
- Update to 2021 edition ([#538])
- Use `Query::crate_scope()` as the `Default` ([#544])
- Bump `cvss` dependency to v2.0 ([#550])
- Bump `cargo-lock` dependency to v8.0 ([#561])
- Flatten `warnings` module; rename `WarningKind` ([#572])
- Flatten `advisory::id` module; rename `IdKind` ([#573])

### Removed
- Legacy database scopes ([#541])

[#524]: https://github.com/RustSec/rustsec/pull/524
[#532]: https://github.com/RustSec/rustsec/pull/532
[#538]: https://github.com/RustSec/rustsec/pull/538
[#541]: https://github.com/RustSec/rustsec/pull/541
[#544]: https://github.com/RustSec/rustsec/pull/544
[#550]: https://github.com/RustSec/rustsec/pull/550
[#561]: https://github.com/RustSec/rustsec/pull/561
[#571]: https://github.com/RustSec/rustsec/pull/571
[#572]: https://github.com/RustSec/rustsec/pull/572
[#573]: https://github.com/RustSec/rustsec/pull/573