### PR TITLE
Fix `bin` screenshot URL in the README

### DIFF
--- a/cargo-audit/README.md
+++ b/cargo-audit/README.md
@@ -88,7 +88,7 @@ $ cargo install cargo-audit --features=binary-scanning
 
 Once installed, run `cargo audit bin` followed by the paths to your binaries to audit them:
 
-<img src="https://github.com/rustsec/rustsec/raw/release-0.17.1/.img/screenshot-bin.png" alt="Screenshot" style="max-width:100%;">
+<img src="https://github.com/rustsec/rustsec/raw/46eeb09cef411bbe926a82c8a0d678a3e43299a1/.img/screenshot-bin.png" alt="Screenshot" style="max-width:100%;">
 
 ## Ignoring advisories
 


### PR DESCRIPTION
The previous URL worked while the branch was alive but is broken now.