### PR TITLE
Update integration test to lower runtimes

### DIFF
--- a/cargo-audit/tests/acceptance.rs
+++ b/cargo-audit/tests/acceptance.rs
@@ -26,7 +26,7 @@ static ADVISORY_DB_DIR: Lazy<TempDir> = Lazy::new(|| TempDir::new().unwrap());
 /// be multithreaded invocations as `cargo test` executes tests in
 /// parallel by default.
 pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| {
-    let mut runner = CmdRunner::new(env!("CARGO_BIN_EXE_CARGO_AUDIT"));
+    let mut runner = CmdRunner::new(env!("CARGO_BIN_EXE_cargo-audit"));
     runner.arg("audit").arg("--db").arg(ADVISORY_DB_DIR.path());
     runner.exclusive().capture_stdout().capture_stderr();
     runner

--- a/cargo-audit/tests/acceptance.rs
+++ b/cargo-audit/tests/acceptance.rs
@@ -26,9 +26,9 @@ static ADVISORY_DB_DIR: Lazy<TempDir> = Lazy::new(|| TempDir::new().unwrap());
 /// be multithreaded invocations as `cargo test` executes tests in
 /// parallel by default.
 pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| {
-    let mut runner = CmdRunner::default();
+    let mut runner = CmdRunner::new(env!("CARGO_BIN_EXE_CARGO_AUDIT"));
     runner.arg("audit").arg("--db").arg(ADVISORY_DB_DIR.path());
-    runner.capture_stdout().capture_stderr();
+    runner.exclusive().capture_stdout().capture_stderr();
     runner
 });
 

--- a/cargo-audit/tests/binary_scanning.rs
+++ b/cargo-audit/tests/binary_scanning.rs
@@ -13,7 +13,7 @@ use tempfile::TempDir;
 static ADVISORY_DB_DIR: Lazy<TempDir> = Lazy::new(|| TempDir::new().unwrap());
 
 /// Executes target binary directly.
-/// Invoke the test with `cargo t --all-features` 
+/// Invoke the test with `cargo t --all-features`
 ///
 /// Storing this value in a `once_cell::sync::Lazy` ensures that all
 /// instances of the runner acquire a mutex when executing commands

--- a/cargo-audit/tests/binary_scanning.rs
+++ b/cargo-audit/tests/binary_scanning.rs
@@ -12,7 +12,8 @@ use tempfile::TempDir;
 /// Instead use a single DB we tear down on test suite exit.
 static ADVISORY_DB_DIR: Lazy<TempDir> = Lazy::new(|| TempDir::new().unwrap());
 
-/// Executes target binary via `cargo run`.
+/// Executes target binary directly.
+/// Invoke the test with `cargo t --all-features` 
 ///
 /// Storing this value in a `once_cell::sync::Lazy` ensures that all
 /// instances of the runner acquire a mutex when executing commands
@@ -20,9 +21,7 @@ static ADVISORY_DB_DIR: Lazy<TempDir> = Lazy::new(|| TempDir::new().unwrap());
 /// be multithreaded invocations as `cargo test` executes tests in
 /// parallel by default.
 pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| {
-    // reimplement CmdRunner::default but with --all-features flag
-    let mut runner = CmdRunner::new("cargo");
-    runner.args(["run", "--all-features", "--"]);
+    let mut runner = CmdRunner::new(env!("CARGO_BIN_EXE_cargo-audit"));
     runner.exclusive();
     runner.capture_stdout();
     runner.capture_stderr();


### PR DESCRIPTION
Does this have any downsides? It should speed up the integration tests overall?

could also help with #832

related: https://github.com/iqlusioninc/abscissa/issues/845