### PR TITLE
Do not require http2 when establishing the connection

### DIFF
--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -91,7 +91,6 @@ impl CachedIndex {
                 // to query other indices that _might_ not support HTTP/2, but
                 // hopefully that would never need to happen
                 let client = client_builder
-                    .http2_prior_knowledge()
                     .build()
                     .map_err(tame_index::Error::from)?;
 


### PR DESCRIPTION
Part of #988 

Also requires https://github.com/EmbarkStudios/tame-index/pull/26 to be effective