### PR TITLE
rustsec: Fix git2 via cargo-edit-9 fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,11 +303,11 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "concolor-control",
- "crates-index 0.19.7",
+ "crates-index",
  "dirs-next",
  "dunce",
  "env_proxy",
- "git2 0.16.1",
+ "git2",
  "hex",
  "indexmap",
  "native-tls",
@@ -532,32 +532,11 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.18.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599f67b56f40863598cb30450427049935d05de2e36c61d33c050f04d7ec8cf2"
-dependencies = [
- "git2 0.15.0",
- "hex",
- "home",
- "memchr",
- "num_cpus",
- "rayon",
- "rustc-hash",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "smartstring",
- "toml 0.5.11",
-]
-
-[[package]]
-name = "crates-index"
 version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ddd986d8b0405750d3da55a36cfa5ddad74a6dbf8826dec1cae40bf1218bd4"
 dependencies = [
- "git2 0.16.1",
+ "git2",
  "hex",
  "home",
  "memchr",
@@ -933,21 +912,6 @@ name = "gimli"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
-
-[[package]]
-name = "git2"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
 
 [[package]]
 name = "git2"
@@ -1788,10 +1752,10 @@ version = "0.26.4"
 dependencies = [
  "cargo-edit-9",
  "cargo-lock 8.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-index 0.18.11",
+ "crates-index",
  "cvss",
  "fs-err",
- "git2 0.16.1",
+ "git2",
  "home",
  "humantime",
  "humantime-serde",
@@ -1815,7 +1779,7 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
- "crates-index 0.18.11",
+ "crates-index",
  "once_cell",
  "rust-embed",
  "rustsec",
@@ -1991,18 +1955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "serde",
- "static_assertions",
- "version_check",
-]
-
-[[package]]
 name = "smol_str"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,12 +1979,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,20 +294,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-edit"
-version = "0.9.1"
+name = "cargo-edit-9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34965aea9b211a43ace81105894e2e2d15103be244884b31f26065e7538fe30b"
+checksum = "c5dc02a722a6b1fc8f825e3797bc3d823c8df738dcd48744b77462a9ce597122"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
  "concolor-control",
- "crates-index",
+ "crates-index 0.19.7",
  "dirs-next",
  "dunce",
  "env_proxy",
- "git2",
+ "git2 0.16.1",
  "hex",
  "indexmap",
  "native-tls",
@@ -536,7 +536,7 @@ version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599f67b56f40863598cb30450427049935d05de2e36c61d33c050f04d7ec8cf2"
 dependencies = [
- "git2",
+ "git2 0.15.0",
  "hex",
  "home",
  "memchr",
@@ -549,6 +549,27 @@ dependencies = [
  "serde_json",
  "smartstring",
  "toml 0.5.11",
+]
+
+[[package]]
+name = "crates-index"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ddd986d8b0405750d3da55a36cfa5ddad74a6dbf8826dec1cae40bf1218bd4"
+dependencies = [
+ "git2 0.16.1",
+ "hex",
+ "home",
+ "memchr",
+ "num_cpus",
+ "rayon",
+ "rustc-hash",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smol_str",
+ "toml 0.7.2",
 ]
 
 [[package]]
@@ -915,9 +936,24 @@ checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "git2"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
+name = "git2"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -1149,9 +1185,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.5+1.4.5"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",
@@ -1516,7 +1552,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "platforms"
-version = "3.0.2"
+version = "3.1.0"
 dependencies = [
  "serde",
 ]
@@ -1750,12 +1786,12 @@ dependencies = [
 name = "rustsec"
 version = "0.26.4"
 dependencies = [
- "cargo-edit",
+ "cargo-edit-9",
  "cargo-lock 8.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-index",
+ "crates-index 0.18.11",
  "cvss",
  "fs-err",
- "git2",
+ "git2 0.16.1",
  "home",
  "humantime",
  "humantime-serde",
@@ -1779,7 +1815,7 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
- "crates-index",
+ "crates-index 0.18.11",
  "once_cell",
  "rust-embed",
  "rustsec",
@@ -1964,6 +2000,15 @@ dependencies = [
  "serde",
  "static_assertions",
  "version_check",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -16,7 +16,7 @@ atom_syndication = "0.12"
 chrono = { version = "0.4", default-features = false, features = ["clock"]  }
 clap = "3"
 comrak = { version = "0.16", default-features = false }
-crates-index = "0.18"
+crates-index = "0.19"
 rust-embed = "6.4.2"
 rustsec = { version = "0.26", path = "../rustsec", features = ["osv-export"] }
 serde = { version = "1", features = ["serde_derive"] }

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -24,9 +24,9 @@ toml = "0.7"
 url = { version = "2", features = ["serde"] }
 
 # optional dependencies
-cargo-edit = { version = "0.9", optional = true, default-features = false,  features = ["upgrade"] }
+cargo-edit = { version = "0.9", package = "cargo-edit-9", optional = true, default-features = false,  features = ["upgrade"] }
 crates-index = { version = "0.18", optional = true }
-git2 = { version = ">= 0.14, < 0.16", optional = true }
+git2 = { version = "0.16.1", optional = true }
 home = { version = "0.5", optional = true }
 humantime = { version = "2", optional = true }
 humantime-serde = { version = "1", optional = true }

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -25,7 +25,7 @@ url = { version = "2", features = ["serde"] }
 
 # optional dependencies
 cargo-edit = { version = "0.9", package = "cargo-edit-9", optional = true, default-features = false,  features = ["upgrade"] }
-crates-index = { version = "0.18", optional = true }
+crates-index = { version = "0.19", optional = true }
 git2 = { version = "0.16.1", optional = true }
 home = { version = "0.5", optional = true }
 humantime = { version = "2", optional = true }


### PR DESCRIPTION
Fixes #830 
Supercedes #801 

`packed_simd_2` is similar how it's used. Can use this and gradually do something about it e.g. minify it for our purposes.

I've worked 0.9 with dependency bumps to: https://github.com/pinkforest/cargo-edit-9

crates-index also has to be bumped to 0.19 that picks up 0.16 git2

This was according to recommendation here:
- https://github.com/killercup/cargo-edit/issues/837#issuecomment-1405714199