### PR TITLE
Add `affected` field to warnings for consistency with vulnerabilities

### DIFF
--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -298,7 +298,7 @@ impl Auditor {
             for pkg in yanked {
                 match pkg {
                     Ok(pkg) => {
-                        let warning = Warning::new(WarningKind::Yanked, pkg, None, None);
+                        let warning = Warning::new(WarningKind::Yanked, pkg, None, None, None);
                         result.push(warning);
                     }
                     Err(e) => status_err!("couldn't check if the package is yanked: {}", e),

--- a/cargo-audit/src/binary_type_filter.rs
+++ b/cargo-audit/src/binary_type_filter.rs
@@ -10,6 +10,7 @@ use rustsec::platforms::{platform::PlatformReq, OS};
 use crate::binary_format::BinaryFormat;
 
 pub fn filter_report_by_binary_type(binary_type: &BinaryFormat, report: &mut rustsec::Report) {
+    // Filter vulnerabilities
     let vulns = &mut report.vulnerabilities;
     assert_eq!(
         vulns.list.len(),
@@ -21,8 +22,12 @@ pub fn filter_report_by_binary_type(binary_type: &BinaryFormat, report: &mut rus
         .retain(|vuln| advisory_applicable_to_binary(binary_type, &vuln.affected));
     vulns.count = vulns.list.len();
     vulns.found = !vulns.list.is_empty();
-    // TODO: warnings do not have information about the platform they affect,
-    // so they're impossible to filter at this layer. This requires modifications to the `rustsec` crate.
+
+    // Filter warnings
+    let warns = &mut report.warnings;
+    warns.iter_mut().for_each(|(_kind, warnings)| {
+        warnings.retain(|w| advisory_applicable_to_binary(binary_type, &w.affected))
+    });
 }
 
 fn advisory_applicable_to_binary(

--- a/rustsec/src/report.rs
+++ b/rustsec/src/report.rs
@@ -206,6 +206,7 @@ pub fn find_warnings(db: &Database, lockfile: &Lockfile, settings: &Settings) ->
                 warning_kind,
                 &advisory_vuln.package,
                 Some(advisory.clone()),
+                advisory_vuln.affected.clone(),
                 Some(advisory_vuln.versions.clone()),
             );
 

--- a/rustsec/src/warning.rs
+++ b/rustsec/src/warning.rs
@@ -17,6 +17,9 @@ pub struct Warning {
     /// Source advisory
     pub advisory: Option<advisory::Metadata>,
 
+    /// More specific information about what the source advisory affects (if available)
+    pub affected: Option<advisory::Affected>,
+
     /// Versions impacted by this warning
     pub versions: Option<advisory::Versions>,
 }
@@ -27,12 +30,14 @@ impl Warning {
         kind: WarningKind,
         package: &Package,
         advisory: Option<advisory::Metadata>,
+        affected: Option<advisory::Affected>,
         versions: Option<advisory::Versions>,
     ) -> Self {
         Self {
             kind,
             package: package.clone(),
             advisory,
+            affected,
             versions,
         }
     }


### PR DESCRIPTION
At last, allows filtering warnings by binary type in addition to vulnerabilities.