### PR TITLE
Regenerate platforms for rustc 1.69.0-nightly

### DIFF
--- a/platforms/Cargo.toml
+++ b/platforms/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from the Rust compiler.
 """
-version    = "3.0.2"
+version    = "3.1.0"
 authors    = ["Tony Arcieri <bascule@gmail.com>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://rustsec.org"

--- a/platforms/src/platform/platforms.rs
+++ b/platforms/src/platform/platforms.rs
@@ -28,6 +28,7 @@ pub(crate) const ALL: &[Platform] = &[
     AARCH64_PC_WINDOWS_GNULLVM,
     AARCH64_PC_WINDOWS_MSVC,
     AARCH64_UNKNOWN_FREEBSD,
+    AARCH64_UNKNOWN_FUCHSIA,
     AARCH64_UNKNOWN_HERMIT,
     AARCH64_UNKNOWN_LINUX_GNU,
     AARCH64_UNKNOWN_LINUX_GNU_ILP32,
@@ -35,6 +36,7 @@ pub(crate) const ALL: &[Platform] = &[
     AARCH64_UNKNOWN_NETBSD,
     AARCH64_UNKNOWN_NONE,
     AARCH64_UNKNOWN_NONE_SOFTFLOAT,
+    AARCH64_UNKNOWN_NTO_QNX710,
     AARCH64_UNKNOWN_OPENBSD,
     AARCH64_UNKNOWN_REDOX,
     AARCH64_UNKNOWN_UEFI,
@@ -62,6 +64,7 @@ pub(crate) const ALL: &[Platform] = &[
     ARMV6K_NINTENDO_3DS,
     ARMV7_APPLE_IOS,
     ARMV7_LINUX_ANDROIDEABI,
+    ARMV7_SONY_VITA_NEWLIBEABIHF,
     ARMV7_UNKNOWN_FREEBSD,
     ARMV7_UNKNOWN_LINUX_GNUEABI,
     ARMV7_UNKNOWN_LINUX_GNUEABIHF,
@@ -131,6 +134,7 @@ pub(crate) const ALL: &[Platform] = &[
     POWERPC_UNKNOWN_OPENBSD,
     POWERPC_WRS_VXWORKS,
     POWERPC_WRS_VXWORKS_SPE,
+    POWERPC64_IBM_AIX,
     POWERPC64_UNKNOWN_FREEBSD,
     POWERPC64_UNKNOWN_LINUX_GNU,
     POWERPC64_UNKNOWN_LINUX_MUSL,
@@ -186,6 +190,7 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_FORTANIX_UNKNOWN_SGX,
     X86_64_FUCHSIA,
     X86_64_LINUX_ANDROID,
+    X86_64_PC_NTO_QNX710,
     X86_64_PC_SOLARIS,
     X86_64_PC_WINDOWS_GNU,
     X86_64_PC_WINDOWS_GNULLVM,
@@ -193,6 +198,7 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_SUN_SOLARIS,
     X86_64_UNKNOWN_DRAGONFLY,
     X86_64_UNKNOWN_FREEBSD,
+    X86_64_UNKNOWN_FUCHSIA,
     X86_64_UNKNOWN_HAIKU,
     X86_64_UNKNOWN_HERMIT,
     X86_64_UNKNOWN_ILLUMOS,
@@ -202,7 +208,6 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_UNKNOWN_LINUX_MUSL,
     X86_64_UNKNOWN_NETBSD,
     X86_64_UNKNOWN_NONE,
-    X86_64_UNKNOWN_NONE_LINUXKERNEL,
     X86_64_UNKNOWN_OPENBSD,
     X86_64_UNKNOWN_REDOX,
     X86_64_UNKNOWN_UEFI,
@@ -277,7 +282,7 @@ pub(crate) const AARCH64_APPLE_WATCHOS_SIM: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARM64 Fuchsia
+/// Alias for `aarch64-unknown-fuchsia`
 pub(crate) const AARCH64_FUCHSIA: Platform = Platform {
     target_triple: "aarch64-fuchsia",
     target_arch: Arch::AArch64,
@@ -351,6 +356,17 @@ pub(crate) const AARCH64_UNKNOWN_FREEBSD: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
+};
+
+/// ARM64 Fuchsia
+pub(crate) const AARCH64_UNKNOWN_FUCHSIA: Platform = Platform {
+    target_triple: "aarch64-unknown-fuchsia",
+    target_arch: Arch::AArch64,
+    target_os: OS::Fuchsia,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Two,
 };
 
 /// ARM64 HermitCore
@@ -429,6 +445,16 @@ pub(crate) const AARCH64_UNKNOWN_NONE_SOFTFLOAT: Platform = Platform {
     tier: Tier::Two,
 };
 
+pub(crate) const AARCH64_UNKNOWN_NTO_QNX710: Platform = Platform {
+    target_triple: "aarch64-unknown-nto-qnx710",
+    target_arch: Arch::AArch64,
+    target_os: OS::Nto,
+    target_env: Env::Nto71,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// ARM64 OpenBSD
 pub(crate) const AARCH64_UNKNOWN_OPENBSD: Platform = Platform {
     target_triple: "aarch64-unknown-openbsd",
@@ -459,7 +485,7 @@ pub(crate) const AARCH64_UNKNOWN_UEFI: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 pub(crate) const AARCH64_UWP_WINDOWS_MSVC: Platform = Platform {
@@ -720,6 +746,17 @@ pub(crate) const ARMV7_LINUX_ANDROIDEABI: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Two,
+};
+
+/// ARM Cortex-A9 Sony PlayStation Vita (requires VITASDK toolchain)
+pub(crate) const ARMV7_SONY_VITA_NEWLIBEABIHF: Platform = Platform {
+    target_triple: "armv7-sony-vita-newlibeabihf",
+    target_arch: Arch::Arm,
+    target_os: OS::Vita,
+    target_env: Env::Newlib,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
 };
 
 /// ARMv7 FreeBSD
@@ -1122,7 +1159,7 @@ pub(crate) const I686_UNKNOWN_UEFI: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 pub(crate) const I686_UWP_WINDOWS_GNU: Platform = Platform {
@@ -1462,6 +1499,17 @@ pub(crate) const POWERPC_WRS_VXWORKS_SPE: Platform = Platform {
     target_env: Env::Gnu,
     target_endian: Endian::Big,
     target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// 64-bit AIX (7.2 and newer)
+pub(crate) const POWERPC64_IBM_AIX: Platform = Platform {
+    target_triple: "powerpc64-ibm-aix",
+    target_arch: Arch::PowerPc64,
+    target_os: OS::Aix,
+    target_env: Env::None,
+    target_endian: Endian::Big,
+    target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
 };
 
@@ -2043,7 +2091,7 @@ pub(crate) const X86_64_FORTANIX_UNKNOWN_SGX: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// 64-bit Fuchsia
+/// Alias for `x86_64-unknown-fuchsia`
 pub(crate) const X86_64_FUCHSIA: Platform = Platform {
     target_triple: "x86_64-fuchsia",
     target_arch: Arch::X86_64,
@@ -2063,6 +2111,16 @@ pub(crate) const X86_64_LINUX_ANDROID: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
+};
+
+pub(crate) const X86_64_PC_NTO_QNX710: Platform = Platform {
+    target_triple: "x86_64-pc-nto-qnx710",
+    target_arch: Arch::X86_64,
+    target_os: OS::Nto,
+    target_env: Env::Nto71,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
 };
 
 /// 64-bit Solaris 10/11, illumos
@@ -2135,6 +2193,17 @@ pub(crate) const X86_64_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "x86_64-unknown-freebsd",
     target_arch: Arch::X86_64,
     target_os: OS::FreeBSD,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Two,
+};
+
+/// 64-bit Fuchsia
+pub(crate) const X86_64_UNKNOWN_FUCHSIA: Platform = Platform {
+    target_triple: "x86_64-unknown-fuchsia",
+    target_arch: Arch::X86_64,
+    target_os: OS::Fuchsia,
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
@@ -2239,17 +2308,6 @@ pub(crate) const X86_64_UNKNOWN_NONE: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Linux kernel modules
-pub(crate) const X86_64_UNKNOWN_NONE_LINUXKERNEL: Platform = Platform {
-    target_triple: "x86_64-unknown-none-linuxkernel",
-    target_arch: Arch::X86_64,
-    target_os: OS::None,
-    target_env: Env::Gnu,
-    target_endian: Endian::Little,
-    target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
-};
-
 /// 64-bit OpenBSD
 pub(crate) const X86_64_UNKNOWN_OPENBSD: Platform = Platform {
     target_triple: "x86_64-unknown-openbsd",
@@ -2280,7 +2338,7 @@ pub(crate) const X86_64_UNKNOWN_UEFI: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 pub(crate) const X86_64_UWP_WINDOWS_GNU: Platform = Platform {

--- a/platforms/src/target/env.rs
+++ b/platforms/src/target/env.rs
@@ -35,6 +35,9 @@ pub enum Env {
     /// `newlib`
     Newlib,
 
+    /// `nto71`
+    Nto71,
+
     /// `psx`
     Psx,
 
@@ -59,6 +62,7 @@ impl Env {
             Env::Msvc => "msvc",
             Env::Musl => "musl",
             Env::Newlib => "newlib",
+            Env::Nto71 => "nto71",
             Env::Psx => "psx",
             Env::Relibc => "relibc",
             Env::Sgx => "sgx",
@@ -80,6 +84,7 @@ impl FromStr for Env {
             "msvc" => Env::Msvc,
             "musl" => Env::Musl,
             "newlib" => Env::Newlib,
+            "nto71" => Env::Nto71,
             "psx" => Env::Psx,
             "relibc" => Env::Relibc,
             "sgx" => Env::Sgx,

--- a/platforms/src/target/os.rs
+++ b/platforms/src/target/os.rs
@@ -13,6 +13,9 @@ use serde::{de, de::Error as DeError, ser, Deserialize, Serialize};
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum OS {
+    /// `aix`
+    Aix,
+
     /// `android`: Google's Android mobile operating system
     Android,
 
@@ -65,6 +68,9 @@ pub enum OS {
     /// `none`
     None,
 
+    /// `nto`
+    Nto,
+
     /// `openbsd`: The OpenBSD operating system
     OpenBSD,
 
@@ -89,6 +95,9 @@ pub enum OS {
     /// `unknown`
     Unknown,
 
+    /// `vita`
+    Vita,
+
     /// `vxworks`: VxWorks is a deterministic, priority-based preemptive RTOS with low latency and minimal jitter
     VxWorks,
 
@@ -109,6 +118,7 @@ impl OS {
     /// String representing this `OS` which matches `#[cfg(target_os)]`
     pub fn as_str(self) -> &'static str {
         match self {
+            OS::Aix => "aix",
             OS::Android => "android",
             OS::Cuda => "cuda",
             OS::Dragonfly => "dragonfly",
@@ -126,6 +136,7 @@ impl OS {
             OS::MacOS => "macos",
             OS::NetBSD => "netbsd",
             OS::None => "none",
+            OS::Nto => "nto",
             OS::OpenBSD => "openbsd",
             OS::Psp => "psp",
             OS::Redox => "redox",
@@ -134,6 +145,7 @@ impl OS {
             OS::TvOS => "tvos",
             OS::Uefi => "uefi",
             OS::Unknown => "unknown",
+            OS::Vita => "vita",
             OS::VxWorks => "vxworks",
             OS::Wasi => "wasi",
             OS::WatchOS => "watchos",
@@ -149,6 +161,7 @@ impl FromStr for OS {
     /// Create a new `OS` from the given string
     fn from_str(name: &str) -> Result<Self, Self::Err> {
         let result = match name {
+            "aix" => OS::Aix,
             "android" => OS::Android,
             "cuda" => OS::Cuda,
             "dragonfly" => OS::Dragonfly,
@@ -166,6 +179,7 @@ impl FromStr for OS {
             "macos" => OS::MacOS,
             "netbsd" => OS::NetBSD,
             "none" => OS::None,
+            "nto" => OS::Nto,
             "openbsd" => OS::OpenBSD,
             "psp" => OS::Psp,
             "redox" => OS::Redox,
@@ -174,6 +188,7 @@ impl FromStr for OS {
             "tvos" => OS::TvOS,
             "uefi" => OS::Uefi,
             "unknown" => OS::Unknown,
+            "vita" => OS::Vita,
             "vxworks" => OS::VxWorks,
             "wasi" => OS::Wasi,
             "watchos" => OS::WatchOS,


### PR DESCRIPTION
This is our first platform removal in the 3.x series too. Time to put the semver policy to the test!