### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.60.0 # MSRV
           override: true
           profile: minimal
       - run: cargo doc --all-features

--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.60.0 # MSRV
           override: true
           profile: minimal
       - run: cargo doc --all-features


### PR DESCRIPTION
Workaround for rust-lang/rust#109266

This pins the docs build to MSRV, which should prevent regressions where new releases break the docs build.