### PR TITLE
cargo-lock: implement From<Name> for String

### DIFF
--- a/cargo-lock/src/package/name.rs
+++ b/cargo-lock/src/package/name.rs
@@ -27,6 +27,12 @@ impl fmt::Display for Name {
     }
 }
 
+impl From<Name> for String {
+    fn from(name: Name) -> String {
+        name.0
+    }
+}
+
 impl FromStr for Name {
     type Err = Error;
 


### PR DESCRIPTION
Since `Name` already stores a `String` internally, this allows for a cheap conversion. Implementing this trait also implicitly adds `Into<String> for Name` - this is more desirable than calling `name.to_string()` (which implies an allocation) if one wants an owned `String` and can consume the `Name` anyway.