### PR TITLE
cargo-lock v9.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ba7d807ad2850c436750154dbc442eb8611527deb6dfcc4e5e0bd10d5fbf28"
 dependencies = [
- "cargo-lock 8.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 8.0.3",
  "semver",
  "serde",
  "serde_json",
@@ -281,7 +281,7 @@ dependencies = [
  "auditable-info",
  "auditable-serde",
  "binfarce",
- "cargo-lock 8.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 8.0.3",
  "clap",
  "home",
  "once_cell",
@@ -328,18 +328,6 @@ dependencies = [
 [[package]]
 name = "cargo-lock"
 version = "8.0.3"
-dependencies = [
- "gumdrop",
- "petgraph",
- "semver",
- "serde",
- "toml 0.7.2",
- "url",
-]
-
-[[package]]
-name = "cargo-lock"
-version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
@@ -347,6 +335,18 @@ dependencies = [
  "semver",
  "serde",
  "toml 0.5.11",
+ "url",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "9.0.0"
+dependencies = [
+ "gumdrop",
+ "petgraph",
+ "semver",
+ "serde",
+ "toml 0.7.2",
  "url",
 ]
 
@@ -1706,7 +1706,7 @@ name = "rustsec"
 version = "0.26.5"
 dependencies = [
  "cargo-edit-9",
- "cargo-lock 8.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-lock 8.0.3",
  "crates-index",
  "cvss",
  "fs-err",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 9.0.0 (2023-04-24)
+### Added
+- Implement `From<Name>` for `String` ([#776])
+- Support sparse registry references in `Lockfile`s ([#780])
+
+### Changed
+- Mark `SourceKind` as `#[non_exhaustive]` ([#793])
+- Use `Display` for `io::ErrorKind`; MSRV 1.60 ([#794])
+- Bump `toml` to 0.7 ([#800], [#805])
+- Improvements to the `cargo lock tree` subcommand ([#860])
+
+### Fixed
+- `Source::is_default_registry` for sparse index ([#859])
+
+[#776]: https://github.com/RustSec/rustsec/pull/776
+[#780]: https://github.com/RustSec/rustsec/pull/780
+[#793]: https://github.com/RustSec/rustsec/pull/793
+[#794]: https://github.com/RustSec/rustsec/pull/794
+[#800]: https://github.com/RustSec/rustsec/pull/800
+[#805]: https://github.com/RustSec/rustsec/pull/805
+[#859]: https://github.com/RustSec/rustsec/pull/859
+[#860]: https://github.com/RustSec/rustsec/pull/860
+
 ## 8.0.3 (2022-11-30)
 ### Fixed
 - Encoding inconsistency when there's only one registry for all packages ([#767])

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "8.0.3"
+version      = "9.0.0"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"


### PR DESCRIPTION
### Added
- Implement `From<Name>` for `String` ([#776])
- Support sparse registry references in `Lockfile`s ([#780])

### Changed
- Mark `SourceKind` as `#[non_exhaustive]` ([#793])
- Use `Display` for `io::ErrorKind`; MSRV 1.60 ([#794])
- Bump `toml` to 0.7 ([#800], [#805])
- Improvements to the `cargo lock tree` subcommand ([#860])

### Fixed
- `Source::is_default_registry` for sparse index ([#859])

[#776]: https://github.com/RustSec/rustsec/pull/776
[#780]: https://github.com/RustSec/rustsec/pull/780
[#793]: https://github.com/RustSec/rustsec/pull/793
[#794]: https://github.com/RustSec/rustsec/pull/794
[#800]: https://github.com/RustSec/rustsec/pull/800
[#805]: https://github.com/RustSec/rustsec/pull/805
[#859]: https://github.com/RustSec/rustsec/pull/859
[#860]: https://github.com/RustSec/rustsec/pull/860