### PR TITLE
Fix `deny = ["warnings"]` being ignored

### DIFF
--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -189,12 +189,16 @@ impl DenyOption {
         ]
     }
     /// Get the warning::Kind that corresponds to self, if applicable
-    pub fn get_warning_kind(self) -> Option<WarningKind> {
+    pub fn get_warning_kind(self) -> &'static [WarningKind] {
         match self {
-            DenyOption::Warnings => None,
-            DenyOption::Unmaintained => Some(WarningKind::Unmaintained),
-            DenyOption::Unsound => Some(WarningKind::Unsound),
-            DenyOption::Yanked => Some(WarningKind::Yanked),
+            DenyOption::Warnings => &[
+                WarningKind::Unmaintained,
+                WarningKind::Unsound,
+                WarningKind::Yanked,
+            ],
+            DenyOption::Unmaintained => &[WarningKind::Unmaintained],
+            DenyOption::Unsound => &[WarningKind::Unsound],
+            DenyOption::Yanked => &[WarningKind::Yanked],
         }
     }
 }

--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -44,7 +44,8 @@ impl Presenter {
             deny_warning_kinds: config
                 .deny
                 .iter()
-                .filter_map(|k| k.get_warning_kind())
+                .flat_map(|k| k.get_warning_kind())
+                .copied()
                 .collect(),
             config: config.clone(),
         }


### PR DESCRIPTION
I'm not sure why `filter_map()` was used in the first place, but that fixes it.

Initially I was looking into adding tests, but unfortunately `abscissa_core::testing::CmdRunner` doesn't support settings the working directory, so I'm unsure how. Happy to take any directions though.

Fixes #991.