### PR TITLE
cargo-lock v8.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ba7d807ad2850c436750154dbc442eb8611527deb6dfcc4e5e0bd10d5fbf28"
 dependencies = [
- "cargo-lock 8.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 8.0.2",
  "semver",
  "serde",
  "serde_json",
@@ -280,7 +280,7 @@ dependencies = [
  "abscissa_core",
  "auditable-info",
  "auditable-serde",
- "cargo-lock 8.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 8.0.2",
  "clap",
  "home",
  "once_cell",
@@ -327,8 +327,9 @@ dependencies = [
 [[package]]
 name = "cargo-lock"
 version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c4c54d47a4532db3494ef7332c257ab57b02750daae3250d49e01ee55201ce8"
 dependencies = [
- "gumdrop",
  "petgraph",
  "semver",
  "serde",
@@ -338,10 +339,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4c54d47a4532db3494ef7332c257ab57b02750daae3250d49e01ee55201ce8"
+version = "8.0.3"
 dependencies = [
+ "gumdrop",
  "petgraph",
  "semver",
  "serde",
@@ -1760,7 +1760,7 @@ name = "rustsec"
 version = "0.26.4"
 dependencies = [
  "cargo-edit",
- "cargo-lock 8.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 8.0.2",
  "crates-index",
  "cvss",
  "fs-err",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 8.0.3 (2022-11-30)
+### Fixed
+- Encoding inconsistency when there's only one registry for all packages ([#767])
+
+[#767]: https://github.com/RustSec/rustsec/pull/767
+
 ## 8.0.2 (2022-06-30)
 ### Fixed
 - Re-export `GitReference` ([#595])

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "8.0.2"
+version      = "8.0.3"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"


### PR DESCRIPTION
### Fixed
- Encoding inconsistency when there's only one registry for all packages ([#767])

[#767]: https://github.com/RustSec/rustsec/pull/767