### PR TITLE
admin: bump `chrono` to v0.4.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "num-integer",

--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -6,7 +6,7 @@ use atom_syndication::{
     CategoryBuilder, ContentBuilder, Entry, EntryBuilder, FeedBuilder, FixedDateTime, LinkBuilder,
     PersonBuilder, Text,
 };
-use chrono::{Date, Duration, NaiveDate, Utc};
+use chrono::{Duration, NaiveDate, Utc};
 use comrak::{markdown_to_html, ComrakOptions};
 use rust_embed::RustEmbed;
 use rustsec::advisory::Id;
@@ -21,6 +21,10 @@ use std::{
     path::{Path, PathBuf},
 };
 use xml::escape::escape_str_attribute;
+
+// TODO(tarcieri): replace with `DateTime`
+#[allow(deprecated)]
+use chrono::Date;
 
 #[derive(Template)]
 #[template(path = "index.html")]
@@ -366,6 +370,9 @@ pub fn render_advisories(output_folder: PathBuf) {
     // Feed
     let feed_path = output_folder.join("feed.xml");
     let min_feed_len = 10;
+
+    // TODO(tarcieri): replace with `DateTime`
+    #[allow(deprecated)]
     let last_week_len = advisories
         .iter()
         .take_while(|(_, c, _)| {
@@ -567,11 +574,14 @@ mod filters {
 
     pub fn friendly_date<T: Borrow<advisory::Date>>(date: T) -> ::askama::Result<String> {
         let date = date.borrow();
-        Ok(
-            NaiveDate::from_ymd(date.year().try_into().unwrap(), date.month(), date.day())
-                .format("%B %e, %Y")
-                .to_string(),
-        )
+
+        // TODO(tarcieri): fix deprecation of `NaiveDate::from_ymd`
+        #[allow(deprecated)]
+        let date = NaiveDate::from_ymd(date.year().try_into().unwrap(), date.month(), date.day())
+            .format("%B %e, %Y")
+            .to_string();
+
+        Ok(date)
     }
 
     pub fn safe_keyword(s: &str) -> ::askama::Result<String> {


### PR DESCRIPTION
This release includes a number of deprecations.

To accomplish the upgrade, this annotates the usages with `allow(deprecated)` and adds a TODO comment for each one.