### PR TITLE
cargo-lock v8.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 8.0.2 (2022-06-30)
+### Fixed
+- Re-export `GitReference` ([#595])
+- Encode version into V3 lockfiles ([#596])
+
+[#595]: https://github.com/RustSec/rustsec/pull/595
+[#596]: https://github.com/RustSec/rustsec/pull/596
+
 ## 8.0.1 (2022-05-21)
 ### Fixed
 - Dependency source extraction for V2+ lockfiles ([#568])

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "8.0.1"
+version      = "8.0.2"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"


### PR DESCRIPTION
### Fixed
- Re-export `GitReference` ([#595])
- Encode version into V3 lockfiles ([#596])

[#595]: https://github.com/RustSec/rustsec/pull/595
[#596]: https://github.com/RustSec/rustsec/pull/596