### PR TITLE
Revert "Don't use --locked in release workflow to allow publishing again"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           use-cross: ${{ matrix.cross }}
           command: build
-          args: --release --features "${{ join(matrix.features, ',') }}" --target ${{ matrix.target }}
+          args: --release --locked --features "${{ join(matrix.features, ',') }}" --target ${{ matrix.target }}
       - name: Package
         shell: bash
         run: |


### PR DESCRIPTION
#718 re-added Cargo.lock and somehow CI didn't fall over, so re-enable --locked publishing.

This reverts commit e8d343beefbd49d986b51fb552984f25d12a47bd.