### PR TITLE
Faster CI for `cargo audit` tests

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -47,7 +47,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           profile: minimal
           override: true
-      - run: cargo test --all-features --release
+      - run: cargo test --all-features
 
   test-macos:
     runs-on: macos-latest
@@ -58,7 +58,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - run: cargo test --all-features --release
+      - run: cargo test --all-features
 
   test-windows:
     runs-on: windows-latest
@@ -69,7 +69,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - run: cargo test --all-features --release
+      - run: cargo test --all-features
 
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -37,19 +37,11 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.67.0 # MSRV
+          - 1.71.0 # sparse index by default for faster CI
           - stable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -61,14 +53,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -80,14 +64,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -101,7 +77,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.67.0 # MSRV
+          toolchain: 1.71.0 # sparse index by default for faster CI
           override: true
           profile: minimal
       - run: cargo doc --all-features

--- a/.github/workflows/quitters.yml
+++ b/.github/workflows/quitters.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0
+          - 1.67.0 # MSRV of `cargo audit`, should be bumped in tandem
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.67.0 # MSRV
+          - 1.71.0 # sparse index by default for faster CI
           - stable
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.67.0 # MSRV
+          toolchain: 1.71.0 # sparse index by default for faster CI
           override: true
           profile: minimal
       - run: cargo doc --all-features

--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -36,9 +36,9 @@ jobs:
           override: true
           profile: minimal
       - run: cargo check
-      - run: cargo test --no-default-features --release
-      - run: cargo test --release
-      - run: cargo test --all-features --release
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --all-features
 
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # sparse index by default for faster CI
+          - 1.67.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71.0 # sparse index by default for faster CI
+          toolchain: 1.67.0 # MSRV
           override: true
           profile: minimal
       - run: cargo doc --all-features

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.67.0
+          toolchain: 1.67.0 # MSRV
           components: clippy
           override: true
           profile: minimal

--- a/cargo-audit/tests/binary_scanning.rs
+++ b/cargo-audit/tests/binary_scanning.rs
@@ -20,13 +20,7 @@ static ADVISORY_DB_DIR: Lazy<TempDir> = Lazy::new(|| TempDir::new().unwrap());
 /// be multithreaded invocations as `cargo test` executes tests in
 /// parallel by default.
 pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| {
-    // reimplement CmdRunner::default but with --all-features flag
-    let mut runner = CmdRunner::new("cargo");
-    runner.args(["run", "--all-features", "--"]);
-    runner.exclusive();
-    runner.capture_stdout();
-    runner.capture_stderr();
-    // feed it the command-line arguments specific to the test
+    let mut runner = CmdRunner::default();
     runner
         .arg("audit")
         .arg("bin")


### PR DESCRIPTION
Speeds up CI by:

1. Running `cargo test` without the `--release` flag, avoiding compiling the code twice (tests are run with `cargo run` without `--release`)
1. Using the sparse index instead of fetching crates.io index via git, which would cause a regression in test performance (`gix` and its deps such as `miniz_oxide` compiled in debug mode)

The Rust toolchain is bumped to v1.71 for sparse index support but MSRV is still enforced by the `workspace` job.