### PR TITLE
Add client-side glob expansion on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "wild",
 ]
 
 [[package]]
@@ -947,6 +948,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gumdrop"
@@ -2442,6 +2449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wild"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b116685a6be0c52f5a103334cbff26db643826c7b3735fc0a3ba9871310a74"
+dependencies = [
+ "glob",
 ]
 
 [[package]]

--- a/admin/src/bin/rustsec-admin/main.rs
+++ b/admin/src/bin/rustsec-admin/main.rs
@@ -7,5 +7,11 @@ use rustsec_admin::application::APPLICATION;
 
 /// Boot the `rustsec-admin` CLI application
 fn main() {
-    abscissa_core::boot(&APPLICATION);
+    // copied from `abscissa` code:
+    // https://github.com/iqlusioninc/abscissa/blob/7c9ab7976145d2920a99ef00eba845efab3247a1/core/src/application.rs#L171-L177
+    // so that we could inject wild::args() instead of std::env::args()
+    // which provides glob expansion on Windows
+    let args = std::env::args();
+    abscissa_core::application::Application::run(&APPLICATION, args);
+    std::process::exit(0);
 }

--- a/cargo-audit/CHANGELOG.md
+++ b/cargo-audit/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.0 (UNRELEASED)
+### Added
+
+ - Glob expressions are now expanded on Windows. Commands like `cargo audit bin .cargo/bin/*` now Just Work, even on Windows.
+
 ## 0.17.4 (2022-11-08)
 ### Fixed
 

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -29,6 +29,7 @@ auditable-info = { version = "0.6.2", optional = true }
 cargo-lock = { version = "8.0.2", optional = true } 
 auditable-serde = { version = "0.5.0",  optional = true, features = ["toml"] }
 quitters = { version = "0.1", optional = true, path = "../quitters" }
+wild = "2.1.0"
 
 [dev-dependencies]
 once_cell = "1.5"


### PR DESCRIPTION
I've bumped version to 0.18.0 because this is technically a breaking change - glob paths now have to be escaped on Windows, which wasn't a requirement previously. 

But I'm not very familiar with argument parsing on Windows so I may be mistaken about the impact of this. In which case erring on the side of caution is prudent.