### PR TITLE
Fix #736 - Cargo audit self advisories repeated

### DIFF
--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -146,7 +146,14 @@ impl Auditor {
 
         self.presenter.before_report(lockfile_path, &lockfile);
 
-        self.audit(&lockfile, None)
+        let report = self.audit(&lockfile, None);
+
+        let self_advisories = self.self_advisories();
+
+        self.presenter
+            .print_self_report(self_advisories.as_slice());
+
+        report
     }
 
     #[cfg(feature = "binary-scanning")]
@@ -170,6 +177,12 @@ impl Auditor {
                 }
             }
         }
+
+        let self_advisories = self.self_advisories();
+
+        self.presenter
+            .print_self_report(self_advisories.as_slice());
+
         if self
             .presenter
             .should_exit_with_failure_due_to_self(&self.self_advisories())
@@ -212,10 +225,8 @@ impl Auditor {
                 .append(&mut yanked);
         }
 
-        let self_advisories = self.self_advisories();
-
         self.presenter
-            .print_report(&report, self_advisories.as_slice(), lockfile, path);
+            .print_report(&report, lockfile, path);
 
         Ok(report)
     }

--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -150,8 +150,7 @@ impl Auditor {
 
         let self_advisories = self.self_advisories();
 
-        self.presenter
-            .print_self_report(self_advisories.as_slice());
+        self.presenter.print_self_report(self_advisories.as_slice());
 
         report
     }
@@ -180,8 +179,7 @@ impl Auditor {
 
         let self_advisories = self.self_advisories();
 
-        self.presenter
-            .print_self_report(self_advisories.as_slice());
+        self.presenter.print_self_report(self_advisories.as_slice());
 
         if self
             .presenter
@@ -225,8 +223,7 @@ impl Auditor {
                 .append(&mut yanked);
         }
 
-        self.presenter
-            .print_report(&report, lockfile, path);
+        self.presenter.print_report(&report, lockfile, path);
 
         Ok(report)
     }

--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -98,7 +98,6 @@ impl Presenter {
     pub fn print_report(
         &mut self,
         report: &rustsec::Report,
-        self_advisories: &[rustsec::Advisory],
         lockfile: &Lockfile,
         path: Option<&Path>,
     ) {
@@ -123,25 +122,6 @@ impl Presenter {
             for warning in warnings.iter() {
                 self.print_warning(warning, &tree)
             }
-        }
-
-        // Print out any self-advisories
-        if !self_advisories.is_empty() {
-            let msg = "This copy of cargo-audit has known advisories!";
-
-            if self.config.deny.contains(&DenyOption::Warnings) {
-                status_err!(msg);
-            } else {
-                status_warn!(msg);
-            }
-
-            for advisory in self_advisories {
-                self.print_metadata(
-                    &advisory.metadata,
-                    self.warning_color(self.config.deny.contains(&DenyOption::Warnings)),
-                );
-            }
-            println!();
         }
 
         if report.vulnerabilities.found {
@@ -196,17 +176,30 @@ impl Presenter {
                 }
             }
         }
+    }
 
-        if !self_advisories.is_empty() {
-            let upgrade_msg = "upgrade cargo-audit to the latest version: \
-                               cargo install --force cargo-audit";
-
-            if self.config.deny.contains(&DenyOption::Warnings) {
-                status_err!(upgrade_msg);
-            } else {
-                status_warn!(upgrade_msg);
-            }
+    /// Print the vulnerability report for cargo-audit
+    pub fn print_self_report(&mut self, self_advisories: &[rustsec::Advisory]) {
+        if self_advisories.is_empty() {
+            return;
         }
+        // Print out any self-advisories
+        let msg = "This copy of cargo-audit has known advisories! Upgrade cargo-audit to the \
+        latest version: cargo install --force cargo-audit";
+
+        if self.config.deny.contains(&DenyOption::Warnings) {
+            status_err!(msg);
+        } else {
+            status_warn!(msg);
+        }
+
+        for advisory in self_advisories {
+            self.print_metadata(
+                &advisory.metadata,
+                self.warning_color(self.config.deny.contains(&DenyOption::Warnings)),
+            );
+        }
+        println!();
     }
 
     /// Determines whether the process should exit with failure based on configuration


### PR DESCRIPTION
`audit()` was called by both the binary, multi binary and lockfile paths. This included a call to check for self advisories against cargo-audit.
For multi-binary this no only printed the results of self scanning multiple times but ran the checks multiple times.

Now the lockfile and binary execution paths check for self issues and print the results.

I have also combined the two older checks to a single check and message.

Tests pass but I believe there are no tests covering this.