### PR TITLE
Foolproof API for the cached index

### DIFF
--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -243,26 +243,24 @@ impl Auditor {
     fn check_for_yanked_crates(&mut self, lockfile: &Lockfile) -> Vec<Warning> {
         let mut result = Vec::new();
         if let Some(index) = &mut self.registry_index {
-
-            let pkgs_to_check: Vec<_> = lockfile.packages.iter().filter(|pkg| {
-                match &pkg.source {
+            let pkgs_to_check: Vec<_> = lockfile
+                .packages
+                .iter()
+                .filter(|pkg| match &pkg.source {
                     Some(source) => source.is_default_registry(),
                     None => false,
-                }
-            } ).collect();
+                })
+                .collect();
 
             let yanked = index.find_yanked(pkgs_to_check);
-            
+
             for pkg in yanked {
                 match pkg {
                     Ok(pkg) => {
                         let warning = Warning::new(WarningKind::Yanked, pkg, None, None);
                         result.push(warning);
-                    },
-                    Err(e) => status_err!(
-                        "couldn't check if the package is yanked: {}",
-                        e
-                    ),
+                    }
+                    Err(e) => status_err!("couldn't check if the package is yanked: {}", e),
                 }
             }
         }

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -107,7 +107,7 @@ impl CachedIndex {
     }
 
     /// Populates the cache entries for all of the specified crates.
-    pub fn populate_cache(&mut self, packages: BTreeSet<&package::Name>) -> Result<(), Error> {
+    fn populate_cache(&mut self, packages: BTreeSet<&package::Name>) -> Result<(), Error> {
         match &self.index {
             Index::Git(_) | Index::SparseCached(_) => {
                 for pkg in packages {
@@ -179,7 +179,7 @@ impl CachedIndex {
     }
 
     /// Is the given package yanked?
-    pub fn is_yanked(&mut self, package: &Package) -> Result<bool, Error> {
+    fn is_yanked(&mut self, package: &Package) -> Result<bool, Error> {
         if !self.cache.contains_key(&package.name) {
             self.insert(package.name.to_owned(), self.index.krate(&package.name));
         }

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -222,7 +222,7 @@ impl CachedIndex {
         let dedup_packages: BTreeSet<&Package> = packages.into_iter().collect();
         let package_names: BTreeSet<&package::Name> = dedup_packages.iter().map(|p| &p.name).collect();
         if let Err(e) = self.populate_cache(package_names) {
-            return vec![Err(e)];
+            yanked.push(Err(Error::new(ErrorKind::Registry, &format!("Failed to download crates.io index: {}\nData may be missing or stale when checking for yanked packages.", e))));
         }
 
         for package in dedup_packages {

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -1,5 +1,8 @@
 //! An efficient way to check whether a given package has been yanked
-use std::{collections::{BTreeSet, HashMap}, time::Duration};
+use std::{
+    collections::{BTreeSet, HashMap},
+    time::Duration,
+};
 
 use crate::{
     error::{Error, ErrorKind},

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -271,6 +271,7 @@ fn new_remote_git_index(
     index: tame_index::index::git::GitIndex,
     lock_timeout: Duration,
 ) -> Result<tame_index::index::RemoteGitIndex, tame_index::Error> {
+    use tame_index::external::gix;
     let lock_policy = if lock_timeout == Duration::from_secs(0) {
         gix::lock::acquire::Fail::Immediately
     } else {

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -9,8 +9,8 @@ use crate::{
     package::{self, Package},
 };
 
-pub use tame_index::external::reqwest::ClientBuilder;
 pub use tame_index::external::gix;
+pub use tame_index::external::reqwest::ClientBuilder;
 
 enum Index {
     Git(tame_index::index::RemoteGitIndex),

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 pub use tame_index::external::reqwest::ClientBuilder;
+pub use tame_index::external::gix;
 
 enum Index {
     Git(tame_index::index::RemoteGitIndex),
@@ -274,7 +275,6 @@ fn new_remote_git_index(
     index: tame_index::index::git::GitIndex,
     lock_timeout: Duration,
 ) -> Result<tame_index::index::RemoteGitIndex, tame_index::Error> {
-    use tame_index::external::gix;
     let lock_policy = if lock_timeout == Duration::from_secs(0) {
         gix::lock::acquire::Fail::Immediately
     } else {

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -210,6 +210,10 @@ impl CachedIndex {
 
     /// Iterate over the provided packages, returning a vector of the
     /// packages which have been yanked.
+    /// 
+    /// This function should be called with many packages at once rather than one by one;
+    /// that way it can download the status of a large number of packages at once from the sparse index
+    /// very quickly, orders of magnitude faster than requesting packages one by one.
     pub fn find_yanked<'a, I>(&mut self, packages: I) -> Vec<Result<&'a Package, Error>>
     where
         I: IntoIterator<Item = &'a Package>,

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -210,7 +210,7 @@ impl CachedIndex {
 
     /// Iterate over the provided packages, returning a vector of the
     /// packages which have been yanked.
-    /// 
+    ///
     /// This function should be called with many packages at once rather than one by one;
     /// that way it can download the status of a large number of packages at once from the sparse index
     /// very quickly, orders of magnitude faster than requesting packages one by one.

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -48,8 +48,7 @@ impl CachedIndex {
     /// If this opens a git index, it will perform a fetch to get the latest index
     /// information.
     ///
-    /// If this is a sparse index, you need to use [`Self::populate_cache`] to
-    /// fetch the latest information from the remote HTTP index.
+    /// If this is a sparse index, it will be downloaded later on demand.
     pub fn fetch(client: Option<ClientBuilder>) -> Result<Self, Error> {
         let index = tame_index::index::ComboIndexCache::new(tame_index::IndexLocation::new(
             tame_index::IndexUrl::crates_io(None, None, None)?,

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -32,10 +32,7 @@ impl Index {
 ///
 /// Operations on crates.io index are rather slow.
 /// Instead of peforming an index lookup for every version of every crate,
-/// this implementation looks up each crate only once and caches the result.
-/// This usually doesn't result in any dramatic performance wins
-/// when auditing a single `Cargo.lock` file because the same crate rarely appears multiple times,
-/// but makes a huge difference when auditing many `Cargo.lock`s or many binaries.
+/// this implementation looks up each crate only once and caches the result in memory.
 pub struct CachedIndex {
     index: Index,
     /// The inner hash map is logically HashMap<Version, IsYanked>
@@ -51,8 +48,8 @@ impl CachedIndex {
     /// If this opens a git index, it will perform a fetch to get the latest index
     /// information.
     ///
-    /// If this is a sparse index, it will allow [`Self::populate_cache`] to
-    /// fetch the latest information from the remote HTTP index
+    /// If this is a sparse index, you need to use [`Self::populate_cache`] to
+    /// fetch the latest information from the remote HTTP index.
     pub fn fetch(client: Option<ClientBuilder>) -> Result<Self, Error> {
         let index = tame_index::index::ComboIndexCache::new(tame_index::IndexLocation::new(
             tame_index::IndexUrl::crates_io(None, None, None)?,
@@ -86,11 +83,10 @@ impl CachedIndex {
 
     /// Open the local crates.io index
     ///
-    /// If this opens a git index, it allows reading of index entries from the
-    /// repository
+    /// If this opens a git index, it allows reading of index entries from the repository.
     ///
     /// If this is a sparse index, it only allows reading of index entries that
-    /// are already cached locally
+    /// are already cached locally.
     pub fn open() -> Result<Self, Error> {
         let index = tame_index::index::ComboIndexCache::new(tame_index::IndexLocation::new(
             tame_index::IndexUrl::crates_io(None, None, None)?,
@@ -110,9 +106,7 @@ impl CachedIndex {
         })
     }
 
-    /// Populates the cache entries for all of the specified crates
-    ///
-    /// This method is preferable to doing invidual updates via `cache_insert`/`is_yanked`
+    /// Populates the cache entries for all of the specified crates.
     pub fn populate_cache(
         &mut self,
         packages: std::collections::BTreeSet<&package::Name>,

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -1,5 +1,5 @@
 //! An efficient way to check whether a given package has been yanked
-use std::collections::{HashMap, BTreeSet};
+use std::collections::{BTreeSet, HashMap};
 
 use crate::{
     error::{Error, ErrorKind},
@@ -107,10 +107,7 @@ impl CachedIndex {
     }
 
     /// Populates the cache entries for all of the specified crates.
-    pub fn populate_cache(
-        &mut self,
-        packages: BTreeSet<&package::Name>,
-    ) -> Result<(), Error> {
+    pub fn populate_cache(&mut self, packages: BTreeSet<&package::Name>) -> Result<(), Error> {
         match &self.index {
             Index::Git(_) | Index::SparseCached(_) => {
                 for pkg in packages {
@@ -220,14 +217,17 @@ impl CachedIndex {
         let mut yanked = Vec::new();
 
         let dedup_packages: BTreeSet<&Package> = packages.into_iter().collect();
-        let package_names: BTreeSet<&package::Name> = dedup_packages.iter().map(|p| &p.name).collect();
+        let package_names: BTreeSet<&package::Name> =
+            dedup_packages.iter().map(|p| &p.name).collect();
         if let Err(e) = self.populate_cache(package_names) {
-            yanked.push(Err(Error::new(ErrorKind::Registry, &format!("Failed to download crates.io index: {}\nData may be missing or stale when checking for yanked packages.", e))));
+            yanked.push(Err(Error::new(ErrorKind::Registry,
+                &format!("Failed to download crates.io index: {}\nData may be missing or stale when checking for yanked packages.", e)
+            )));
         }
 
         for package in dedup_packages {
             match self.is_yanked(package) {
-                Ok(false) => {}, // not yanked, nothing to report
+                Ok(false) => {} // not yanked, nothing to report
                 Ok(true) => yanked.push(Ok(package)),
                 Err(error) => yanked.push(Err(error)),
             }

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -7,6 +7,7 @@ use std::{
 };
 use thiserror::Error;
 
+#[cfg(feature = "git")]
 use tame_index::external::gix;
 
 /// Create a new error (of a given enum variant) with a formatted message

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -7,6 +7,8 @@ use std::{
 };
 use thiserror::Error;
 
+use tame_index::external::gix;
+
 /// Create a new error (of a given enum variant) with a formatted message
 macro_rules! format_err {
     ($kind:path, $msg:expr) => {


### PR DESCRIPTION
Cleaning up the APIs after the addition of sparse index support in #923:

 - Make `find_yanked()` automatically populate the cache
 - Make `is_yanked()` private because of the performance pitfall of calling it in a loop without populating cache first.
   - With it gone, there is no reason to expose `populate_cache()` publicly, so make it private too.
 - Adjust `cargo-audit` code accordingly
 - Slightly improve documentation

@Jake-Shadle FYI