### PR TITLE
cargo-audit v0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "abscissa_core",
  "auditable-info",

--- a/cargo-audit/CHANGELOG.md
+++ b/cargo-audit/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.1 (2023-08-31)
+
+### Fixed
+
+- Release workflow: don't enable `fix` and `vendored-openssl` features ([#980])
+
+[#980]: https://github.com/rustsec/rustsec/pull/980
+
 ## 0.18.0 (2023-08-31)
 
 ### Added

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-audit"
 description  = "Audit Cargo.lock for crates with security vulnerabilities"
-version      = "0.18.0"
+version      = "0.18.1"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"


### PR DESCRIPTION
### Fixed

- Release workflow: don't enable `fix` and `vendored-openssl` features ([#980])

[#980]: https://github.com/rustsec/rustsec/pull/980