### PR TITLE
Fix unknown license handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,6 +2846,7 @@ dependencies = [
  "semver",
  "serde",
  "tame-index",
+ "serde_json",
  "tempfile",
  "thiserror",
  "time",

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -45,6 +45,7 @@ features = [
 [dev-dependencies]
 tempfile = "3"
 once_cell = "1"
+serde_json = "1"
 
 [features]
 default = ["git"]

--- a/rustsec/src/advisory/license.rs
+++ b/rustsec/src/advisory/license.rs
@@ -1,14 +1,15 @@
 use crate::Error;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Default, Deserialize)]
+#[serde(from = "String")]
 /// Type representing licenses used for advisory content
 #[non_exhaustive]
 pub enum License {
     /// Creative Commons Zero v1.0 Universal
     /// SPDX identifier: CC0-1.0
-    #[serde(rename = "CC0-1.0")]
     #[default]
     CcZero10,
     /// Creative Commons Attribution 4.0 International
@@ -21,10 +22,45 @@ pub enum License {
     /// For advisories imported from a GitHub Security Advisory, we follow this by putting the
     /// original URL in the `url` filed of the RustSec advisory, as it assures the link will be
     /// visible to downstream users.
-    #[serde(rename = "CC-BY-4.0")]
     CcBy40,
     /// Other SPDX requirement
     Other(String),
+}
+
+impl From<String> for License {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "CC0-1.0" => License::CcZero10,
+            "CC-BY-4.0" => License::CcBy40,
+            _ => License::Other(s),
+        }
+    }
+}
+
+impl Serialize for License {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.spdx())
+    }
+}
+
+impl Display for License {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.spdx())
+    }
+}
+
+impl License {
+    /// Get license as an `&str` containing the SPDX identifier
+    pub fn spdx(&self) -> &str {
+        match self {
+            License::CcBy40 => "CC-BY-4.0",
+            License::CcZero10 => "CC0-1.0",
+            License::Other(ref l) => l,
+        }
+    }
 }
 
 impl FromStr for License {
@@ -40,13 +76,27 @@ impl FromStr for License {
     }
 }
 
-impl License {
-    /// Get license as an `&str` containing the SPDX identifier
-    pub fn spdx(&self) -> &str {
-        match self {
-            License::CcBy40 => "CC-BY-4.0",
-            License::CcZero10 => "CC0-1.0",
-            License::Other(ref l) => l,
-        }
+#[cfg(test)]
+mod tests {
+    use crate::advisory::License;
+
+    #[test]
+    fn serialize_licenses() {
+        assert_eq!(
+            serde_json::to_string(&License::CcBy40).unwrap(),
+            "\"CC-BY-4.0\"".to_string()
+        );
+        assert_eq!(
+            serde_json::to_string(&License::Other("MPL-2.0".to_string())).unwrap(),
+            "\"MPL-2.0\"".to_string()
+        );
+    }
+
+    #[test]
+    fn deserialize_licenses() {
+        let l: License = serde_json::from_str("\"CC-BY-4.0\"").unwrap();
+        assert_eq!(l, License::CcBy40);
+        let l: License = serde_json::from_str("\"MPL-2.0\"").unwrap();
+        assert_eq!(l, License::Other("MPL-2.0".to_string()));
     }
 }

--- a/rustsec/tests/support/example_advisory_v4_unknown_license.md
+++ b/rustsec/tests/support/example_advisory_v4_unknown_license.md
@@ -1,0 +1,24 @@
+```toml
+id = "RUSTSEC-2001-2101"
+package = "base"
+date = "2001-02-03"
+url = "https://github.com/advisories/GHSA-f8vr-r385-rh5r"
+categories = ["code-execution", "privilege-escalation"]
+keywords = ["how", "are", "you", "gentlemen"]
+aliases = ["CVE-2001-2101"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+license = "MPL-2.0"
+
+[versions]
+patched = [">= 1.2.3"]
+unaffected = ["0.1.2"]
+
+[affected]
+arch = ["x86"]
+os = ["windows"]
+functions = { "base::belongs::All" = ["< 1.2.3"] }
+```
+
+# All your base are belong to us
+
+You have no chance to survive. Make your time.


### PR DESCRIPTION
* We _actually_ need special serialization/deserialization to handle the `Other(_)` license case, doesn't seem possible with serde annotations.
* Also add a test case for unknown license