### PR TITLE
rustsec-admin v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec-admin"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "abscissa_core",
  "askama",

--- a/admin/CHANGELOG.md
+++ b/admin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.0 (2022-05-23)
+- Update Abscissa to 0.6; replace `gumdrop` with `clap` v3 ([#525])
+- Update `rustsec` crate to v0.26 ([#574])
+
+[#525]: https://github.com/RustSec/rustsec/pull/525
+[#574]: https://github.com/RustSec/rustsec/pull/574
+
 ## 0.6.0 (2021-11-13)
 - Update `rustsec` crate to v0.25 ([#480])
 - Update `atom_syndication` to 0.11 ([#481])

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "rustsec-admin"
 description = "Admin utility for maintaining the RustSec Advisory Database"
-version     = "0.6.1"
+version     = "0.7.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"


### PR DESCRIPTION
- Update Abscissa to 0.6; replace `gumdrop` with `clap` v3 ([#525])
- Update `rustsec` crate to v0.26 ([#574])

[#525]: https://github.com/RustSec/rustsec/pull/525
[#574]: https://github.com/RustSec/rustsec/pull/574