### PR TITLE
Deprecate yanked

### DIFF
--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.27.0 (TBD)
+## 0.26.1 (TBD)
 ### Added
 ### Changed
-- Deprecate `yanked` (#TBD])
+- Deprecate `yanked` ([#631])
+
+[#631]: https://github.com/RustSec/rustsec/pull/631
 
 ## 0.26.0 (2022-05-21)
 ### Added

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.27.0 (TBD)
+### Added
+### Changed
+- Deprecate `yanked` (#TBD])
+
 ## 0.26.0 (2022-05-21)
 ### Added
 - `[advisory.source]` ([#541])

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -186,24 +186,6 @@ impl Linter {
                             year = Some(y1);
                         }
                     }
-                    "yanked" => {
-                        if self.advisory.metadata.withdrawn.is_none() {
-                            self.errors.push(Error {
-                                kind: ErrorKind::Malformed,
-                                section: Some("metadata"),
-                                message: Some("Advisories with `yanked = true` must also set the `withdrawn` field"),
-                            });
-                        }
-                    }
-                    "withdrawn" => {
-                        if !matches!(table.get("yanked"), Some(toml::Value::Boolean(true))) {
-                            self.errors.push(Error {
-                                kind: ErrorKind::Malformed,
-                                section: Some("metadata"),
-                                message: Some("Advisories with the `withdrawn` field must also set `yanked = true`"),
-                            });
-                        }
-                    }
                     "aliases" | "cvss" | "keywords" | "package" | "references" | "related"
                     | "title" | "description" => (),
                     _ => self.errors.push(Error {

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -191,7 +191,9 @@ impl Linter {
                             self.errors.push(Error {
                                 kind: ErrorKind::Malformed,
                                 section: Some("metadata"),
-                                message: Some("Field `yanked` is deprecated, use `withdrawn` field instead"),
+                                message: Some(
+                                    "Field `yanked` is deprecated, use `withdrawn` field instead",
+                                ),
                             });
                         }
                     }

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -191,7 +191,7 @@ impl Linter {
                             self.errors.push(Error {
                                 kind: ErrorKind::Malformed,
                                 section: Some("metadata"),
-                                message: Some("Advisories with `yanked = true` must set the `withdrawn` field instead"),
+                                message: Some("Field `yanked` is deprecated, use `withdrawn` field instead"),
                             });
                         }
                     }

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -186,6 +186,15 @@ impl Linter {
                             year = Some(y1);
                         }
                     }
+                    "yanked" => {
+                        if self.advisory.metadata.withdrawn.is_none() {
+                            self.errors.push(Error {
+                                kind: ErrorKind::Malformed,
+                                section: Some("metadata"),
+                                message: Some("Advisories with `yanked = true` must set the `withdrawn` field instead"),
+                            });
+                        }
+                    }
                     "aliases" | "cvss" | "keywords" | "package" | "references" | "related"
                     | "title" | "description" => (),
                     _ => self.errors.push(Error {


### PR DESCRIPTION
**When I was moving http-tower to 2022**
https://github.com/rustsec/advisory-db/pull/1319
https://github.com/rustsec/advisory-db/pull/1320

Also happened here:
https://github.com/rustsec/advisory-db/pull/1310

Linter still requires **yanked = true**
`malformed content in [metadata]: Advisories with the withdrawn field must also set yanked = true`

## Deprecation of `yanked`

This will only error in case where `withdrawn` has not been set when `yanked` was still set, allowing deprecation of `yanked` field

We can then remove `yanked` from all the existing advisories and then we can further take the field out from linter completely after