### PR TITLE
cargo-lock: use `Display` for `io::ErrorKind`; MSRV 1.60

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -40,7 +40,7 @@ jobs:
           - macos-latest
           #- windows-latest # TODO(tarcieri): debug Windows build timeouts
         toolchain:
-          - 1.58.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/cargo-lock.yml
+++ b/.github/workflows/cargo-lock.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.58.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.58.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.58.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.58.0
+          toolchain: 1.60.0
           components: clippy
           override: true
           profile: minimal

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -10,7 +10,7 @@ readme       = "README.md"
 categories   = ["development-tools::cargo-plugins"]
 keywords     = ["cargo-subcommand", "security", "audit", "vulnerability"]
 edition      = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 exclude      = ["tests/"]
 
 [badges]
@@ -24,6 +24,7 @@ rustsec = { version = "0.26.3", features = ["dependency-tree"], path = "../rusts
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 thiserror = "1"
+
 # for scanning binary files
 auditable-info = { version = "0.6.2", optional = true }
 cargo-lock = { version = "8.0.2", optional = true } 

--- a/cargo-audit/README.md
+++ b/cargo-audit/README.md
@@ -12,7 +12,7 @@ Audit your dependencies for crates with security vulnerabilities reported to the
 
 ## Requirements
 
-`cargo audit` requires Rust **1.57** or later.
+`cargo audit` requires Rust **1.60** or later.
 
 ## Installation
 
@@ -152,7 +152,7 @@ additional terms or conditions.
 [build-image]: https://github.com/RustSec/rustsec/actions/workflows/cargo-audit.yml/badge.svg
 [build-link]: https://github.com/RustSec/rustsec/actions/workflows/cargo-audit.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-- MSRV 1.58 to support more ported-from-cargo code ([#559])
-
 ## 8.0.3 (2022-11-30)
 ### Fixed
 - Encoding inconsistency when there's only one registry for all packages ([#767])

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -10,7 +10,7 @@ repository   = "https://github.com/RustSec/rustsec/tree/main/cargo-lock"
 categories   = ["parser-implementations"]
 keywords     = ["cargo", "dependency", "lock", "lockfile"]
 edition      = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 
 [[bin]]
 name = "cargo-lock"

--- a/cargo-lock/README.md
+++ b/cargo-lock/README.md
@@ -21,7 +21,7 @@ the [`cargo-tree`] crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.58** or higher.
+Rust **1.60** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 accompanied by a minor version bump.
@@ -76,7 +76,7 @@ additional terms or conditions.
 [build-image]: https://github.com/RustSec/rustsec/actions/workflows/cargo-lock.yml/badge.svg
 [build-link]: https://github.com/RustSec/rustsec/actions/workflows/cargo-lock.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [zulip-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/cargo-lock/src/error.rs
+++ b/cargo-lock/src/error.rs
@@ -22,8 +22,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            // TODO(tarcieri): use `Display` impl when MSRV 1.60
-            Error::Io(kind) => write!(f, "I/O operation failed: {:?}", kind),
+            Error::Io(kind) => write!(f, "I/O operation failed: {}", kind),
             Error::Parse(s) => write!(f, "parse error: {}", s),
             Error::Version(err) => write!(f, "version error: {}", err),
         }

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -10,7 +10,7 @@ readme       = "README.md"
 categories   = ["api-bindings", "development-tools"]
 keywords     = ["audit", "rustsec", "security", "advisory", "vulnerability"]
 edition      = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 cargo-lock = { version = "8", default-features = false }

--- a/rustsec/README.md
+++ b/rustsec/README.md
@@ -24,7 +24,7 @@ database in other capacities.
 
 ## Minimum Supported Rust Version
 
-Rust **1.57** or higher.
+Rust **1.60** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -54,7 +54,7 @@ additional terms or conditions.
 [build-link]: https://github.com/RustSec/rustsec/actions/workflows/rustsec.yml
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rust-lang.zulipchat.com/#narrow/stream/146229-wg-secure-code/


### PR DESCRIPTION
Addresses a TODO.

1.60 is a particularly viral MSRV as it's not possible to have crates in a workspace that use namespaced/weak features unless all crates in the workspace are MSRV 1.60.

So, bumping this now prior to a breaking release means we'll also be futureproof for updates which use namespaced/weak features (including transitive dependencies)