### PR TITLE
Clarify location of audit config

### DIFF
--- a/cargo-audit/audit.toml.example
+++ b/cargo-audit/audit.toml.example
@@ -1,4 +1,8 @@
-# Example `~/.cargo/audit.toml` file
+# Example audit config file
+#
+# It may be located in the user home (`~/.cargo/audit.toml`) or in the project
+# root (`.cargo/audit.toml`).
+#
 # All of the options which can be passed via CLI arguments can also be
 # permanently specified in this file.
 

--- a/cargo-audit/src/commands.rs
+++ b/cargo-audit/src/commands.rs
@@ -8,7 +8,7 @@ use abscissa_core::{config::Override, Command, Configurable, FrameworkError, Run
 use clap::Parser;
 use std::{ops::Deref, path::PathBuf};
 
-/// Name of the configuration file (located in `~/.cargo`)
+/// Name of the configuration file
 ///
 /// This file allows setting some default auditing options.
 pub const CONFIG_FILE: &str = "audit.toml";

--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -1,4 +1,4 @@
-//! The `~/.cargo/audit.toml` configuration file
+//! The configuration file
 
 use rustsec::{
     advisory,
@@ -10,7 +10,8 @@ use std::{path::PathBuf, str::FromStr};
 
 /// `cargo audit` configuration:
 ///
-/// An optional TOML config file located in `~/.cargo/audit.toml`
+/// An optional TOML config file located in `~/.cargo/audit.toml` or
+/// `.cargo/audit.toml`.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AuditConfig {


### PR DESCRIPTION
It took me a while to realize that the audit config can be located in the project directory as well. This PR adds some documentation for that.