### PR TITLE
Cargo audit release with a fix for RUSTSEC-2023-0064

### DIFF
--- a/cargo-audit/CHANGELOG.md
+++ b/cargo-audit/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.2 (2023-09-25)
+
+### Fixed
+
+- Fix [RUSTSEC-2023-0064](https://rustsec.org/advisories/RUSTSEC-2023-0064.html) security issue by requiring `rustsec` 0.28.2 or higher.
+
+[#980]: https://github.com/rustsec/rustsec/pull/980
+
 ## 0.18.1 (2023-08-31)
 
 ### Fixed

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 abscissa_core = "0.6"
 clap = "3"
 home = "0.5"
-rustsec = { version = "0.28.0", features = ["dependency-tree"] }
+rustsec = { version = "0.28.2", features = ["dependency-tree"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 thiserror = "1"


### PR DESCRIPTION
Release a new `cargo audit` version so that Linux distributions would pick it up, and people who installed it through `cargo` would get a fix with a `cargo install` instead of requiring `cargo install --force`.

I think this is a good idea, but I'd like one of the other maintainers to sign off on it before I ship it.