### PR TITLE
cvss: bump MSRV to 1.60

### DIFF
--- a/.github/workflows/cvss.yml
+++ b/.github/workflows/cvss.yml
@@ -14,8 +14,8 @@ defaults:
     working-directory: cvss
 
 env:
-  RUSTFLAGS: -D warnings
-  RUSTDOCFLAGS: -D warnings
+  RUSTFLAGS: "-D warnings"
+  RUSTDOCFLAGS: "-D warnings"
 
 jobs:
   build:
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/cvss/Cargo.toml
+++ b/cvss/Cargo.toml
@@ -9,7 +9,7 @@ readme       = "README.md"
 categories   = ["parser-implementations"]
 keywords     = ["cvssv3", "security", "advisory", "vulnerability"]
 edition      = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 serde = { version = "1", optional = true }

--- a/cvss/README.md
+++ b/cvss/README.md
@@ -14,7 +14,10 @@ Rust implementation of the [Common Vulnerability Scoring System (Version 3.1) Sp
 
 ## Minimum Supported Rust Version
 
-Rust **1.56**
+Rust **1.60** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
 
 ## License
 
@@ -41,7 +44,7 @@ additional terms or conditions.
 [build-link]: https://github.com/RustSec/rustsec/actions/workflows/cvss.yml
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
 [zulip-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [zulip-link]: https://rust-lang.zulipchat.com/#narrow/stream/146229-wg-secure-code/


### PR DESCRIPTION
This crate's older MSRV is blocking the use of newer crates which make use of namespaced/weak feature activation:

https://github.com/rustsec/rustsec/actions/runs/3998049178/jobs/6860183561

See also: #794