### PR TITLE
Re-export `GitReference` in cargo-lock.

### DIFF
--- a/cargo-lock/src/package.rs
+++ b/cargo-lock/src/package.rs
@@ -7,7 +7,7 @@ mod source;
 pub use self::{
     checksum::Checksum,
     name::Name,
-    source::{SourceId, SourceKind},
+    source::{GitReference, SourceId, SourceKind},
 };
 pub use semver::Version;
 


### PR DESCRIPTION
closes https://github.com/rustsec/rustsec/issues/587