### PR TITLE
admin: use `gix` max-performance-safe instead of max-performance

### DIFF
--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -10,7 +10,7 @@ readme      = "README.md"
 edition     = "2021"
 
 [features]
-default = ["gix?/max-performance"]
+default = ["gix?/max-performance-safe"]
 
 [dependencies]
 abscissa_core = "0.6"


### PR DESCRIPTION
to avoid dealing with C dependencies