### PR TITLE
Fix `withdrawn`

### DIFF
--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.26.2 (TBD)
 ### Fixed
-- Fixed `withdrawn` ([#xxx])
+- Fixed `withdrawn` ([#642])
 
-[#xxx]: https://github.com/RustSec/rustsec/pull/xxx
+[#642]: https://github.com/RustSec/rustsec/pull/642
 	
 ## 0.26.1 (2022-08-14)
 ### Changed

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.26.2 (TBD)
+### Fixed
+- Fixed `withdrawn` ([#xxx])
+
+[#xxx]: https://github.com/RustSec/rustsec/pull/xxx
+	
 ## 0.26.1 (2022-08-14)
 ### Changed
 - Deprecate `yanked` ([#631])

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "rustsec"
 description  = "Client library for the RustSec security advisory database"
-version      = "0.26.1" # Also update html_root_url in lib.rs when bumping this
+version      = "0.26.2" # Also update html_root_url in lib.rs when bumping this
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -198,7 +198,7 @@ impl Linter {
                         }
                     }
                     "aliases" | "cvss" | "keywords" | "package" | "references" | "related"
-                    | "title" | "description" => (),
+                    | "title" | "withdrawn" | "description" => (),
                     _ => self.errors.push(Error {
                         kind: ErrorKind::key(key),
                         section: Some("advisory"),


### PR DESCRIPTION
For some reason it didn't get tested properly that removing `yanked` works with `withdrawn` and seems I forgot to allow the field when I removed the error that also acted as whitelist -gate for the allowed metadata fields *sigh* :woman_shrugging: 

Need to add tests with test_data for all feature changes like this instead of just testing against current production data which can be later changed following the tooling change - which is prone to error - I really thought I had manually tested that ! :cry: 