### PR TITLE
Add vulnerability severity to the cargo-audit report presenter

### DIFF
--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -323,6 +323,14 @@ impl Presenter {
         } else if let Some(url) = &metadata.url {
             self.print_attr(color, "URL:      ", url);
         }
+
+        if let Some(cvss) = &metadata.cvss {
+            self.print_attr(
+                color,
+                "Severity: ",
+                format!("{}, {}", cvss.score().value(), cvss.score().severity()),
+            );
+        }
     }
 
     /// Display an attribute of a particular vulnerability


### PR DESCRIPTION
Closes #746 

I put the score and severity on a single line (see below) as I felt that it did not warrant two lines. I am happy to change this if there are reasons to split them.

```
Crate:     base64
Version:   0.5.1
Title:     Integer overflow leads to heap-based buffer overflow in encode_config_buf
Date:      2017-05-03
ID:        RUSTSEC-2017-0004
URL:       https://rustsec.org/advisories/RUSTSEC-2017-0004
Severity:  9.8, critical
Solution:  Upgrade to >=0.5.2
Dependency tree:
base64 0.5.1
└── base64_vuln 0.1.0

error: 1 vulnerability found!
```