### PR TITLE
Various improvements to the "cargo-lock tree" subcommand

### DIFF
--- a/cargo-lock/src/bin/cargo-lock/main.rs
+++ b/cargo-lock/src/bin/cargo-lock/main.rs
@@ -128,12 +128,17 @@ impl TranslateCmd {
 #[derive(Debug, Options)]
 struct TreeCmd {
     /// Input `Cargo.lock` file
-    #[options(short = "f", help = "input Cargo.lock file to translate")]
+    #[options(
+        short = "f",
+        long = "file",
+        help = "input Cargo.lock file to translate"
+    )]
     file: Option<PathBuf>,
 
     /// Show exact package identities (checksums or specific source versions) when available
     #[options(
         short = "x",
+        long = "exact",
         help = "show exact package identies (checksums or specific source versions) when available"
     )]
     exact: bool,
@@ -141,6 +146,7 @@ struct TreeCmd {
     // Show inverse dependencies rather than forward dependencies
     #[options(
         short = "i",
+        long = "invert",
         help = "show inverse dependencies _on_ a package, rather than forward dependencies _of_ a package"
     )]
     inverse: bool,
@@ -151,7 +157,7 @@ struct TreeCmd {
 }
 
 fn package_matches_name(pkg: &Package, name: &str) -> bool {
-    pkg.name.as_str().contains(name)
+    pkg.name.as_str() == name
 }
 
 fn package_matches_ver(pkg: &Package, ver: &str) -> bool {
@@ -162,13 +168,13 @@ fn package_matches_ver(pkg: &Package, ver: &str) -> bool {
     // Try comparing ver to hashes in either the package checksum or the source
     // precise field
     if let Some(cksum) = &pkg.checksum {
-        if cksum.to_string().contains(ver) {
+        if cksum.to_string() == ver {
             return true;
         }
     }
     if let Some(src) = &pkg.source {
         if let Some(precise) = src.precise() {
-            if precise.contains(ver) {
+            if precise == ver {
                 return true;
             }
         }

--- a/cargo-lock/src/bin/cargo-lock/main.rs
+++ b/cargo-lock/src/bin/cargo-lock/main.rs
@@ -7,13 +7,15 @@ use cargo_lock::{
     dependency::graph::EdgeDirection,
     dependency::Tree,
     package::{self},
-    Dependency, Lockfile, ResolveVersion,
+    Dependency, Lockfile, Package, ResolveVersion, Version,
 };
 use gumdrop::Options;
+use petgraph::graph::NodeIndex;
 use std::{
     env, fs, io,
     path::{Path, PathBuf},
     process::exit,
+    str::FromStr,
 };
 
 /// `cargo lock` subcommands
@@ -129,9 +131,57 @@ struct TreeCmd {
     #[options(short = "f", help = "input Cargo.lock file to translate")]
     file: Option<PathBuf>,
 
-    /// Dependencies names to draw a tree for
-    #[options(free, help = "dependency names to draw trees for")]
-    dependencies: Vec<package::Name>,
+    /// Show exact package identities (checksums or specific source versions) when available
+    #[options(
+        short = "x",
+        help = "show exact package identies (checksums or specific source versions) when available"
+    )]
+    exact: bool,
+
+    // Show inverse dependencies rather than forward dependencies
+    #[options(
+        short = "i",
+        help = "show inverse dependencies _on_ a package, rather than forward dependencies _of_ a package"
+    )]
+    inverse: bool,
+
+    /// Dependencies names or hashes to draw a tree for
+    #[options(free, help = "dependency names or hashes to draw trees for")]
+    dependencies: Vec<String>,
+}
+
+fn package_matches_name(pkg: &Package, name: &str) -> bool {
+    pkg.name.as_str().contains(name)
+}
+
+fn package_matches_ver(pkg: &Package, ver: &str) -> bool {
+    // Try interpreting ver as a semver string.
+    if let Ok(v) = Version::from_str(ver) {
+        return pkg.version == v;
+    }
+    // Try comparing ver to hashes in either the package checksum or the source
+    // precise field
+    if let Some(cksum) = &pkg.checksum {
+        if cksum.to_string().contains(ver) {
+            return true;
+        }
+    }
+    if let Some(src) = &pkg.source {
+        if let Some(precise) = src.precise() {
+            if precise.contains(ver) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn package_matches(pkg: &Package, spec: &str) -> bool {
+    if let Some((name, ver)) = spec.split_once('@') {
+        package_matches_name(pkg, name) && package_matches_ver(pkg, ver)
+    } else {
+        package_matches_name(pkg, spec) || package_matches_ver(pkg, spec)
+    }
 }
 
 impl TreeCmd {
@@ -144,43 +194,40 @@ impl TreeCmd {
             exit(1);
         });
 
-        if self.dependencies.is_empty() {
-            self.dependency_tree(&tree);
+        let indices: Vec<NodeIndex> = if self.dependencies.is_empty() {
+            tree.roots().to_vec()
         } else {
-            self.inverse_dependency_tree(&lockfile, &tree);
-        }
-    }
-
-    /// Show forward dependency tree for detected root dependencies
-    fn dependency_tree(&self, tree: &Tree) {
-        for (i, index) in tree.roots().iter().enumerate() {
-            if i > 0 {
-                println!();
-            }
-
-            tree.render(&mut io::stdout(), *index, EdgeDirection::Outgoing)
-                .unwrap();
-        }
-    }
-
-    /// Show inverse dependency tree for the provided dependencies
-    fn inverse_dependency_tree(&self, lockfile: &Lockfile, tree: &Tree) {
-        for (i, dep) in self.dependencies.iter().enumerate() {
-            if i > 0 {
-                println!();
-            }
-
-            let package = lockfile
-                .packages
+            self.dependencies
                 .iter()
-                .find(|pkg| pkg.name == *dep)
-                .unwrap_or_else(|| {
-                    eprintln!("*** error: invalid dependency name: `{}`", dep);
-                    exit(1);
-                });
+                .map(|dep| {
+                    let package = lockfile
+                        .packages
+                        .iter()
+                        .find(|pkg| package_matches(pkg, dep))
+                        .unwrap_or_else(|| {
+                            eprintln!("*** error: invalid dependency name: `{}`", dep);
+                            exit(1);
+                        });
+                    tree.nodes()[&package.into()]
+                })
+                .collect()
+        };
 
-            let index = tree.nodes()[&package.into()];
-            tree.render(&mut io::stdout(), index, EdgeDirection::Incoming)
+        self.dependency_tree(&tree, &indices);
+    }
+
+    /// Show dependency tree for the provided dependencies
+    fn dependency_tree(&self, tree: &Tree, indices: &[NodeIndex]) {
+        for (i, index) in indices.iter().enumerate() {
+            if i > 0 {
+                println!();
+            }
+            let direction = if self.inverse {
+                EdgeDirection::Incoming
+            } else {
+                EdgeDirection::Outgoing
+            };
+            tree.render(&mut io::stdout(), *index, direction, self.exact)
                 .unwrap();
         }
     }


### PR DESCRIPTION
This adds a few improvements to the `cargo-lock tree` subcommand:

1. Separates the decision of "should we print trees related to specific packages or all the roots" from the decision of "forward tree or inverse tree", giving the latter its own option (`-i`) and thereby allowing specific package selection for either forward or inverse trees.
2. Allows selecting packages by name, version, hash, or name@version-or-hash
3. Adds an option `-x` for printing "exact" information about each found dependency, in the form of either its sha256 package checksum or, if that's not found, its package source (which usually contains a precise git hash)

These changes are necessary to support a specific use-case I have, where I've got multiple versions of the same crate as a dependency and I want to separately inspect (and pin) each of those versions _and all their dependencies_, despite the fact that they share a number of dependencies with one another and with other crates in the final program (which makes it difficult to eyeball a change to the lockfile and infer which subtree is being affected).

This at least lets me run commands like so:

~~~
$ cargo-lock tree -x rand@6a6b167
rand 0.7.3 checksum:6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03
├── rand_hc 0.2.0 checksum:ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c
│   └── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19
│       └── getrandom 0.1.16 checksum:8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce
│           ├── wasi 0.9.0+wasi-snapshot-preview1 checksum:cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519
│           ├── libc 0.2.140 checksum:99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c
│           └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
├── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19
├── rand_chacha 0.2.2 checksum:f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402
│   ├── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19
│   └── ppv-lite86 0.2.17 checksum:5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de
├── libc 0.2.140 checksum:99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c
└── getrandom 0.1.16 checksum:8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce
~~~
