### PR TITLE
feature: render third-party crates json as API

### DIFF
--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -573,6 +573,8 @@ fn render_api(db: &Database, output_folder: &Path) {
         fs::create_dir(api_path).unwrap();
     }
     for (package, advisories) in map {
+        // Replace dashes with underscores to make the conssistent format
+        let package = package.as_str().replace("-", "_");
         let mut file = std::fs::File::create(api_path.join(format!("{package}.json"))).unwrap();
         let json = serde_json::to_string_pretty(&advisories).unwrap();
         file.write_all(json.as_bytes()).unwrap();

--- a/rustsec/src/osv/advisory.rs
+++ b/rustsec/src/osv/advisory.rs
@@ -138,7 +138,7 @@ impl From<Affected> for OsvEcosystemSpecificAffected {
         OsvEcosystemSpecificAffected {
             arch: a.arch,
             os: a.os,
-            functions: a.functions.into_iter().map(|(f, _v)| f).collect(),
+            functions: a.functions.into_keys().collect(),
         }
     }
 }


### PR DESCRIPTION
This PR aimed to provide an Open API for vulnerability advisories of third-party crates.

The approach is to render each crate as a JSON file:

```
$ tree _site/api
_site/api
├── abi_stable.json
├── abomonation.json
├── abox.json
├── acc_reader.json
├── actix_codec.json
├── actix_http.json
├── actix_service.json
├── actix_utils.json
├── actix_web.json
....
├── ws.json
├── xcb.json
├── xml_rs.json
├── yaml_rust.json
├── yottadb.json
└── zeroize_derive.json

0 directories, 409 files
```

The user can use `curl` command to fetch the vulnerability info about the given crate.
The API format is https://rustsec.org/api/{crate_name}.json, for example:
`curl https://rustsec.org/api/actix_web.json` will get the json response :

```json
[
  {
    "advisory": {
      "id": "RUSTSEC-2018-0019",
      "package": "actix-web",
      "title": "Multiple memory safety issues",
      "description": "Affected versions contain multiple memory safety issues, such as:\n\n - Unsoundly coercing immutable references to mutable references\n - Unsoundly extending lifetimes of strings\n - Adding the `Send` marker trait to objects that cannot be safely sent between threads\n\nThis may result in a variety of memory corruption scenarios, most likely use-after-free.\n \nA significant refactoring effort has been conducted to resolve these issues.",
      "date": "2018-06-08",
      "aliases": [],
      "related": [],
      "collection": "crates",
      "categories": [
        "memory-corruption"
      ],
      "keywords": [],
      "cvss": null,
      "informational": null,
      "references": [],
      "source": null,
      "url": "https://github.com/actix/actix-web/issues/289",
      "withdrawn": null
    },
    "affected": null,
    "versions": {
      "patched": [
        ">=0.7.15"
      ],
      "unaffected": []
    }
  }
]
```