### PR TITLE
Add readme section about ignore

### DIFF
--- a/cargo-audit/README.md
+++ b/cargo-audit/README.md
@@ -76,7 +76,7 @@ shows a preview of what dependencies would be upgraded, run
 
 ## Ignoring advisories
 
-The first and best way to fix a vulnerability is to upgrade vulnerable crate.
+The first and best way to fix a vulnerability is to upgrade the vulnerable crate.
 
 But there may be situations where an upgrade isn't available and the advisory doesn't affect your application. For example the advisory might involve a cargo feature or API that is unused.
 

--- a/cargo-audit/README.md
+++ b/cargo-audit/README.md
@@ -74,6 +74,20 @@ This will modify `Cargo.toml` in place. To perform a dry run instead, which
 shows a preview of what dependencies would be upgraded, run
 `cargo audit fix --dry-run`.
 
+## Ignoring advisories
+
+The first and best way to fix a vulnerability is to upgrade vulnerable crate.
+
+But there may be situations where an upgrade isn't available and the advisory doesn't affect your application. For example the advisory might involve a cargo feature or API that is unused.
+
+In these cases, you can ignore advisories using the `--ignore` option.
+
+```
+$ cargo audit --ignore RUSTSEC-2017-0001
+```
+
+This option can also be configured via the [`audit.toml`](./audit.toml.example) file.
+
 ## Using `cargo audit` on Travis CI
 
 To automatically run `cargo audit` on every build in Travis CI, you can add the following to your `.travis.yml`:


### PR DESCRIPTION
@djmitche [suggested](https://github.com/actions-rs/audit-check/issues/223#issuecomment-1215962478) documentation to help cover the usage of `audit.toml` to ignore advisories, especially when running under a github action.

This is a draft of documentation that might help meet the need of future similar users.

Wording adapted from the description of https://github.com/rustsec/rustsec/issues/53

Fixes https://github.com/rustsec/rustsec/issues/650