### PR TITLE
Revert "Re-enable self-audit"

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -86,16 +86,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --all-features
 
-  self-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: Swatinem/rust-cache@v2
-      - name: Run cargo audit
-        run: cargo generate-lockfile
-        run: cargo run -- audit
+# TODO(tarcieri): re-enable after vulnerable deps have been upgraded
+#  self-audit:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          profile: minimal
+#          override: true
+#      - name: Run cargo audit
+#        run: cargo run -- audit


### PR DESCRIPTION
Reverts rustsec/rustsec#931

CI passing was misleading: the added test was simply not run.