### PR TITLE
cargo-lock: mark `SourceKind` as `#[non_exhaustive]`

### DIFF
--- a/cargo-lock/src/package/source.rs
+++ b/cargo-lock/src/package/source.rs
@@ -39,6 +39,7 @@ pub struct SourceId {
 
 /// The possible kinds of code source.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum SourceKind {
     /// A git repository.
     Git(GitReference),


### PR DESCRIPTION
We need to do a breaking v9 release because `SourceKind` added a `SparseRegistry` variant.

Marking this enum as `non_exhaustive` means we'll be able to do future non-breaking additions in the event that Cargo adds new `SourceKind` variants upstream.