### PR TITLE
rustsec v0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "cargo-edit",
  "cargo-lock",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec-admin"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "abscissa_core",
  "askama",

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.26.1 (TBD)
-### Added
+## 0.26.1 (2022-08-14)
 ### Changed
 - Deprecate `yanked` ([#631])
 

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "rustsec"
 description  = "Client library for the RustSec security advisory database"
-version      = "0.26.0" # Also update html_root_url in lib.rs when bumping this
+version      = "0.26.1" # Also update html_root_url in lib.rs when bumping this
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"


### PR DESCRIPTION
### Changed
- Deprecate `yanked` ([#631])

[#631]: https://github.com/RustSec/rustsec/pull/631