### PR TITLE
Better the formatting of severity output

### DIFF
--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -328,7 +328,7 @@ impl Presenter {
             self.print_attr(
                 color,
                 "Severity: ",
-                format!("{}, {}", cvss.score().value(), cvss.score().severity()),
+                format!("{} ({})", cvss.score().value(), cvss.score().severity()),
             );
         }
     }


### PR DESCRIPTION
Better formatting of the severity output in cargo audit as mentioned by @tarcieri  [here](https://github.com/rustsec/rustsec/pull/825#discussion_r1132517108).

```
Crate:     base64
Version:   0.5.1
Title:     Integer overflow leads to heap-based buffer overflow in encode_config_buf
Date:      2017-05-03
ID:        RUSTSEC-2017-0004
URL:       https://rustsec.org/advisories/RUSTSEC-2017-0004
Severity:  9.8 (critical)
Solution:  Upgrade to >=0.5.2
```