### PR TITLE
Do not leak `tame-index` and `gix` types into the public API

### DIFF
--- a/rustsec/src/advisory.rs
+++ b/rustsec/src/advisory.rs
@@ -106,7 +106,7 @@ impl FromStr for Advisory {
         };
 
         let mut advisory: Self =
-            toml::from_str(&front_matter).map_err(|e| format_err!(crate::ErrorKind::Parse, &e))?;
+            toml::from_str(&front_matter).map_err(crate::Error::from_toml)?;
 
         if !advisory.metadata.title.is_empty() {
             fail!(

--- a/rustsec/src/advisory.rs
+++ b/rustsec/src/advisory.rs
@@ -105,8 +105,7 @@ impl FromStr for Advisory {
             String::from("[advisory]\n") + parts.front_matter
         };
 
-        let mut advisory: Self =
-            toml::from_str(&front_matter).map_err(crate::Error::from_toml)?;
+        let mut advisory: Self = toml::from_str(&front_matter).map_err(crate::Error::from_toml)?;
 
         if !advisory.metadata.title.is_empty() {
             fail!(

--- a/rustsec/src/advisory.rs
+++ b/rustsec/src/advisory.rs
@@ -105,7 +105,8 @@ impl FromStr for Advisory {
             String::from("[advisory]\n") + parts.front_matter
         };
 
-        let mut advisory: Self = toml::from_str(&front_matter)?;
+        let mut advisory: Self =
+            toml::from_str(&front_matter).map_err(|e| format_err!(crate::ErrorKind::Parse, &e))?;
 
         if !advisory.metadata.title.is_empty() {
             fail!(

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -52,7 +52,10 @@ impl Linter {
 
         // Get advisory "front matter" (TOML formatted)
         let advisory_parts = parts::Parts::parse(s)?;
-        let front_matter = advisory_parts.front_matter.parse::<toml::Value>()?;
+        let front_matter = advisory_parts
+            .front_matter
+            .parse::<toml::Value>()
+            .map_err(|e| format_err!(crate::ErrorKind::Parse, &e))?;
 
         let mut linter = Self {
             advisory,

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -55,7 +55,7 @@ impl Linter {
         let front_matter = advisory_parts
             .front_matter
             .parse::<toml::Value>()
-            .map_err(|e| format_err!(crate::ErrorKind::Parse, &e))?;
+            .map_err(crate::Error::from_toml)?;
 
         let mut linter = Self {
             advisory,

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -9,7 +9,7 @@ use crate::{
     package::{self, Package},
 };
 
-pub use tame_index::external::gix;
+use tame_index::external::gix;
 pub use tame_index::external::reqwest::ClientBuilder;
 
 enum Index {

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -21,14 +21,15 @@ enum Index {
 impl Index {
     #[inline]
     fn krate(&self, name: &package::Name) -> Result<Option<tame_index::IndexKrate>, Error> {
-        let name = name.as_str().try_into()?;
+        let name = name.as_str().try_into().map_err(Error::from_tame)?;
         let res = match self {
             Self::Git(gi) => gi.krate(name, true),
             Self::SparseCached(si) => si.cached_krate(name),
             Self::SparseRemote(rsi) => rsi.cached_krate(name),
-        };
+        }
+        .map_err(Error::from_tame)?;
 
-        Ok(res?)
+        Ok(res)
     }
 }
 
@@ -67,6 +68,13 @@ impl CachedIndex {
     /// if the process is interrupted with Ctrl+C. To support `panic = abort` you also need to register
     /// the `gix` signal handler to clean up the locks, see [`gix::interrupt::init_handler`].
     pub fn fetch(client: Option<ClientBuilder>, lock_timeout: Duration) -> Result<Self, Error> {
+        Self::fetch_inner(client, lock_timeout).map_err(Error::from_tame)
+    }
+
+    fn fetch_inner(
+        client: Option<ClientBuilder>,
+        lock_timeout: Duration,
+    ) -> Result<Self, tame_index::Error> {
         let index = tame_index::index::ComboIndexCache::new(tame_index::IndexLocation::new(
             tame_index::IndexUrl::crates_io(None, None, None)?,
         ))?;
@@ -117,6 +125,10 @@ impl CachedIndex {
     /// if the process is interrupted with Ctrl+C. To support `panic = abort` you also need to register
     /// the `gix` signal handler to clean up the locks, see [`gix::interrupt::init_handler`].
     pub fn open(lock_timeout: Duration) -> Result<Self, Error> {
+        Self::open_inner(lock_timeout).map_err(Error::from_tame)
+    }
+
+    fn open_inner(lock_timeout: Duration) -> Result<Self, tame_index::Error> {
         let index = tame_index::index::ComboIndexCache::new(tame_index::IndexLocation::new(
             tame_index::IndexUrl::crates_io(None, None, None)?,
         ))?;
@@ -180,7 +192,7 @@ impl CachedIndex {
                 for (name, res) in results {
                     self.insert(
                         name.parse().expect("this was a package name before"),
-                        res.map_err(Error::from),
+                        res.map_err(Error::from_tame),
                     );
                 }
             }

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -144,12 +144,6 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<semver::Error> for Error {
-    fn from(other: semver::Error) -> Self {
-        format_err!(ErrorKind::Version, &other)
-    }
-}
-
 impl From<toml::de::Error> for Error {
     fn from(other: toml::de::Error) -> Self {
         format_err!(ErrorKind::Parse, &other)

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -161,7 +161,7 @@ impl Error {
     ///
     /// This is a separate function instead of a `From` impl
     /// because a trait impl would leak into the public API,
-    /// and we need to keep it private because tame_index semver
+    /// and we need to keep it private because `tame_index` semver
     /// will be bumped frequently and we don't want to bump `rustsec` semver
     /// every time it changes.
     #[cfg(feature = "git")]
@@ -180,7 +180,7 @@ impl Error {
     ///
     /// This is a separate function instead of a `From` impl
     /// because a trait impl would leak into the public API,
-    /// and we need to keep it private because tame_index semver
+    /// and we need to keep it private because `gix` semver
     /// will be bumped frequently and we don't want to bump `rustsec` semver
     /// every time it changes.
     #[cfg(feature = "git")]

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -189,4 +189,12 @@ impl Error {
             ),
         }
     }
+
+    /// Converts from [`toml::de::Error`] to our `Error`.
+    ///
+    /// This is used so rarely that there is no need to `impl From`,
+    /// and this way we can avoid leaking it into the public API.
+    pub(crate) fn from_toml(other: toml::de::Error) -> Self {
+        format_err!(crate::ErrorKind::Parse, &other)
+    }
 }

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -144,12 +144,6 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<toml::de::Error> for Error {
-    fn from(other: toml::de::Error) -> Self {
-        format_err!(ErrorKind::Parse, &other)
-    }
-}
-
 impl Error {
     /// Converts from [`tame_index::Error`] to our `Error`.
     ///

--- a/rustsec/src/osv/advisory.rs
+++ b/rustsec/src/osv/advisory.rs
@@ -183,7 +183,7 @@ impl OsvAdvisory {
             reference_urls.push(url);
         }
         // other references
-        reference_urls.extend(metadata.references.into_iter());
+        reference_urls.extend(metadata.references);
 
         OsvAdvisory {
             id: metadata.id,

--- a/rustsec/src/report.rs
+++ b/rustsec/src/report.rs
@@ -123,7 +123,7 @@ impl DatabaseInfo {
     pub fn new(db: &Database) -> Self {
         Self {
             advisory_count: db.iter().count(),
-            last_commit: db.latest_commit().map(|c| c.commit_id.to_hex().to_string()),
+            last_commit: db.latest_commit().map(|c| c.commit_id.to_hex()),
             last_updated: db.latest_commit().map(|c| c.timestamp),
         }
     }

--- a/rustsec/src/repository/git.rs
+++ b/rustsec/src/repository/git.rs
@@ -1,13 +1,14 @@
 //! Git repository handling for the RustSec advisory DB
 
 mod commit;
+mod commit_hash;
 #[cfg(feature = "osv-export")]
 mod gitpath;
 #[cfg(feature = "osv-export")]
 mod modification_time;
 mod repository;
 
-pub use self::{commit::Commit, repository::Repository};
+pub use self::{commit::Commit, commit_hash::CommitHash, repository::Repository};
 use tame_index::external::gix;
 
 #[cfg(feature = "osv-export")]

--- a/rustsec/src/repository/git/commit.rs
+++ b/rustsec/src/repository/git/commit.rs
@@ -17,7 +17,7 @@ const STALE_AFTER: Duration = Duration::from_secs(90 * 86400);
 #[derive(Debug)]
 pub struct Commit {
     /// ID (i.e. SHA-1 hash) of the latest commit
-    pub commit_id: gix::ObjectId,
+    pub commit_id: gix::ObjectId, // TODO: wrap
 
     /// Information about the author of a commit
     pub author: String,

--- a/rustsec/src/repository/git/commit.rs
+++ b/rustsec/src/repository/git/commit.rs
@@ -4,7 +4,7 @@ use tame_index::external::gix;
 
 use crate::{
     error::{Error, ErrorKind},
-    repository::{git::Repository, signature::Signature},
+    repository::{git::{Repository, CommitHash}, signature::Signature},
 };
 use std::time::{Duration, SystemTime};
 
@@ -17,7 +17,7 @@ const STALE_AFTER: Duration = Duration::from_secs(90 * 86400);
 #[derive(Debug)]
 pub struct Commit {
     /// ID (i.e. SHA-1 hash) of the latest commit
-    pub commit_id: gix::ObjectId, // TODO: wrap
+    pub commit_id: CommitHash,
 
     /// Information about the author of a commit
     pub author: String,
@@ -69,6 +69,7 @@ impl Commit {
                 commit_id
             ));
         }
+        let commit_id = CommitHash::from_gix(commit_id);
 
         let (signature, signed_data) = if let Some(sig) = cref.extra_headers().pgp_signature() {
             // Note this is inefficient as gix doesn't yet support signature extraction natively.
@@ -122,7 +123,7 @@ impl Commit {
         })?;
 
         let root_tree = repo
-            .find_object(self.commit_id)
+            .find_object(self.commit_id.to_gix())
             .map_err(|err| format_err!(ErrorKind::Repo, "unable to locate commit: {}", err))?
             .peel_to_tree()
             .map_err(|err| format_err!(ErrorKind::Repo, "unable to peel to tree: {}", err))?

--- a/rustsec/src/repository/git/commit.rs
+++ b/rustsec/src/repository/git/commit.rs
@@ -4,7 +4,10 @@ use tame_index::external::gix;
 
 use crate::{
     error::{Error, ErrorKind},
-    repository::{git::{Repository, CommitHash}, signature::Signature},
+    repository::{
+        git::{CommitHash, Repository},
+        signature::Signature,
+    },
 };
 use std::time::{Duration, SystemTime};
 

--- a/rustsec/src/repository/git/commit_hash.rs
+++ b/rustsec/src/repository/git/commit_hash.rs
@@ -1,0 +1,35 @@
+use tame_index::external::gix;
+
+/// ID (i.e. SHA-1 hash) of a git commit
+/// 
+/// This is a wrapper around [gix::ObjectId] to prevent gix semver changes
+/// also breaking semver for `rustsec` crate.
+#[cfg_attr(docsrs, doc(cfg(feature = "git")))]
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Clone, Copy)]
+pub struct CommitHash {
+    hash: gix::ObjectId,
+}
+
+impl CommitHash {
+    // Conversions to/from `gix` are only pub(crate)
+    // to avoid leaking `gix` types and semver into the external API
+    pub(crate) fn to_gix(self) -> gix::ObjectId {
+        self.hash
+    }
+
+    pub(crate) fn from_gix(hash: gix::ObjectId) -> Self {
+        CommitHash { hash }
+    }
+
+    /// Interpret this object id as raw byte slice.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.hash.as_bytes()
+    }
+
+    /// Display the hash as a hexadecimal string.
+    #[inline]
+    pub fn to_hex(&self) -> String {
+        self.hash.to_hex().to_string()
+    }
+}

--- a/rustsec/src/repository/git/commit_hash.rs
+++ b/rustsec/src/repository/git/commit_hash.rs
@@ -26,7 +26,7 @@ impl CommitHash {
     /// Interpret this object id as raw byte slice.
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
-        &self.hash.as_bytes()
+        self.hash.as_bytes()
     }
 
     /// Display the hash as a hexadecimal string.

--- a/rustsec/src/repository/git/commit_hash.rs
+++ b/rustsec/src/repository/git/commit_hash.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use tame_index::external::gix;
 
 /// ID (i.e. SHA-1 hash) of a git commit
@@ -31,5 +33,23 @@ impl CommitHash {
     #[inline]
     pub fn to_hex(&self) -> String {
         self.hash.to_hex().to_string()
+    }
+
+    /// Returns `true` if this hash is equal to an empty blob.
+    #[inline]
+    pub fn is_empty_blob(&self) -> bool {
+        self.hash.is_empty_blob()
+    }
+
+    /// Returns `true` if this hash is equal to an empty tree.
+    #[inline]
+    pub fn is_empty_tree(&self) -> bool {
+        self.hash.is_empty_tree()
+    }
+}
+
+impl Display for CommitHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.hash.fmt(f)
     }
 }

--- a/rustsec/src/repository/git/commit_hash.rs
+++ b/rustsec/src/repository/git/commit_hash.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use tame_index::external::gix;
 
 /// ID (i.e. SHA-1 hash) of a git commit
-/// 
+///
 /// This is a wrapper around [gix::ObjectId] to prevent gix semver changes
 /// also breaking semver for `rustsec` crate.
 #[cfg_attr(docsrs, doc(cfg(feature = "git")))]

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -116,7 +116,8 @@ impl Repository {
             Some(std::path::PathBuf::from_iter(Some(
                 std::path::Component::RootDir,
             ))),
-        )?;
+        )
+        .map_err(Error::from_gix_lock)?;
 
         let open_or_clone_repo = || -> Result<_, Error> {
             let mut mapping = gix::sec::trust::Mapping::default();

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -188,7 +188,8 @@ impl Repository {
                 &repo,
                 &fetch_outcome,
                 &repo.find_remote("origin").unwrap(),
-            )?;
+            )
+            .map_err(Error::from_tame)?;
         } else {
             // If we didn't open a fresh repo we need to peform a fetch ourselves, and
             // do the work of updating the HEAD to point at the latest remote HEAD, which
@@ -294,7 +295,8 @@ impl Repository {
             .receive(&mut gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)
             .map_err(|err| format_err!(ErrorKind::Repo, "failed to fetch: {}", err))?;
 
-        let remote_head_id = tame_index::utils::git::write_fetch_head(&repo, &outcome, &remote)?;
+        let remote_head_id = tame_index::utils::git::write_fetch_head(&repo, &outcome, &remote)
+            .map_err(Error::from_tame)?;
 
         use gix::refs::{transaction as tx, Target};
 


### PR DESCRIPTION
`gix` bumps semver rather frequently, which will in turn make `tame-index` bump semver too. 

This change lets us avoid bumping semver in `rustsec` with every `gix` release.