### PR TITLE
rustsec-admin with tame-index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "askama"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +484,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807"
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +602,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +647,16 @@ dependencies = [
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -890,6 +929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide 0.7.1",
 ]
 
@@ -1253,12 +1293,16 @@ checksum = "f414c99e1a7abc69b21f3225a6539d203b0513f1d1d448607c4ea81cdcf9ee59"
 dependencies = [
  "bytes",
  "crc32fast",
+ "crossbeam-channel",
  "flate2",
  "gix-hash",
  "gix-trace",
+ "jwalk",
  "libc",
  "once_cell",
+ "parking_lot",
  "prodash",
+ "sha1",
  "sha1_smol",
  "thiserror",
  "walkdir",
@@ -1455,6 +1499,7 @@ dependencies = [
  "parking_lot",
  "smallvec",
  "thiserror",
+ "uluru",
 ]
 
 [[package]]
@@ -2070,6 +2115,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "kstring"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2180,16 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
+dependencies = [
+ "cmake",
+ "libc",
 ]
 
 [[package]]
@@ -2849,6 +2914,7 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
+ "gix",
  "once_cell",
  "rust-embed",
  "rustsec",
@@ -2993,6 +3059,27 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "sha1-asm",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba6947745e7f86be3b8af00b7355857085dbdf8901393c89514510eb61f4e21"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3476,6 +3563,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uluru"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -2848,12 +2849,12 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
- "crates-index",
  "once_cell",
  "rust-embed",
  "rustsec",
  "serde",
  "serde_json",
+ "tame-index",
  "termcolor",
  "thiserror",
  "toml 0.7.6",
@@ -3546,7 +3547,7 @@ dependencies = [
  "serde_json",
  "socks",
  "url",
- "webpki-roots",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -3687,6 +3688,25 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -9,6 +9,9 @@ repository  = "https://github.com/RustSec/rustsec/tree/main/admin"
 readme      = "README.md"
 edition     = "2021"
 
+[features]
+default = ["gix?/max-performance"]
+
 [dependencies]
 abscissa_core = "0.6"
 askama = "0.11"
@@ -17,6 +20,8 @@ chrono = { version = "0.4", default-features = false, features = ["clock"]  }
 clap = "3"
 comrak = { version = "0.18", default-features = false }
 tame-index = { version = "0.6.0", features = ["git"] }
+# NOTE: Keep in sync with `gix` used by `tame-index`.
+gix = { version = "0.53.1", default-features = false, optional = true }
 rust-embed = "6.8.1"
 rustsec = { version = "0.28.0", features = ["osv-export"] }
 serde = { version = "1", features = ["serde_derive"] }

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -16,7 +16,7 @@ atom_syndication = "0.12"
 chrono = { version = "0.4", default-features = false, features = ["clock"]  }
 clap = "3"
 comrak = { version = "0.18", default-features = false }
-crates-index = "0.19"
+tame-index = { version = "0.6.0", features = ["git"] }
 rust-embed = "6.8.1"
 rustsec = { version = "0.28.0", features = ["osv-export"] }
 serde = { version = "1", features = ["serde_derive"] }

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -7,7 +7,7 @@ license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"
 repository  = "https://github.com/RustSec/rustsec/tree/main/admin"
 readme      = "README.md"
-edition     = "2018"
+edition     = "2021"
 
 [dependencies]
 abscissa_core = "0.6"

--- a/admin/src/error.rs
+++ b/admin/src/error.rs
@@ -66,8 +66,8 @@ impl From<Context<ErrorKind>> for Error {
     }
 }
 
-impl From<crates_index::Error> for Error {
-    fn from(other: crates_index::Error) -> Self {
+impl From<tame_index::Error> for Error {
+    fn from(other: tame_index::Error) -> Self {
         format_err!(ErrorKind::CratesIo, "{}", other).into()
     }
 }

--- a/admin/src/linter.rs
+++ b/admin/src/linter.rs
@@ -4,7 +4,6 @@ use crate::{
     error::{Error, ErrorKind},
     prelude::*,
 };
-use std::convert::TryInto;
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/admin/src/linter.rs
+++ b/admin/src/linter.rs
@@ -4,11 +4,12 @@ use crate::{
     error::{Error, ErrorKind},
     prelude::*,
 };
-use crates_index::Index;
+use std::convert::TryInto;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
+use tame_index::index::RemoteGitIndex;
 
 /// List of "collections" within the Advisory DB
 // TODO(tarcieri): provide some other means of iterating over the collections?
@@ -21,7 +22,7 @@ pub struct Linter {
     repo_path: PathBuf,
 
     /// Loaded crates.io index
-    crates_index: Index,
+    crates_index: RemoteGitIndex,
 
     /// Loaded Advisory DB
     advisory_db: rustsec::Database,
@@ -40,8 +41,10 @@ impl Linter {
         skip_namecheck: Option<String>,
     ) -> Result<Self, Error> {
         let repo_path = repo_path.into();
-        let mut crates_index = crates_index::Index::new_cargo_default()?;
-        crates_index.update()?;
+        let mut crates_index = RemoteGitIndex::new(tame_index::GitIndex::new(
+            tame_index::IndexLocation::new(tame_index::IndexUrl::CratesIoGit),
+        )?)?;
+        crates_index.fetch()?;
         let advisory_db = rustsec::Database::open(&repo_path)?;
 
         Ok(Self {
@@ -153,7 +156,7 @@ impl Linter {
 
     /// Checks if a crate with this name is present on crates.io
     fn name_exists_on_crates_io(&self, name: &str) -> bool {
-        if let Some(crate_) = self.crates_index.crate_(name) {
+        if let Ok(Some(crate_)) = self.crates_index.krate(name.try_into().unwrap(), true) {
             // This check verifies name normalization.
             // A request for "serde-json" might return "serde_json",
             // and we want to catch use a non-canonical name and report it as an error.

--- a/admin/src/list_versions.rs
+++ b/admin/src/list_versions.rs
@@ -1,6 +1,5 @@
 //! Backend for the `list-affected-versions` subcommand.
 
-use std::convert::TryInto;
 use std::path::PathBuf;
 
 use rustsec::{Advisory, Database};

--- a/admin/src/list_versions.rs
+++ b/admin/src/list_versions.rs
@@ -1,16 +1,17 @@
 //! Backend for the `list-affected-versions` subcommand.
 
+use std::convert::TryInto;
 use std::path::PathBuf;
 
-use crates_index::Index;
 use rustsec::{Advisory, Database};
+use tame_index::index::RemoteGitIndex;
 
 use crate::{error::Error, prelude::*};
 
 /// Lists all versions for a crate and prints info on which ones are affected
 pub struct AffectedVersionLister {
     /// Loaded crates.io index
-    crates_index: Index,
+    crates_index: RemoteGitIndex,
 
     /// Loaded Advisory DB
     advisory_db: Database,
@@ -20,8 +21,10 @@ impl AffectedVersionLister {
     /// Load the the database at the given path
     pub fn new(repo_path: impl Into<PathBuf>) -> Result<Self, Error> {
         let repo_path = repo_path.into();
-        let mut crates_index = crates_index::Index::new_cargo_default()?;
-        crates_index.update()?;
+        let mut crates_index = RemoteGitIndex::new(tame_index::GitIndex::new(
+            tame_index::IndexLocation::new(tame_index::IndexUrl::CratesIoGit),
+        )?)?;
+        crates_index.fetch()?;
         let advisory_db = Database::open(&repo_path)?;
         Ok(Self {
             crates_index,
@@ -43,13 +46,17 @@ impl AffectedVersionLister {
             advisory.metadata.package
         );
         let crate_name = advisory.metadata.package.as_str();
-        let crate_info = self.crates_index.crate_(crate_name).unwrap();
-        for version in crate_info.versions() {
-            let parsed_version = rustsec::Version::parse(version.version()).unwrap();
+        let crate_info = self
+            .crates_index
+            .krate(crate_name.try_into().unwrap(), true)
+            .unwrap()
+            .unwrap_or_else(|| panic!("expected crate {} to exist", crate_name));
+        for version in crate_info.versions {
+            let parsed_version = rustsec::Version::parse(&version.version).unwrap();
             if advisory.versions.is_vulnerable(&parsed_version) {
-                println!("{} vulnerable", version.version())
+                println!("{} vulnerable", version.version)
             } else {
-                println!("{} OK", version.version())
+                println!("{} OK", version.version)
             }
         }
     }

--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -572,7 +572,6 @@ mod filters {
     use chrono::NaiveDate;
     use rustsec::advisory;
     use std::borrow::Borrow;
-    use std::convert::TryInto;
 
     pub fn friendly_date<T: Borrow<advisory::Date>>(date: T) -> ::askama::Result<String> {
         let date = date.borrow();

--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -221,7 +221,7 @@ impl FromStr for DenyOption {
 }
 
 /// Output format
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Default, Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum OutputFormat {
     /// Display JSON
     #[serde(rename = "json")]
@@ -229,13 +229,8 @@ pub enum OutputFormat {
 
     /// Display human-readable output to the terminal
     #[serde(rename = "terminal")]
+    #[default]
     Terminal,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        OutputFormat::Terminal
-    }
 }
 
 /// Target configuration

--- a/rustsec/src/repository/git/commit.rs
+++ b/rustsec/src/repository/git/commit.rs
@@ -160,8 +160,8 @@ impl Commit {
                 let objects = repo.objects.clone().into_arc()?;
                 move |oid, buf| objects.find_blob(oid, buf)
             },
-            &mut gix::progress::Discard,
-            &mut gix::progress::Discard,
+            &gix::progress::Discard,
+            &gix::progress::Discard,
             &gix::interrupt::IS_INTERRUPTED,
             opts,
         )


### PR DESCRIPTION
This PR switches rustsec-admin to tame-index, which uses `gix`.

Originally the idea was to speed the linting which takes 3 minutes on CI, 
but as it turns out the linting itself takes only about 1s.

What can take time though is the initial clone of the crates-index. Using git2, this
was single-threaded and took about 1m50s. Now, with a single thread, it's done in 47s. With all 10 cores it's at 24s (most of which is downloading the pack).

I also enabled multi-threading and performance options to speed it up even more.
Unfortunately I don't know how effective these changes are on CI when linting advisories though.

### Tasks

* [x] switch to `tame-index`
* [x] allow multi-threading when dealing with git and enable performance options


### Review Notes

I now see…

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

…when compiling and don't know if this is due to setting edition 2021 in `rustsec-admin`. It would be easy to drop the edition change.

* Should the clippy errors by fixed by boxing, or just be ignored?