### PR TITLE
cargo-audit: disable macOS CI for `--all-features`

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -32,25 +32,21 @@ jobs:
         with:
           command: check
 
-  test:
+  # TODO(tarcieri): re-unify build matrix when platform-specific problems are fixed
+  test-linux:
     strategy:
       matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
         toolchain:
-          # TODO(tarcieri): investigate long build times
-          # - 1.60.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3.0.11
+      - uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-      - uses: actions/cache@v3.0.11
+      - uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
@@ -60,33 +56,45 @@ jobs:
           profile: minimal
           override: true
       - run: cargo test --release
-      #- run: cargo test --all-features --release
+      - run: cargo test --all-features --release
 
-  # TODO(tarcieri): re-unify with `test` job
-  # Extracted out due to macOS build failures. See rustsec/rustsec#795
-  test-all-features:
-    strategy:
-      matrix:
-        toolchain:
-          - 1.60.0 # MSRV
-          - stable
-    runs-on: ubuntu-latest
+  test-macos:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3.0.11
+      - uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-      - uses: actions/cache@v3.0.11
+      - uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           profile: minimal
           override: true
-      - run: cargo test --all-features --release
+      - run: cargo test --release
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - run: cargo test --release
 
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -38,9 +38,10 @@ jobs:
         platform:
           - ubuntu-latest
           - macos-latest
-          #- windows-latest # TODO(tarcieri): debug Windows build timeouts
+          - windows-latest
         toolchain:
-          - 1.60.0 # MSRV
+          # TODO(tarcieri): investigate long build times
+          # - 1.60.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
@@ -59,6 +60,32 @@ jobs:
           profile: minimal
           override: true
       - run: cargo test --release
+      #- run: cargo test --all-features --release
+
+  # TODO(tarcieri): re-unify with `test` job
+  # Extracted out due to macOS build failures. See rustsec/rustsec#795
+  test-all-features:
+    strategy:
+      matrix:
+        toolchain:
+          - 1.60.0 # MSRV
+          - stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3.0.11
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+      - uses: actions/cache@v3.0.11
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
       - run: cargo test --all-features --release
 
   doc:


### PR DESCRIPTION
It's currently failing. See #795.

This also attempts to re-enable the Windows build.