### PR TITLE
Remove latest commit signature check

### DIFF
--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -132,18 +132,6 @@ impl Repository {
         let latest_commit = repo.latest_commit()?;
         latest_commit.reset(&repo)?;
 
-        // Any commits we fetch should always be signed
-        // TODO: verify signatures against GitHub's public key
-        if latest_commit.signature.is_none() {
-            fail!(
-                ErrorKind::Repo,
-                "no signature on commit {}: {} ({})",
-                latest_commit.commit_id,
-                latest_commit.summary,
-                latest_commit.author
-            );
-        }
-
         // Ensure that the upstream repository hasn't gone stale
         if ensure_fresh && !latest_commit.is_fresh() {
             fail!(


### PR DESCRIPTION
Closes #629 

Removed the signature check of the latest commit which solved #629. Left other existing signature related functionality in place so as not to create an API break.

Tested manually against an altered advisory-db without a signed latest commit.