### PR TITLE
Update Clippy to fix useless warnings

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.67.0 # MSRV
+          toolchain: 1.71.0 # MSRV of 1.67 causes false positives
           components: clippy
           override: true
           profile: minimal


### PR DESCRIPTION
The underlying issue was reported to https://github.com/EmbarkStudios/tame-index/issues/31 but doesn't happen in that repository on recent Clippy versions either.