### PR TITLE
[DOCS] Improve documentation for Cargo audit configuration file 

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,6 +5,7 @@ ignore = [
 ]
 
 show = ["unmaintained", "unsound"]
+fatal = ["critical"]
 
 [output]
 quiet = false

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,6 +4,8 @@ ignore = [
     "RUSTSEC-2020-0159", # `chrono` localtime_r segfault
 ]
 
+show = ["unmaintained", "unsound"]
+
 [output]
 quiet = false
 deny = ["warnings"]

--- a/cargo-audit/README.md
+++ b/cargo-audit/README.md
@@ -97,11 +97,14 @@ But there may be situations where an upgrade isn't available and the advisory do
 
 In these cases, you can ignore advisories using the `--ignore` option.
 
+
 ```
 $ cargo audit --ignore RUSTSEC-2017-0001
 ```
 
 This option can also be configured via the [`audit.toml`](./audit.toml.example) file.
+
+Cargo audit can be configured using a file called [audit.toml](./.cargo/audit.toml) This file is optional, and the default settings will work well for most people.
 
 ## Using `cargo audit` on Travis CI
 


### PR DESCRIPTION
Fixes #818 

### Description

Cargo audit provides flexible controls for which kinds of advisories are reported (e.g. show/hide unmaintained or unsound) and which are considered fatal (i.e. cause non-zero exit code, cause CI to fail) via a config file is to be located in `.cargo/audit.toml`. However, this file is not discoverable, leading to people complaining that the default doesn't work well for them and asking to change the defaults.

This pull request proposes to add the following to the Cargo audit documentation:

* A section on the configuration file, including its location and a brief description of the settings that can be configured.
* A link to the TOML documentation, which provides more detailed information about the TOML format.

This will help users find and understand the configuration file, and make it easier for them to customize the behavior of Cargo audit.

### Changes

* Added advisories (unmaintained, unsound and critical) in `.cargo/audit.toml` file.
* Added a section on the configuration file to the Cargo audit documentation.
* Added a link to the TOML documentation to the Cargo audit documentation.