### PR TITLE
Do not re-lookup packages that are already cached

### DIFF
--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -149,7 +149,9 @@ impl CachedIndex {
     }
 
     /// Populates the cache entries for all of the specified crates.
-    fn populate_cache(&mut self, packages: BTreeSet<&package::Name>) -> Result<(), Error> {
+    fn populate_cache(&mut self, mut packages: BTreeSet<&package::Name>) -> Result<(), Error> {
+        // only look up info on packages that aren't yet cached
+        packages.retain(|pkg| !self.cache.contains_key(&pkg));
         match &self.index {
             Index::Git(_) | Index::SparseCached(_) => {
                 for pkg in packages {

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -151,7 +151,7 @@ impl CachedIndex {
     /// Populates the cache entries for all of the specified crates.
     fn populate_cache(&mut self, mut packages: BTreeSet<&package::Name>) -> Result<(), Error> {
         // only look up info on packages that aren't yet cached
-        packages.retain(|pkg| !self.cache.contains_key(&pkg));
+        packages.retain(|pkg| !self.cache.contains_key(pkg));
         match &self.index {
             Index::Git(_) | Index::SparseCached(_) => {
                 for pkg in packages {


### PR DESCRIPTION
Fixes a performance regression when scanning multiple files. Only possible in `cargo audit bin`.