### PR TITLE
🔥 Remove $ from install snippet on README

### DIFF
--- a/cargo-lock/README.md
+++ b/cargo-lock/README.md
@@ -41,7 +41,7 @@ accompanied by a minor version bump.
 This crate provides a `cargo lock` subcommand which can be installed with:
 
 ```text
-$ cargo install cargo-lock --features=cli
+cargo install cargo-lock --features=cli
 ```
 
 It supports the following subcommands:


### PR DESCRIPTION
Fixes syntax error if copied text is executed verbatim