### PR TITLE
Add a command to synchronize advisory data from osv.dev/GHSA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,6 +2991,7 @@ dependencies = [
  "termcolor",
  "thiserror",
  "toml 0.7.8",
+ "toml_edit 0.19.11",
  "xml-rs",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,7 +2991,7 @@ dependencies = [
  "termcolor",
  "thiserror",
  "toml 0.7.8",
- "toml_edit 0.19.11",
+ "toml_edit 0.19.15",
  "xml-rs",
 ]
 

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1"
 termcolor = "1"
 thiserror = "1"
 toml = "0.7"
+toml_edit = "0.19.8"
 xml-rs = "0.8"
 
 [dev-dependencies]

--- a/admin/src/commands.rs
+++ b/admin/src/commands.rs
@@ -4,12 +4,13 @@ mod assign_id;
 mod lint;
 mod list_affected_versions;
 mod osv;
+mod sync;
 mod version;
 mod web;
 
 use self::{
     assign_id::AssignIdCmd, lint::LintCmd, list_affected_versions::ListAffectedVersionsCmd,
-    osv::OsvCmd, version::VersionCmd, web::WebCmd,
+    osv::OsvCmd, sync::SyncCmd, version::VersionCmd, web::WebCmd,
 };
 use crate::config::AppConfig;
 use abscissa_core::{Command, Configurable, Runnable};
@@ -22,6 +23,10 @@ pub enum AdminSubCmd {
     /// The `lint` subcommand
     #[command(about = "lint Advisory DB and ensure is well-formed")]
     Lint(LintCmd),
+
+    /// The `sync` subcommand
+    #[clap(about = "synchronize information from external sources (osv.dev, NVD, etc.)")]
+    Sync(SyncCmd),
 
     /// The `web` subcommand
     #[command(about = "render advisory Markdown files for the rustsec.org web site")]

--- a/admin/src/commands/sync.rs
+++ b/admin/src/commands/sync.rs
@@ -23,6 +23,8 @@ pub struct SyncCmd {
     // Downloaded with:
     //
     // gsutil cp gs://osv-vulnerabilities/crates.io/all.zip .
+    // or
+    // wget https://osv-vulnerabilities.storage.googleapis.com/crates.io/all.zip
     #[clap(
         long = "osv",
         help = "filesystem path to the OSV crates.io data export"

--- a/admin/src/commands/sync.rs
+++ b/admin/src/commands/sync.rs
@@ -12,8 +12,8 @@ use std::{
 #[derive(Command, Debug, Default, Parser)]
 pub struct SyncCmd {
     /// Path to the advisory database
-    #[clap(
-        min_values = 1,
+    #[arg(
+        num_args = 1..,
         help = "filesystem path to the RustSec advisory DB git repo"
     )]
     path: Vec<PathBuf>,

--- a/admin/src/commands/sync.rs
+++ b/admin/src/commands/sync.rs
@@ -1,0 +1,88 @@
+//! `rustsec-admin sync` subcommand
+
+use crate::{prelude::*, synchronizer::Synchronizer};
+use abscissa_core::{Command, Runnable};
+use clap::Parser;
+use std::{
+    path::{Path, PathBuf},
+    process::exit,
+};
+
+/// `rustsec-admin sync` subcommand
+#[derive(Command, Debug, Default, Parser)]
+pub struct SyncCmd {
+    /// Path to the advisory database
+    #[clap(
+        min_values = 1,
+        help = "filesystem path to the RustSec advisory DB git repo"
+    )]
+    path: Vec<PathBuf>,
+
+    /// Path to the OSV export
+    //
+    // Downloaded with:
+    //
+    // gsutil cp gs://osv-vulnerabilities/crates.io/all.zip .
+    #[clap(
+        long = "osv",
+        help = "filesystem path to the OSV crates.io data export"
+    )]
+    osv: PathBuf,
+}
+
+impl Runnable for SyncCmd {
+    fn run(&self) {
+        let repo_path = match self.path.len() {
+            0 => Path::new("."),
+            1 => self.path[0].as_path(),
+            _ => unreachable!(),
+        };
+
+        let mut synchronizer = Synchronizer::new(repo_path, &self.osv).unwrap_or_else(|e| {
+            status_err!(
+                "error loading advisory DB repo from {}: {}",
+                repo_path.display(),
+                e
+            );
+
+            exit(1);
+        });
+
+        let advisories = synchronizer.advisory_db().iter();
+
+        // Ensure we're parsing some advisories
+        if advisories.len() == 0 {
+            status_err!("no advisories found!");
+            exit(1);
+        }
+
+        status_ok!(
+            "Loaded",
+            "{} security advisories (from {})",
+            advisories.len(),
+            repo_path.display()
+        );
+
+        let (updated, new) = synchronizer.sync().unwrap_or_else(|e| {
+            status_err!(
+                "error synchronizing advisory DB {}: {}",
+                repo_path.display(),
+                e
+            );
+
+            exit(1);
+        });
+
+        if new == 0 {
+            status_ok!("Success", "no new advisories to import");
+        } else {
+            status_ok!("Success", "{} aliases are missing in RustSec", new);
+        }
+
+        if updated == 0 {
+            status_ok!("Success", "all advisories are up to date");
+        } else {
+            status_ok!("Success", "{} advisories have been updated", updated);
+        }
+    }
+}

--- a/admin/src/error.rs
+++ b/admin/src/error.rs
@@ -24,6 +24,10 @@ pub enum ErrorKind {
     #[error("I/O error")]
     Io,
 
+    /// Parsing error
+    #[error("RustSec error")]
+    Parse,
+
     /// `rustsec` crate errors
     #[error("RustSec error")]
     RustSec,

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -15,6 +15,7 @@ pub mod list_versions;
 pub mod lock;
 pub mod osv_export;
 pub mod prelude;
+pub mod synchronizer;
 pub mod web;
 
 use std::collections::BTreeMap as Map;

--- a/admin/src/synchronizer.rs
+++ b/admin/src/synchronizer.rs
@@ -260,7 +260,7 @@ impl Synchronizer {
         external: &OsvAdvisory,
     ) -> Result<(), Error> {
         let mut missing_aliases = vec![];
-        let mut missing_related = vec![];
+        let missing_related = vec![];
         for external_id in external.aliases().iter().chain(iter::once(external.id())) {
             // Heuristic based on advisory kind
             match external_id.kind() {
@@ -272,17 +272,6 @@ impl Synchronizer {
                         status_info!(
                             "Info",
                             "Adding missing alias {} for {}",
-                            external_id,
-                            advisory.id()
-                        );
-                    }
-                }
-                IdKind::PySec => {
-                    if !advisory.metadata.related.contains(external_id) {
-                        missing_related.push(external_id.clone());
-                        status_info!(
-                            "Info",
-                            "Adding missing related {} for {}",
                             external_id,
                             advisory.id()
                         );

--- a/admin/src/synchronizer.rs
+++ b/admin/src/synchronizer.rs
@@ -50,6 +50,8 @@
 //!
 //! ```shell
 //! gsutil cp gs://osv-vulnerabilities/crates.io/all.zip .
+//! # or
+//! curl -o advisories.zip https://osv-vulnerabilities.storage.googleapis.com/crates.io/all.zip
 //! ```
 //!
 //! ## Sync process

--- a/admin/src/synchronizer.rs
+++ b/admin/src/synchronizer.rs
@@ -1,0 +1,341 @@
+//! RustSec Advisory DB Synchronizer
+//!
+//! Update the RustSec advisories from external sources.
+//! We use the OSV format as input, as it is the interoperable standard.
+//!
+//! ## GitHub Advisory Database
+//!
+//! Our unique source of external information is the [GitHub Advisory Database](https://github.com/advisories).
+//! Their Rust vulnerabilities have various possible origins:
+//!
+//! * Reported directly to GitHub using their build-in security advisories feature
+//! * imported from a CVE, using metadata from [NVD](https://nvd.nist.gov/vuln)
+//! * imported from RustSec.
+//!   When importing a RustSec inventory, they assign it a GHSA and CVE IDs.
+//!
+//! The data from this database allows us to:
+//!
+//! * Find advisories missing in RustSec
+//!   * We want to manually review those before importing them, to ensure
+//!     the content match our standards and processes.
+//! * Add GHSA and CVE aliases to our vulnerabilities.
+//!   CVE are specially important
+//!   as they are the most use ID for vulnerabilities.
+//! * Add missing metadata to our advisories
+//!
+//! GitHub exposes a GraphQL API, but we chose to use their OSV export as a source.
+//!
+//! ## osv.dev
+//!
+//! osv.dev imports from both GitHub Security Advisories and RustSec,
+//! and exposes its advisories through both an HTTP API and ZIP files.
+//!
+//!
+//! Workflow:
+//!    
+//! ```text                                                     
+//!          ┌───────────────────────────────────┐
+//!          │                                   │
+//!     ┌────┴────┐         ┌─────────┐        ┌─▼────┐
+//!     │ RustSec │─────────▶ OSV.dev ◀────────│ GHSA │
+//!     └────▲────┘         └────┬────┘        └──────┘
+//!          │                   │
+//!          └───────────────────┘
+//! ```
+//!
+//! We use the ZIP file export as a source as we need all advisories at once.
+//!
+//!
+//! The file containing crates.io vulnerabilities is available with:
+//!
+//! ```shell
+//! gsutil cp gs://osv-vulnerabilities/crates.io/all.zip .
+//! ```
+//!
+//! ## Sync process
+//!
+//! ### Get aliases for advisories imported from RustSec
+//!
+//! We can detect advisories imported from RustSec quite reliabilly by looking for a reference to the
+//! advisory file in the `advisory-db` repository.
+//! In this case, we can also check if there is only one RustSec advisory to make sure
+//! it is really an alias.
+//!
+//! Then we can add the GHSA id and the CVE id as aliases in the RustSec advisory.
+//!
+//! ## List missing advisories
+//!
+//! When an advisory contains no reference to an existing RustSec advisory, it is likely
+//! missing.
+
+use crate::{
+    error::{Error, ErrorKind},
+    prelude::*,
+};
+use crates_index::Index;
+use rustsec::advisory::{Id, Parts};
+use rustsec::osv::OsvAdvisory;
+use rustsec::{Advisory, Collection};
+use std::fs::read_to_string;
+use std::iter::FromIterator;
+use std::{
+    fs, iter,
+    path::{Path, PathBuf},
+};
+use toml_edit::{value, Document};
+
+/// Advisory synchronizer
+#[allow(dead_code)]
+pub struct Synchronizer {
+    /// Path to the advisory database
+    repo_path: PathBuf,
+
+    /// Loaded crates.io index
+    crates_index: Index,
+
+    /// Loaded Advisory DB
+    advisory_db: rustsec::Database,
+
+    /// OSV advisories to synchronize from
+    osv: Vec<OsvAdvisory>,
+
+    /// Number of updated advisories
+    updated_advisories: usize,
+
+    /// Number of missing advisories
+    missing_advisories: usize,
+}
+
+impl Synchronizer {
+    /// Create a new synchronizer for the database at the given path
+    pub fn new(repo_path: impl Into<PathBuf>, osv_path: impl Into<PathBuf>) -> Result<Self, Error> {
+        let repo_path = repo_path.into();
+        let mut crates_index = Index::new_cargo_default()?;
+        crates_index.update()?;
+        let advisory_db = rustsec::Database::open(&repo_path)?;
+
+        let osv = Self::load_osv_export(&osv_path.into())?;
+        status_info!(
+            "Info",
+            "Loaded {} advisories from {}",
+            osv.len(),
+            repo_path.display()
+        );
+
+        Ok(Self {
+            repo_path,
+            crates_index,
+            advisory_db,
+            osv,
+            updated_advisories: 0,
+            missing_advisories: 0,
+        })
+    }
+
+    /// Borrow the loaded advisory database
+    pub fn advisory_db(&self) -> &rustsec::Database {
+        &self.advisory_db
+    }
+
+    /// Synchronize data
+    pub fn sync(&mut self) -> Result<(usize, usize), Error> {
+        // A single OSV advisory could describe a vulnerability affecting several crates
+        // (even if GitHub does not produce such advisories currently).
+        // Additionally, a single RustSec advisory can cover several OSV advisories
+        // depending on the way it was reported.
+        // Therefore, we make as few assumptions as possible here.
+        for osv in self.osv.clone() {
+            if osv.withdrawn() {
+                // Ignore withdrawn advisories from the start
+                continue;
+            }
+
+            // The list of RustSec ids referenced by this OSV advisory,
+            // generally one for a GHSA created from RustSec.
+            // When imported, they can be considered actual aliases.
+            let rustsec_ids_in_osv = osv.rustsec_refs_imported();
+            // The list of crates affected by the advisory, normally one
+            // for a GHSA created from RustSec.
+            let affected_crates = osv.crates();
+
+            // The list of RustSec advisories already having this advisory id as alias
+            let rustsec_ids_alias: Vec<Id> = self
+                .advisory_db
+                .iter()
+                .filter_map(|a| {
+                    if a.metadata.aliases.contains(osv.id()) {
+                        Some(a.id().clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            // Build the full list of rs aliases
+            let mut rs_aliases = rustsec_ids_in_osv.clone();
+            rs_aliases.extend(rustsec_ids_alias.clone());
+            rs_aliases.sort();
+            rs_aliases.dedup();
+
+            // This advisory does not link to RustSec (i.e., was not imported)
+            // and is not aliased from RustSec. Let's consider importing it.
+            if rs_aliases.is_empty() {
+                for c in affected_crates {
+                    if let Some(crate_) = self.crates_index.crate_(&c) {
+                        // Only a message from now
+                        // TODO: automate new advisory draft
+                        status_info!(
+                            "Info",
+                            "Missing advisory {} ({}) for {} crate",
+                            osv.id(),
+                            osv.published(),
+                            crate_.name(),
+                        );
+                        self.missing_advisories += 1;
+                    } else {
+                        status_info!(
+                            "Info",
+                            "Unknown crate {} in {} advisory, skipping",
+                            c,
+                            osv.id()
+                        );
+                        continue;
+                    }
+                }
+            } else {
+                // Update advisories from known links
+                for rs_id in rs_aliases {
+                    // ensure all these advisories have up-to-date aliases
+                    // missing alias to GHSA
+                    let rs_advisory = self
+                        .advisory_db
+                        .get(&rs_id)
+                        .expect("Referenced advisory not in rustsec")
+                        .clone();
+
+                    // ensure the crate name matches
+                    if !affected_crates
+                        .iter()
+                        .any(|c| c == rs_advisory.metadata.package.as_str())
+                    {
+                        status_info!(
+                            "Info",
+                            "Wrong crate names {:?} in {} advisory, skipping",
+                            affected_crates,
+                            osv.id()
+                        );
+                        continue;
+                    }
+
+                    self.update_advisory_from_alias(&rs_advisory, &osv)?;
+                }
+            }
+        }
+        Ok((self.updated_advisories, self.missing_advisories))
+    }
+
+    /// Add missing data to advisory from an external source
+    ///
+    /// For now, only add missing aliases.
+    fn update_advisory_from_alias(
+        &mut self,
+        advisory: &Advisory,
+        external: &OsvAdvisory,
+    ) -> Result<(), Error> {
+        let mut missing_aliases = vec![];
+        for alias_id in external.aliases().iter().chain(iter::once(external.id())) {
+            if alias_id != advisory.id() && !advisory.metadata.aliases.contains(alias_id) {
+                missing_aliases.push(alias_id.clone());
+                status_info!(
+                    "Info",
+                    "Adding missing alias {} for {}",
+                    alias_id,
+                    advisory.id()
+                );
+            }
+        }
+        if !missing_aliases.is_empty() {
+            self.update_aliases(
+                &self
+                    .repo_path
+                    .join(Collection::Crates.to_string())
+                    .join(advisory.metadata.package.as_str())
+                    .join(format!("{}.md", advisory.id())),
+                &missing_aliases,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Edit advisory file to extend aliases field
+    fn update_aliases(
+        &mut self,
+        advisory_path: &Path,
+        missing_aliases: &[Id],
+    ) -> Result<(), Error> {
+        let content = read_to_string(advisory_path)?;
+        // First extract toml and markdown content
+        // We can't parse as Advisory as we want to preserve formatting
+        let parts = Parts::parse(&content)?;
+        // Parse toml
+        let mut metadata = parts
+            .front_matter
+            .parse::<Document>()
+            .expect("invalid TOML front matter");
+        // Read current aliases
+        let mut aliases: Vec<String> = metadata["advisory"]
+            .get("aliases")
+            .map(|i| {
+                i.as_array()
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| v.as_str().unwrap().to_string())
+                    .collect()
+            })
+            .unwrap_or_else(Vec::new);
+        // Add missing aliases
+        aliases.extend(missing_aliases.iter().map(|a| a.to_string()));
+        // Ensure sorted output
+        aliases.sort();
+        aliases.dedup();
+        metadata["advisory"]["aliases"] = value(toml_edit::Array::from_iter(aliases.iter()));
+        let updated = format!("```toml\n{}```\n\n{}", metadata, parts.markdown);
+        fs::write(advisory_path, updated)?;
+        status_info!("Info", "Written {}", advisory_path.display());
+        self.updated_advisories += 1;
+        Ok(())
+    }
+
+    /// Load an OSV advisory from a JSON file
+    fn load_osv_file(path: impl AsRef<Path>) -> Result<OsvAdvisory, Error> {
+        let path = path.as_ref();
+
+        let advisory_data = read_to_string(path)
+            .map_err(|e| format_err!(ErrorKind::Io, "couldn't open {}: {}", path.display(), e))?;
+
+        let advisory: OsvAdvisory = serde_json::from_str(&advisory_data).map_err(|e| {
+            format_err!(ErrorKind::Parse, "error parsing {}: {}", path.display(), e)
+        })?;
+
+        Ok(advisory)
+    }
+
+    /// Load data from an OSV export
+    fn load_osv_export(path: &Path) -> Result<Vec<OsvAdvisory>, Error> {
+        let mut result = vec![];
+        for advisory_entry in fs::read_dir(path).unwrap() {
+            let advisory_path = advisory_entry.unwrap().path();
+            if advisory_path.extension() != Some("json".as_ref()) {
+                // Skip non-JSON files
+                continue;
+            }
+            if advisory_path.to_string_lossy().contains("RUSTSEC-") {
+                // Don't parse advisories already coming from RustSec
+                continue;
+            }
+            let advisory = Self::load_osv_file(advisory_path)?;
+            result.push(advisory)
+        }
+        Ok(result)
+    }
+}

--- a/rustsec/src/advisory.rs
+++ b/rustsec/src/advisory.rs
@@ -32,6 +32,8 @@ use crate::{
     fs,
 };
 use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::Write;
 use std::{path::Path, str::FromStr};
 
 /// RustSec Security Advisories
@@ -49,7 +51,7 @@ pub struct Advisory {
 }
 
 impl Advisory {
-    /// Load an advisory from a `RUSTSEC-20XX-NNNN.toml` file
+    /// Load an advisory from a `RUSTSEC-20XX-NNNN.md` file
     pub fn load_file(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
 
@@ -59,6 +61,28 @@ impl Advisory {
         advisory_data
             .parse()
             .map_err(|e| format_err!(ErrorKind::Parse, "error parsing {}: {}", path.display(), e))
+    }
+
+    /// Write an `RUSTSEC-20XX-NNNN.md` file
+    pub fn write_file(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+        let path = path.as_ref();
+
+        //let updated = format!("```toml\n{}```\n\n{}", metadata, parts.markdown);
+        //fs::write(advisory_path, updated)?;
+
+        // FIXME properly serialize metadata
+
+        let metadata = toml::to_string(&self.metadata)?;
+
+        // If the crate folder does not exist
+        let prefix = path.parent().unwrap();
+        std::fs::create_dir_all(prefix).unwrap();
+
+        let mut file = File::create(path)
+            .map_err(|e| format_err!(ErrorKind::Io, "couldn't create {}: {}", path.display(), e))?;
+        file.write_all(metadata.as_bytes())?;
+        file.write_all(self.metadata.description.as_bytes())?;
+        Ok(())
     }
 
     /// Get advisory ID

--- a/rustsec/src/advisory/id.rs
+++ b/rustsec/src/advisory/id.rs
@@ -54,6 +54,15 @@ impl Id {
     pub fn is_ghsa(&self) -> bool {
         self.kind == IdKind::Ghsa
     }
+    /// Is this advisory ID a TALOS advisory?
+    pub fn is_talos(&self) -> bool {
+        self.kind == IdKind::Talos
+    }
+
+    /// Is this advisory ID a PYSEC advisory?
+    pub fn is_pysec(&self) -> bool {
+        self.kind == IdKind::PySec
+    }
 
     /// Is this an unknown kind of advisory ID?
     pub fn is_other(&self) -> bool {
@@ -100,6 +109,7 @@ impl Id {
                 "https://www.talosintelligence.com/reports/{}",
                 &self.string
             )),
+            IdKind::PySec => Some(format!("https://osv.dev/vulnerability/{}", &self.string)),
             _ => None,
         }
     }
@@ -180,6 +190,9 @@ pub enum IdKind {
     /// Cisco Talos identifiers
     Talos,
 
+    /// PYSEC identifiers
+    PySec,
+
     /// Other types of advisory identifiers we don't know about
     Other,
 }
@@ -193,6 +206,8 @@ impl IdKind {
             IdKind::Cve
         } else if string.starts_with("TALOS-") {
             IdKind::Talos
+        } else if string.starts_with("PYSEC-") {
+            IdKind::PySec
         } else if string.starts_with("GHSA-") {
             IdKind::Ghsa
         } else {

--- a/rustsec/src/advisory/id.rs
+++ b/rustsec/src/advisory/id.rs
@@ -59,11 +59,6 @@ impl Id {
         self.kind == IdKind::Talos
     }
 
-    /// Is this advisory ID a PYSEC advisory?
-    pub fn is_pysec(&self) -> bool {
-        self.kind == IdKind::PySec
-    }
-
     /// Is this an unknown kind of advisory ID?
     pub fn is_other(&self) -> bool {
         self.kind == IdKind::Other
@@ -109,7 +104,6 @@ impl Id {
                 "https://www.talosintelligence.com/reports/{}",
                 &self.string
             )),
-            IdKind::PySec => Some(format!("https://osv.dev/vulnerability/{}", &self.string)),
             _ => None,
         }
     }
@@ -190,9 +184,6 @@ pub enum IdKind {
     /// Cisco Talos identifiers
     Talos,
 
-    /// PYSEC identifiers
-    PySec,
-
     /// Other types of advisory identifiers we don't know about
     Other,
 }
@@ -206,8 +197,6 @@ impl IdKind {
             IdKind::Cve
         } else if string.starts_with("TALOS-") {
             IdKind::Talos
-        } else if string.starts_with("PYSEC-") {
-            IdKind::PySec
         } else if string.starts_with("GHSA-") {
             IdKind::Ghsa
         } else {

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -215,3 +215,9 @@ impl Error {
         format_err!(crate::ErrorKind::Parse, &other)
     }
 }
+
+impl From<toml::ser::Error> for Error {
+    fn from(other: toml::ser::Error) -> Self {
+        format_err!(ErrorKind::Parse, &other)
+    }
+}

--- a/rustsec/src/osv/advisory.rs
+++ b/rustsec/src/osv/advisory.rs
@@ -13,7 +13,6 @@ use crate::{
     Advisory,
 };
 use serde::{Deserialize, Deserializer, Serialize};
-use std::ops::Add;
 use std::str::FromStr;
 use url::Url;
 
@@ -41,6 +40,7 @@ pub struct OsvAdvisory {
     affected: Vec<OsvAffected>,
     #[serde(default)]
     references: Vec<OsvReference>,
+    #[serde(default)]
     database_specific: MainOsvDatabaseSpecific,
 }
 
@@ -51,7 +51,8 @@ pub struct OsvPackage {
     /// Crate name
     pub(crate) name: String,
     /// https://github.com/package-url/purl-spec derived from the other two
-    purl: String,
+    #[serde(default)]
+    purl: Option<String>,
 }
 
 impl From<&cargo_lock::Name> for OsvPackage {
@@ -59,7 +60,7 @@ impl From<&cargo_lock::Name> for OsvPackage {
         OsvPackage {
             ecosystem: ECOSYSTEM.to_string(),
             name: package.to_string(),
-            purl: "pkg:cargo/".to_string() + package.as_str(),
+            purl: Some("pkg:cargo/".to_string() + package.as_str()),
         }
     }
 }
@@ -185,9 +186,10 @@ pub struct OsvDatabaseSpecific {
     informational: Option<Informational>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct MainOsvDatabaseSpecific {
-    license: String,
+    #[serde(default)]
+    license: Option<String>,
 }
 
 impl OsvAdvisory {
@@ -255,7 +257,7 @@ impl OsvAdvisory {
             details: metadata.description,
             references: osv_references(reference_urls),
             database_specific: MainOsvDatabaseSpecific {
-                license: metadata.license.spdx().to_string(),
+                license: Some(metadata.license.spdx().to_string()),
             },
         }
     }

--- a/rustsec/src/osv/advisory.rs
+++ b/rustsec/src/osv/advisory.rs
@@ -1,43 +1,55 @@
 //! OSV advisories.
+//!
+//! It implements the parts of the [OSV schema](https://ossf.github.io/osv-schema) required for
+//! RustSec.
 
 use tame_index::external::gix;
 
 use super::ranges_for_advisory;
+use crate::advisory::Versions;
 use crate::{
     advisory::{affected::FunctionPath, Affected, Category, Id, Informational},
     repository::git::{self, GitModificationTimes, GitPath},
     Advisory,
 };
-use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::ops::Add;
+use std::str::FromStr;
 use url::Url;
 
 const ECOSYSTEM: &str = "crates.io";
 
 /// Security advisory in the format defined by <https://github.com/google/osv>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(docsrs, doc(cfg(feature = "osv-export")))]
 pub struct OsvAdvisory {
+    schema_version: Option<semver::Version>,
     id: Id,
     modified: String,  // maybe add an rfc3339 newtype?
     published: String, // maybe add an rfc3339 newtype?
     #[serde(skip_serializing_if = "Option::is_none")]
     withdrawn: Option<String>, // maybe add an rfc3339 newtype?
+    #[serde(default)]
     aliases: Vec<Id>,
+    #[serde(default)]
     related: Vec<Id>,
     summary: String,
     details: String,
+    #[serde(default)]
     severity: Vec<OsvSeverity>,
+    #[serde(default)]
     affected: Vec<OsvAffected>,
+    #[serde(default)]
     references: Vec<OsvReference>,
     database_specific: MainOsvDatabaseSpecific,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OsvPackage {
     /// Set to a constant identifying crates.io
-    ecosystem: &'static str,
+    pub(crate) ecosystem: String,
     /// Crate name
-    name: String,
+    pub(crate) name: String,
     /// https://github.com/package-url/purl-spec derived from the other two
     purl: String,
 }
@@ -45,14 +57,14 @@ pub struct OsvPackage {
 impl From<&cargo_lock::Name> for OsvPackage {
     fn from(package: &cargo_lock::Name) -> Self {
         OsvPackage {
-            ecosystem: ECOSYSTEM,
+            ecosystem: ECOSYSTEM.to_string(),
             name: package.to_string(),
             purl: "pkg:cargo/".to_string() + package.as_str(),
         }
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 #[serde(tag = "type", content = "score")]
 pub enum OsvSeverity {
@@ -65,38 +77,57 @@ impl From<cvss::v3::Base> for OsvSeverity {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OsvAffected {
-    package: OsvPackage,
-    ecosystem_specific: OsvEcosystemSpecific,
+    pub(crate) package: OsvPackage,
+    ecosystem_specific: Option<OsvEcosystemSpecific>,
     database_specific: OsvDatabaseSpecific,
-    ranges: Vec<OsvJsonRange>,
-    // 'versions' field is not needed because we use semver ranges
+    ranges: Option<Vec<OsvJsonRange>>,
+    // FIXME deserialize with deserialize_semver_compat
+    versions: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OsvJsonRange {
     // 'type' is a reserved keyword in Rust
     #[serde(rename = "type")]
-    kind: &'static str,
+    kind: String,
     events: Vec<OsvTimelineEvent>,
     // 'repo' field is not used because we don't track or export git commit data
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum OsvTimelineEvent {
     #[serde(rename = "introduced")]
+    #[serde(deserialize_with = "deserialize_semver_compat")]
     Introduced(semver::Version),
     #[serde(rename = "fixed")]
+    #[serde(deserialize_with = "deserialize_semver_compat")]
     Fixed(semver::Version),
+    #[serde(rename = "last_affected")]
+    #[serde(deserialize_with = "deserialize_semver_compat")]
+    LastAffected(semver::Version),
 }
 
-#[derive(Debug, Clone, Serialize)]
+fn deserialize_semver_compat<'de, D>(deserializer: D) -> Result<semver::Version, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut ver = String::deserialize(deserializer)?;
+    match ver.matches('.').count() {
+        0 => ver.push_str(".0.0"),
+        1 => ver.push_str(".0"),
+        _ => (),
+    }
+    semver::Version::from_str(&ver).map_err(serde::de::Error::custom)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OsvReference {
     // 'type' is a reserved keyword in Rust
     #[serde(rename = "type")]
-    kind: OsvReferenceKind,
-    url: Url,
+    pub kind: OsvReferenceKind,
+    pub url: Url,
 }
 
 impl From<Url> for OsvReference {
@@ -109,7 +140,7 @@ impl From<Url> for OsvReference {
 }
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum OsvReferenceKind {
     ADVISORY,
     #[allow(dead_code)]
@@ -121,12 +152,13 @@ pub enum OsvReferenceKind {
     WEB,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OsvEcosystemSpecific {
-    affects: OsvEcosystemSpecificAffected,
+    affects: Option<OsvEcosystemSpecificAffected>,
+    affected_functions: Option<Vec<FunctionPath>>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OsvEcosystemSpecificAffected {
     arch: Vec<platforms::target::Arch>,
     os: Vec<platforms::target::OS>,
@@ -145,8 +177,9 @@ impl From<Affected> for OsvEcosystemSpecificAffected {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OsvDatabaseSpecific {
+    #[serde(default)]
     categories: Vec<Category>,
     cvss: Option<cvss::v3::Base>,
     informational: Option<Informational>,
@@ -158,6 +191,16 @@ pub struct MainOsvDatabaseSpecific {
 }
 
 impl OsvAdvisory {
+    /// Advisory ID
+    pub fn id(&self) -> &Id {
+        &self.id
+    }
+
+    /// Publication date
+    pub fn published(&self) -> &str {
+        &self.published
+    }
+
     /// Converts a single RustSec advisory to OSV format.
     /// `path` is the path to the advisory file. It must be relative to the git repository root.
     pub fn from_rustsec(
@@ -186,15 +229,18 @@ impl OsvAdvisory {
         reference_urls.extend(metadata.references);
 
         OsvAdvisory {
+            schema_version: None,
             id: metadata.id,
             modified: git_time_to_rfc3339(mod_times.for_path(path)),
             published: rustsec_date_to_rfc3339(&metadata.date),
             affected: vec![OsvAffected {
                 package: (&metadata.package).into(),
-                ranges: vec![timeline_for_advisory(&advisory.versions)],
-                ecosystem_specific: OsvEcosystemSpecific {
-                    affects: advisory.affected.unwrap_or_default().into(),
-                },
+                ranges: Some(vec![timeline_for_advisory(&advisory.versions)]),
+                versions: Some(vec![]),
+                ecosystem_specific: Some(OsvEcosystemSpecific {
+                    affects: Some(advisory.affected.unwrap_or_default().into()),
+                    affected_functions: None,
+                }),
                 database_specific: OsvDatabaseSpecific {
                     categories: metadata.categories,
                     cvss: metadata.cvss.clone(),
@@ -212,6 +258,51 @@ impl OsvAdvisory {
                 license: metadata.license.spdx().to_string(),
             },
         }
+    }
+
+    /// Try to extract RustSec alias id from OSV advisory metadata
+    pub fn rustsec_refs_imported(&self) -> Vec<Id> {
+        let mut refs: Vec<Id> = self
+            .references
+            .iter()
+            .filter(|r| {
+                r.url
+                    .as_str()
+                    .starts_with("https://rustsec.org/advisories/")
+            })
+            .map(|r| Id::from_str(&r.url.as_str()[31..48]).expect("Invalid rustsec url"))
+            .collect();
+        refs.sort();
+        refs.dedup();
+        refs
+    }
+
+    /// Get crates in crates.io ecosystem referenced in this advisory
+    pub fn crates(&self) -> Vec<String> {
+        let mut res: Vec<String> = self
+            .affected
+            .iter()
+            .filter_map(|a| {
+                if a.package.ecosystem == ECOSYSTEM {
+                    Some(a.package.name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        res.sort();
+        res.dedup();
+        res
+    }
+
+    /// Get aliases ids
+    pub fn aliases(&self) -> &[Id] {
+        self.aliases.as_slice()
+    }
+
+    /// Is this advisory withdrawn?
+    pub fn withdrawn(&self) -> bool {
+        self.withdrawn.is_some()
     }
 }
 
@@ -235,7 +326,7 @@ fn guess_url_kind(url: &Url) -> OsvReferenceKind {
 
 /// Generates the timeline of the bug being introduced and fixed for the
 /// [`affected[].ranges[].events`](https://github.com/ossf/osv-schema/blob/main/schema.md#affectedrangesevents-fields) field.
-fn timeline_for_advisory(versions: &crate::advisory::Versions) -> OsvJsonRange {
+fn timeline_for_advisory(versions: &Versions) -> OsvJsonRange {
     let ranges = ranges_for_advisory(versions);
     assert!(!ranges.is_empty()); // zero ranges means nothing is affected, so why even have an advisory?
     let mut timeline = Vec::new();
@@ -253,7 +344,7 @@ fn timeline_for_advisory(versions: &crate::advisory::Versions) -> OsvJsonRange {
         }
     }
     OsvJsonRange {
-        kind: "SEMVER",
+        kind: "SEMVER".to_string(),
         events: timeline,
     }
 }


### PR DESCRIPTION
Result in https://github.com/rustsec/advisory-db/pull/1693.

Refs: https://github.com/rustsec/rustsec/issues/644

This PR implements:

* Alias id update from OSV advisories
* Listing OSV advisories we should consider importing into RustSec

The end goal is to be able to automatically open pull requests with the advisories updates and drafts from missing ones. For now I plan to run it regularly manually until we're confident with the result.