### PR TITLE
Fix unexisting crate advisory in tests

### DIFF
--- a/admin/tests/acceptance.rs
+++ b/admin/tests/acceptance.rs
@@ -17,6 +17,8 @@ fn lint_advisory_db() {
 
     runner
         .arg("lint")
+        .arg("--skip-namecheck")
+        .arg("rustdecimal")
         .arg(&git::Repository::default_path())
         .capture_stdout()
         .status()


### PR DESCRIPTION
Not very generic but makes the tests pass.