### PR TITLE
Encode version into V3 lockfiles

### DIFF
--- a/cargo-lock/src/lockfile/encoding.rs
+++ b/cargo-lock/src/lockfile/encoding.rs
@@ -170,6 +170,14 @@ impl ToString for EncodableLockfile {
         out.push_str(extra_line);
         out.push('\n');
 
+        if let Some(value) = toml.get("version") {
+            if let Some(version) = value.as_integer() {
+                if version >= 3 {
+                    out.push_str(&format!("version = {}\n", version));
+                }
+            }
+        }
+
         let deps = toml["package"].as_array().unwrap();
         for dep in deps {
             let dep = dep.as_table().unwrap();

--- a/cargo-lock/tests/lockfile.rs
+++ b/cargo-lock/tests/lockfile.rs
@@ -56,6 +56,16 @@ fn load_example_v3_lockfile() {
     assert_eq!(lockfile.metadata.len(), 0);
 }
 
+/// Ensure V3 lockfiles encode their version correctly.
+#[test]
+fn serialize_v3() {
+    let lockfile = Lockfile::load(V3_LOCKFILE_PATH).unwrap();
+    let reserialized = lockfile.to_string();
+    let lockfile2 = reserialized.parse::<Lockfile>().unwrap();
+    assert_eq!(lockfile2.version, ResolveVersion::V3);
+    assert_eq!(lockfile2.packages, lockfile.packages);
+}
+
 /// Ensure we can serialize a V2 lockfile as a V1 lockfile
 #[test]
 fn serialize_v2_to_v1() {


### PR DESCRIPTION
V3 lockfiles currently do not include their version when encoded causing them to be mistaken for V2 lockfiles in some cases. This PR fixes that by lockfiles V3 or newer encode `version = #`.