### PR TITLE
Bring back version information using Clap Derive attribute

### DIFF
--- a/cargo-audit/CHANGELOG.md
+++ b/cargo-audit/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.17.1 (TBD)
+### Fixed
+- Fixed version information ([#632])
+
+[#632]: https://github.com/RustSec/rustsec/pull/632
+
 ## 0.17.0 (2022-05-23)
 ### Changed
 - Update Abscissa to 0.6; replace `gumdrop` with `clap` v3 ([#525])

--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -20,6 +20,7 @@ use clap::Subcommand;
 
 /// The `cargo audit` subcommand
 #[derive(Command, Default, Debug, Parser)]
+#[clap(version)]
 pub struct AuditCommand {
     /// Optional subcommand (used for `cargo audit fix`)
     #[cfg(feature = "fix")]
@@ -29,10 +30,6 @@ pub struct AuditCommand {
     /// Get help information
     #[clap(short = 'h', long = "help", help = "output help information and exit")]
     help: bool,
-
-    /// Get version information
-    #[clap(long = "version", help = "output version and exit")]
-    version: bool,
 
     /// Colored output configuration
     #[clap(

--- a/cargo-audit/tests/acceptance.rs
+++ b/cargo-audit/tests/acceptance.rs
@@ -149,7 +149,10 @@ fn advisories_found_json() {
 fn version() {
     let mut runner = RUNNER.clone();
     runner.arg("--version");
-    let process = runner.run();
+    let mut process = runner.run();
+    let mut version_information = String::new();
+    process.stdout().read_line(&mut version_information).unwrap();
+    assert_eq!(version_information, format!("cargo-audit-audit {}\n", env!("CARGO_PKG_VERSION")));
     process.wait().unwrap().expect_success();
 }
 


### PR DESCRIPTION
Currently because of a way Clap does Subcommands printing the version information of `cargo-audit` does nothing: 

```
❯ cargo audit --help
cargo-audit-audit
Audit Cargo.lock files for vulnerable crates
#...snip... 

❯ cargo audit --version
cargo-audit-audit
```

This PR adds the Clap Derive Version attribute and fixes version information for the Subcommand. It also updates the version test to check the output and ensure version information does not disappear in the future. 


```
❯ ./cargo-audit audit --help
cargo-audit-audit 0.17.0
Audit Cargo.lock files for vulnerable crates
#...snip...

❯ ./cargo-audit audit --version
cargo-audit-audit 0.17.0
```


Related to: https://github.com/rust-lang/cargo/issues/10699