### PR TITLE
fix(cargo-audit): set clap bin_name to cargo

### DIFF
--- a/cargo-audit/src/commands.rs
+++ b/cargo-audit/src/commands.rs
@@ -15,6 +15,7 @@ pub const CONFIG_FILE: &str = "audit.toml";
 
 /// `cargo audit` subcommands (presently only `audit`)
 #[derive(Command, Debug, Parser, Runnable)]
+#[clap(bin_name = "cargo")]
 pub enum CargoAuditSubCommand {
     /// The `cargo audit` subcommand
     #[clap(about = "Audit Cargo.lock files for vulnerable crates")]


### PR DESCRIPTION
This adjusts the help usage section of `cargo-audit` to `cargo audit` instead of `cargo-audit audit`.