### PR TITLE
make 'cargo test --no-default-features' run without errors

### DIFF
--- a/cvss/tests/base.rs
+++ b/cvss/tests/base.rs
@@ -5,7 +5,7 @@
 use core::str::FromStr;
 
 /// CVE-2013-1937
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2013_1937() {
     let cvss_for_cve_2013_1937 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -15,7 +15,7 @@ fn cve_2013_1937() {
 }
 
 /// Missing CVSS:3.1 prefix
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn bad_prefix() {
     let cvss_for_cve_2013_1937e = "AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -23,7 +23,7 @@ fn bad_prefix() {
 }
 
 /// CVSS:3.0 prefix (parse these as for the purposes of this library they're identical)
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cvss_v3_0_prefix() {
     let cvss_for_cve_2013_1937 = "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -33,7 +33,7 @@ fn cvss_v3_0_prefix() {
 }
 
 /// CVE-2013-0375
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2013_0375() {
     let cvss_for_cve_2013_0375 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N";
@@ -43,7 +43,7 @@ fn cve_2013_0375() {
 }
 
 /// CVE-2014-3566
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_3566() {
     let cvss_for_cve_2014_3566 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N";
@@ -53,7 +53,7 @@ fn cve_2014_3566() {
 }
 
 /// CVE-2012-1516
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2012_1516() {
     let cvss_for_cve_2012_1516 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H";
@@ -63,7 +63,7 @@ fn cve_2012_1516() {
 }
 
 /// CVE-2009-0783
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2009_0783() {
     let cvss_for_cve_2009_0783 = "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L";
@@ -73,7 +73,7 @@ fn cve_2009_0783() {
 }
 
 /// CVE-2012-0384
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2012_0384() {
     let cvss_for_cve_2012_0384 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H";
@@ -83,7 +83,7 @@ fn cve_2012_0384() {
 }
 
 /// CVE-2015-1098
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2015_1098() {
     let cvss_for_cve_2015_1098 = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -93,7 +93,7 @@ fn cve_2015_1098() {
 }
 
 /// CVE-2014-0160
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_0160() {
     let cvss_for_cve_2014_0160 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N";
@@ -103,7 +103,7 @@ fn cve_2014_0160() {
 }
 
 /// CVE-2014-6271
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_6271() {
     let cvss_for_cve_2014_6271 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -113,7 +113,7 @@ fn cve_2014_6271() {
 }
 
 /// CVE-2008-1447
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2008_1447() {
     let cvss_for_cve_2008_1447 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N";
@@ -123,7 +123,7 @@ fn cve_2008_1447() {
 }
 
 /// CVE-2014-2005
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_2005() {
     let cvss_for_cve_2014_2005 = "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -133,7 +133,7 @@ fn cve_2014_2005() {
 }
 
 /// CVE-2010-0467
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2010_0467() {
     let cvss_for_cve_2010_0467 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N";
@@ -143,7 +143,7 @@ fn cve_2010_0467() {
 }
 
 /// CVE-2012-1342
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2012_1342() {
     let cvss_for_cve_2012_1342 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N";
@@ -153,7 +153,7 @@ fn cve_2012_1342() {
 }
 
 /// CVE-2013-6014
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2013_6014() {
     let cvss_for_cve_2013_6014 = "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:H";
@@ -163,7 +163,7 @@ fn cve_2013_6014() {
 }
 
 /// CVE-2014-9253
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_9253() {
     let cvss_for_cve_2014_9253 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N";
@@ -173,7 +173,7 @@ fn cve_2014_9253() {
 }
 
 /// CVE-2009-0658
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2009_0658() {
     let cvss_for_cve_2009_0658 = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -183,7 +183,7 @@ fn cve_2009_0658() {
 }
 
 /// CVE-2011-1265
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2011_1265() {
     let cvss_for_cve_2011_1265 = "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -193,7 +193,7 @@ fn cve_2011_1265() {
 }
 
 /// CVE-2014-2019
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_2019() {
     let cvss_for_cve_2014_2019 = "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N";
@@ -203,7 +203,7 @@ fn cve_2014_2019() {
 }
 
 /// CVE-2015-0970
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2015_0970() {
     let cvss_for_cve_2015_0970 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -213,7 +213,7 @@ fn cve_2015_0970() {
 }
 
 /// CVE-2014-0224
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_0224() {
     let cvss_for_cve_2014_0224 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N";
@@ -223,7 +223,7 @@ fn cve_2014_0224() {
 }
 
 /// CVE-2012-5376
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2012_5376() {
     let cvss_for_cve_2012_5376 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H";
@@ -233,7 +233,7 @@ fn cve_2012_5376() {
 }
 
 /// No impact scope changed
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn no_impact_scope_changed() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N => 0.0
@@ -244,7 +244,7 @@ fn no_impact_scope_changed() {
 }
 
 /// No impact scope unchanged
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn no_impact_scope_unchanged() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N => 0.0
@@ -254,7 +254,7 @@ fn no_impact_scope_unchanged() {
     assert_eq!(base.score().value(), 0.0);
 }
 
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn low_scope_unchanged() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L => 1.6
@@ -264,7 +264,7 @@ fn low_scope_unchanged() {
     assert_eq!(base.score().value(), 1.6);
 }
 
-#[cfg(feature = "default")]
+#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn low_scope_changed() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:C/C:N/I:N/A:L => 1.8

--- a/cvss/tests/base.rs
+++ b/cvss/tests/base.rs
@@ -1,3 +1,4 @@
+#![cfg(all(feature = "v3", feature = "std"))]
 /// Base Metrics tests
 ///
 /// NOTE: These CVEs are actually `CVSS:3.0` and have been modified for the
@@ -5,7 +6,6 @@
 use core::str::FromStr;
 
 /// CVE-2013-1937
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2013_1937() {
     let cvss_for_cve_2013_1937 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -15,7 +15,6 @@ fn cve_2013_1937() {
 }
 
 /// Missing CVSS:3.1 prefix
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn bad_prefix() {
     let cvss_for_cve_2013_1937e = "AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -23,7 +22,6 @@ fn bad_prefix() {
 }
 
 /// CVSS:3.0 prefix (parse these as for the purposes of this library they're identical)
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cvss_v3_0_prefix() {
     let cvss_for_cve_2013_1937 = "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -33,7 +31,6 @@ fn cvss_v3_0_prefix() {
 }
 
 /// CVE-2013-0375
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2013_0375() {
     let cvss_for_cve_2013_0375 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N";
@@ -43,7 +40,6 @@ fn cve_2013_0375() {
 }
 
 /// CVE-2014-3566
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_3566() {
     let cvss_for_cve_2014_3566 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N";
@@ -53,7 +49,6 @@ fn cve_2014_3566() {
 }
 
 /// CVE-2012-1516
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2012_1516() {
     let cvss_for_cve_2012_1516 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H";
@@ -63,7 +58,6 @@ fn cve_2012_1516() {
 }
 
 /// CVE-2009-0783
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2009_0783() {
     let cvss_for_cve_2009_0783 = "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L";
@@ -73,7 +67,6 @@ fn cve_2009_0783() {
 }
 
 /// CVE-2012-0384
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2012_0384() {
     let cvss_for_cve_2012_0384 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H";
@@ -83,7 +76,6 @@ fn cve_2012_0384() {
 }
 
 /// CVE-2015-1098
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2015_1098() {
     let cvss_for_cve_2015_1098 = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -93,7 +85,6 @@ fn cve_2015_1098() {
 }
 
 /// CVE-2014-0160
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_0160() {
     let cvss_for_cve_2014_0160 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N";
@@ -103,7 +94,6 @@ fn cve_2014_0160() {
 }
 
 /// CVE-2014-6271
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_6271() {
     let cvss_for_cve_2014_6271 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -113,7 +103,6 @@ fn cve_2014_6271() {
 }
 
 /// CVE-2008-1447
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2008_1447() {
     let cvss_for_cve_2008_1447 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N";
@@ -123,7 +112,6 @@ fn cve_2008_1447() {
 }
 
 /// CVE-2014-2005
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_2005() {
     let cvss_for_cve_2014_2005 = "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -133,7 +121,6 @@ fn cve_2014_2005() {
 }
 
 /// CVE-2010-0467
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2010_0467() {
     let cvss_for_cve_2010_0467 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N";
@@ -143,7 +130,6 @@ fn cve_2010_0467() {
 }
 
 /// CVE-2012-1342
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2012_1342() {
     let cvss_for_cve_2012_1342 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N";
@@ -153,7 +139,6 @@ fn cve_2012_1342() {
 }
 
 /// CVE-2013-6014
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2013_6014() {
     let cvss_for_cve_2013_6014 = "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:H";
@@ -163,7 +148,6 @@ fn cve_2013_6014() {
 }
 
 /// CVE-2014-9253
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_9253() {
     let cvss_for_cve_2014_9253 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N";
@@ -173,7 +157,6 @@ fn cve_2014_9253() {
 }
 
 /// CVE-2009-0658
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2009_0658() {
     let cvss_for_cve_2009_0658 = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -183,7 +166,6 @@ fn cve_2009_0658() {
 }
 
 /// CVE-2011-1265
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2011_1265() {
     let cvss_for_cve_2011_1265 = "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -193,7 +175,6 @@ fn cve_2011_1265() {
 }
 
 /// CVE-2014-2019
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_2019() {
     let cvss_for_cve_2014_2019 = "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N";
@@ -203,7 +184,6 @@ fn cve_2014_2019() {
 }
 
 /// CVE-2015-0970
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2015_0970() {
     let cvss_for_cve_2015_0970 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -213,7 +193,6 @@ fn cve_2015_0970() {
 }
 
 /// CVE-2014-0224
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2014_0224() {
     let cvss_for_cve_2014_0224 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N";
@@ -223,7 +202,6 @@ fn cve_2014_0224() {
 }
 
 /// CVE-2012-5376
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn cve_2012_5376() {
     let cvss_for_cve_2012_5376 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H";
@@ -233,7 +211,6 @@ fn cve_2012_5376() {
 }
 
 /// No impact scope changed
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn no_impact_scope_changed() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N => 0.0
@@ -244,7 +221,6 @@ fn no_impact_scope_changed() {
 }
 
 /// No impact scope unchanged
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn no_impact_scope_unchanged() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N => 0.0
@@ -254,7 +230,6 @@ fn no_impact_scope_unchanged() {
     assert_eq!(base.score().value(), 0.0);
 }
 
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn low_scope_unchanged() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L => 1.6
@@ -264,7 +239,6 @@ fn low_scope_unchanged() {
     assert_eq!(base.score().value(), 1.6);
 }
 
-#[cfg(all(feature = "v3", feature = "std"))]
 #[test]
 fn low_scope_changed() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:C/C:N/I:N/A:L => 1.8

--- a/cvss/tests/base.rs
+++ b/cvss/tests/base.rs
@@ -5,6 +5,7 @@
 use core::str::FromStr;
 
 /// CVE-2013-1937
+#[cfg(feature = "default")]
 #[test]
 fn cve_2013_1937() {
     let cvss_for_cve_2013_1937 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -14,6 +15,7 @@ fn cve_2013_1937() {
 }
 
 /// Missing CVSS:3.1 prefix
+#[cfg(feature = "default")]
 #[test]
 fn bad_prefix() {
     let cvss_for_cve_2013_1937e = "AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -21,6 +23,7 @@ fn bad_prefix() {
 }
 
 /// CVSS:3.0 prefix (parse these as for the purposes of this library they're identical)
+#[cfg(feature = "default")]
 #[test]
 fn cvss_v3_0_prefix() {
     let cvss_for_cve_2013_1937 = "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N";
@@ -30,6 +33,7 @@ fn cvss_v3_0_prefix() {
 }
 
 /// CVE-2013-0375
+#[cfg(feature = "default")]
 #[test]
 fn cve_2013_0375() {
     let cvss_for_cve_2013_0375 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N";
@@ -39,6 +43,7 @@ fn cve_2013_0375() {
 }
 
 /// CVE-2014-3566
+#[cfg(feature = "default")]
 #[test]
 fn cve_2014_3566() {
     let cvss_for_cve_2014_3566 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N";
@@ -48,6 +53,7 @@ fn cve_2014_3566() {
 }
 
 /// CVE-2012-1516
+#[cfg(feature = "default")]
 #[test]
 fn cve_2012_1516() {
     let cvss_for_cve_2012_1516 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H";
@@ -57,6 +63,7 @@ fn cve_2012_1516() {
 }
 
 /// CVE-2009-0783
+#[cfg(feature = "default")]
 #[test]
 fn cve_2009_0783() {
     let cvss_for_cve_2009_0783 = "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L";
@@ -66,6 +73,7 @@ fn cve_2009_0783() {
 }
 
 /// CVE-2012-0384
+#[cfg(feature = "default")]
 #[test]
 fn cve_2012_0384() {
     let cvss_for_cve_2012_0384 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H";
@@ -75,6 +83,7 @@ fn cve_2012_0384() {
 }
 
 /// CVE-2015-1098
+#[cfg(feature = "default")]
 #[test]
 fn cve_2015_1098() {
     let cvss_for_cve_2015_1098 = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -84,6 +93,7 @@ fn cve_2015_1098() {
 }
 
 /// CVE-2014-0160
+#[cfg(feature = "default")]
 #[test]
 fn cve_2014_0160() {
     let cvss_for_cve_2014_0160 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N";
@@ -93,6 +103,7 @@ fn cve_2014_0160() {
 }
 
 /// CVE-2014-6271
+#[cfg(feature = "default")]
 #[test]
 fn cve_2014_6271() {
     let cvss_for_cve_2014_6271 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -102,6 +113,7 @@ fn cve_2014_6271() {
 }
 
 /// CVE-2008-1447
+#[cfg(feature = "default")]
 #[test]
 fn cve_2008_1447() {
     let cvss_for_cve_2008_1447 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N";
@@ -111,6 +123,7 @@ fn cve_2008_1447() {
 }
 
 /// CVE-2014-2005
+#[cfg(feature = "default")]
 #[test]
 fn cve_2014_2005() {
     let cvss_for_cve_2014_2005 = "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -120,6 +133,7 @@ fn cve_2014_2005() {
 }
 
 /// CVE-2010-0467
+#[cfg(feature = "default")]
 #[test]
 fn cve_2010_0467() {
     let cvss_for_cve_2010_0467 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N";
@@ -129,6 +143,7 @@ fn cve_2010_0467() {
 }
 
 /// CVE-2012-1342
+#[cfg(feature = "default")]
 #[test]
 fn cve_2012_1342() {
     let cvss_for_cve_2012_1342 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N";
@@ -138,6 +153,7 @@ fn cve_2012_1342() {
 }
 
 /// CVE-2013-6014
+#[cfg(feature = "default")]
 #[test]
 fn cve_2013_6014() {
     let cvss_for_cve_2013_6014 = "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:H";
@@ -147,6 +163,7 @@ fn cve_2013_6014() {
 }
 
 /// CVE-2014-9253
+#[cfg(feature = "default")]
 #[test]
 fn cve_2014_9253() {
     let cvss_for_cve_2014_9253 = "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N";
@@ -156,6 +173,7 @@ fn cve_2014_9253() {
 }
 
 /// CVE-2009-0658
+#[cfg(feature = "default")]
 #[test]
 fn cve_2009_0658() {
     let cvss_for_cve_2009_0658 = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -165,6 +183,7 @@ fn cve_2009_0658() {
 }
 
 /// CVE-2011-1265
+#[cfg(feature = "default")]
 #[test]
 fn cve_2011_1265() {
     let cvss_for_cve_2011_1265 = "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
@@ -174,6 +193,7 @@ fn cve_2011_1265() {
 }
 
 /// CVE-2014-2019
+#[cfg(feature = "default")]
 #[test]
 fn cve_2014_2019() {
     let cvss_for_cve_2014_2019 = "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N";
@@ -183,6 +203,7 @@ fn cve_2014_2019() {
 }
 
 /// CVE-2015-0970
+#[cfg(feature = "default")]
 #[test]
 fn cve_2015_0970() {
     let cvss_for_cve_2015_0970 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H";
@@ -192,6 +213,7 @@ fn cve_2015_0970() {
 }
 
 /// CVE-2014-0224
+#[cfg(feature = "default")]
 #[test]
 fn cve_2014_0224() {
     let cvss_for_cve_2014_0224 = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N";
@@ -201,6 +223,7 @@ fn cve_2014_0224() {
 }
 
 /// CVE-2012-5376
+#[cfg(feature = "default")]
 #[test]
 fn cve_2012_5376() {
     let cvss_for_cve_2012_5376 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H";
@@ -210,6 +233,7 @@ fn cve_2012_5376() {
 }
 
 /// No impact scope changed
+#[cfg(feature = "default")]
 #[test]
 fn no_impact_scope_changed() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N => 0.0
@@ -220,6 +244,7 @@ fn no_impact_scope_changed() {
 }
 
 /// No impact scope unchanged
+#[cfg(feature = "default")]
 #[test]
 fn no_impact_scope_unchanged() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N => 0.0
@@ -229,6 +254,7 @@ fn no_impact_scope_unchanged() {
     assert_eq!(base.score().value(), 0.0);
 }
 
+#[cfg(feature = "default")]
 #[test]
 fn low_scope_unchanged() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L => 1.6
@@ -238,6 +264,7 @@ fn low_scope_unchanged() {
     assert_eq!(base.score().value(), 1.6);
 }
 
+#[cfg(feature = "default")]
 #[test]
 fn low_scope_changed() {
     // https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:C/C:N/I:N/A:L => 1.8


### PR DESCRIPTION
Without this I got errors like this one:

```
error[E0433]: failed to resolve: could not find `v3` in `cvss`
  --> cvss/tests/base.rs:11:22
   |
11 |     let base = cvss::v3::Base::from_str(cvss_for_cve_2013_1937).unwrap();
   |                      ^^ could not find `v3` in `cvss`
```

Ref: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/cvss/debian/patches/fix-unit-tests.patch