### PR TITLE
Switch from Git-compatible locks to OS locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "byteyarn"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7534301c0ea17abb4db06d75efc7b4b0fa360fce8e175a4330d721c71c942ff"
+
+[[package]]
 name = "camino"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,46 +1073,99 @@ version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06a8c9f9452078f474fecd2880de84819b8c77224ab62273275b646bf785f906"
 dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-commitgraph",
- "gix-config",
- "gix-credentials",
+ "gix-actor 0.26.0",
+ "gix-attributes 0.18.0",
+ "gix-commitgraph 0.20.0",
+ "gix-config 0.29.0",
+ "gix-credentials 0.19.0",
  "gix-date",
- "gix-diff",
- "gix-discover",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-glob",
+ "gix-diff 0.35.0",
+ "gix-discover 0.24.0",
+ "gix-features 0.34.0",
+ "gix-filter 0.4.0",
+ "gix-fs 0.6.0",
+ "gix-glob 0.12.0",
  "gix-hash",
  "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
+ "gix-ignore 0.7.0",
+ "gix-index 0.24.0",
+ "gix-lock 9.0.0",
  "gix-macros",
- "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
+ "gix-negotiate 0.7.0",
+ "gix-object 0.36.0",
+ "gix-odb 0.52.0",
+ "gix-pack 0.42.0",
  "gix-path",
- "gix-pathspec",
+ "gix-pathspec 0.2.0",
  "gix-prompt",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
+ "gix-protocol 0.39.0",
+ "gix-ref 0.36.0",
+ "gix-refspec 0.17.0",
+ "gix-revision 0.21.0",
+ "gix-revwalk 0.7.0",
  "gix-sec",
- "gix-submodule",
- "gix-tempfile",
+ "gix-submodule 0.3.0",
+ "gix-tempfile 9.0.0",
  "gix-trace",
- "gix-transport",
- "gix-traverse",
- "gix-url",
+ "gix-transport 0.36.1",
+ "gix-traverse 0.32.0",
+ "gix-url 0.23.0",
  "gix-utils",
  "gix-validate",
- "gix-worktree",
+ "gix-worktree 0.25.0",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6d32e74454459690d57d18ea4ebec1629936e6b130b51d12cb4a81630ac953"
+dependencies = [
+ "gix-actor 0.27.0",
+ "gix-attributes 0.19.0",
+ "gix-commitgraph 0.21.0",
+ "gix-config 0.30.0",
+ "gix-credentials 0.20.0",
+ "gix-date",
+ "gix-diff 0.36.0",
+ "gix-discover 0.25.0",
+ "gix-features 0.35.0",
+ "gix-filter 0.5.0",
+ "gix-fs 0.7.0",
+ "gix-glob 0.13.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore 0.8.0",
+ "gix-index 0.25.0",
+ "gix-lock 10.0.0",
+ "gix-macros",
+ "gix-negotiate 0.8.0",
+ "gix-object 0.37.0",
+ "gix-odb 0.53.0",
+ "gix-pack 0.43.0",
+ "gix-path",
+ "gix-pathspec 0.3.0",
+ "gix-prompt",
+ "gix-protocol 0.40.0",
+ "gix-ref 0.37.0",
+ "gix-refspec 0.18.0",
+ "gix-revision 0.22.0",
+ "gix-revwalk 0.8.0",
+ "gix-sec",
+ "gix-submodule 0.4.0",
+ "gix-tempfile 10.0.0",
+ "gix-trace",
+ "gix-transport 0.37.0",
+ "gix-traverse 0.33.0",
+ "gix-url 0.24.0",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree 0.26.0",
  "gix-worktree-state",
  "once_cell",
  "parking_lot",
@@ -1130,17 +1189,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-actor"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c60e982c5290897122d4e2622447f014a2dadd5a18cb73d50bb91b31645e27"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-date",
+ "itoa",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
 name = "gix-attributes"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3548b76829d33a7160a4685134df16de0cc3b77418302e8a9969f0b662e698f"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.12.0",
  "gix-path",
  "gix-quote",
  "gix-trace",
  "kstring 2.0.0",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2451665e70709ba4753b623ef97511ee98c4a73816b2c5b5df25678d607ed820"
+dependencies = [
+ "bstr",
+ "byteyarn",
+ "gix-glob 0.13.0",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
  "smallvec",
  "thiserror",
  "unicode-bom",
@@ -1181,7 +1271,21 @@ checksum = "4676ede3a7d37e7028e2889830349a6aca22efc1d2f2dd9fa3351c1a8ddb0c6a"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-features",
+ "gix-features 0.34.0",
+ "gix-hash",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75a975ee22cf0a002bfe9b5d5cb3d2a88e263a8a178cd7509133cff10f4df8a"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features 0.35.0",
  "gix-hash",
  "memmap2",
  "thiserror",
@@ -1195,10 +1299,31 @@ checksum = "1108c4ac88248dd25cc8ab0d0dae796e619fb72d92f88e30e00b29d61bb93cc4"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features",
- "gix-glob",
+ "gix-features 0.34.0",
+ "gix-glob 0.12.0",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.36.0",
+ "gix-sec",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c171514b40487d3f677ae37efc0f45ac980e3169f23c27eb30a70b47fdf88ab5"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features 0.35.0",
+ "gix-glob 0.13.0",
+ "gix-path",
+ "gix-ref 0.37.0",
  "gix-sec",
  "memchr",
  "once_cell",
@@ -1233,7 +1358,23 @@ dependencies = [
  "gix-path",
  "gix-prompt",
  "gix-sec",
- "gix-url",
+ "gix-url 0.23.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46900b884cc5af6a6c141ee741607c0c651a4e1d33614b8d888a1ba81cc0bc8a"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-url 0.24.0",
  "thiserror",
 ]
 
@@ -1256,7 +1397,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45e342d148373bd9070d557e6fb1280aeae29a3e05e32506682d027278501eb"
 dependencies = [
  "gix-hash",
- "gix-object",
+ "gix-object 0.36.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788ddb152c388206e81f36bcbb574e7ed7827c27d8fa62227b34edc333d8928c"
+dependencies = [
+ "gix-hash",
+ "gix-object 0.37.0",
  "thiserror",
 ]
 
@@ -1270,7 +1422,22 @@ dependencies = [
  "dunce",
  "gix-hash",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.36.0",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69507643d75a0ea9a402fcf73ced517d2b95cc95385904ac09d03e0b952fde33"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-hash",
+ "gix-path",
+ "gix-ref 0.37.0",
  "gix-sec",
  "thiserror",
 ]
@@ -1298,6 +1465,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-features"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9ff423ae4983f762659040d13dd7a5defbd54b6a04ac3cc7347741cec828cd"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "flate2",
+ "gix-hash",
+ "gix-trace",
+ "libc",
+ "once_cell",
+ "prodash",
+ "sha1_smol",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
 name = "gix-filter"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,10 +1491,30 @@ checksum = "afbdb2ffae9e595d70f8c7b40953a82706d536bb8107874c258fe6368389832b"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes",
+ "gix-attributes 0.18.0",
  "gix-command",
  "gix-hash",
- "gix-object",
+ "gix-object 0.36.0",
+ "gix-packetline-blocking",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be40d28cd41445bb6cd52c4d847d915900e5466f7433eaee6a9e0a3d1d88b08"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes 0.19.0",
+ "gix-command",
+ "gix-hash",
+ "gix-object 0.37.0",
  "gix-packetline-blocking",
  "gix-path",
  "gix-quote",
@@ -1323,7 +1529,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "404795da3d4c660c9ab6c3b2ad76d459636d1e1e4b37b0c7ff68eee898c298d4"
 dependencies = [
- "gix-features",
+ "gix-features 0.34.0",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09815faba62fe9b32d918b75a554686c98e43f7d48c43a80df58eb718e5c6635"
+dependencies = [
+ "gix-features 0.35.0",
 ]
 
 [[package]]
@@ -1334,7 +1549,19 @@ checksum = "e3ac79c444193b0660fe0c0925d338bd338bd643e32138784dccfb12c628b892"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
- "gix-features",
+ "gix-features 0.34.0",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d76e85f11251dcf751d2c5e918a14f562db5be6f727fd24775245653e9b19d"
+dependencies = [
+ "bitflags 2.3.3",
+ "bstr",
+ "gix-features 0.35.0",
  "gix-path",
 ]
 
@@ -1366,7 +1593,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04ff3ec0fd9fb5bb0ae36b252976b0bc94b45ba969b1639f7402425d9d6baf67"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.12.0",
+ "gix-path",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048f443a1f6b02da4205c34d2e287e3fd45d75e8e2f06cfb216630ea9bff5e3"
+dependencies = [
+ "bstr",
+ "gix-glob 0.13.0",
  "gix-path",
  "unicode-bom",
 ]
@@ -1382,12 +1621,35 @@ dependencies = [
  "btoi",
  "filetime",
  "gix-bitmap",
- "gix-features",
- "gix-fs",
+ "gix-features 0.34.0",
+ "gix-fs 0.6.0",
  "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
+ "gix-lock 9.0.0",
+ "gix-object 0.36.0",
+ "gix-traverse 0.32.0",
+ "itoa",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54d63a9d13c13088f41f5a3accbec284e492ac8f4f707fcc307c139622e17b7"
+dependencies = [
+ "bitflags 2.3.3",
+ "bstr",
+ "btoi",
+ "filetime",
+ "gix-bitmap",
+ "gix-features 0.35.0",
+ "gix-fs 0.7.0",
+ "gix-hash",
+ "gix-lock 10.0.0",
+ "gix-object 0.37.0",
+ "gix-traverse 0.33.0",
  "itoa",
  "memmap2",
  "smallvec",
@@ -1400,7 +1662,18 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1568c3d90594c60d52670f325f5db88c2d572e85c8dd45fabc23d91cadb0fd52"
 dependencies = [
- "gix-tempfile",
+ "gix-tempfile 9.0.0",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47fc96fa8b6b6d33555021907c81eb3b27635daecf6e630630bdad44f8feaa95"
+dependencies = [
+ "gix-tempfile 10.0.0",
  "gix-utils",
  "thiserror",
 ]
@@ -1423,11 +1696,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "208b25af0e59d04e7313479fc949bd68e11a065b51718995139cefac498e24df"
 dependencies = [
  "bitflags 2.3.3",
- "gix-commitgraph",
+ "gix-commitgraph 0.20.0",
  "gix-date",
  "gix-hash",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.36.0",
+ "gix-revwalk 0.7.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f1697bf9911c6d1b8d709b9e6ef718cb5ea5821a1b7991520125a8134448004"
+dependencies = [
+ "bitflags 2.3.3",
+ "gix-commitgraph 0.21.0",
+ "gix-date",
+ "gix-hash",
+ "gix-object 0.37.0",
+ "gix-revwalk 0.8.0",
  "smallvec",
  "thiserror",
 ]
@@ -1440,9 +1729,28 @@ checksum = "3e5528d5b2c984044d547e696e44a8c45fa122e83cd8c2ac1da69bd474336be8"
 dependencies = [
  "bstr",
  "btoi",
- "gix-actor",
+ "gix-actor 0.26.0",
  "gix-date",
- "gix-features",
+ "gix-features 0.34.0",
+ "gix-hash",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7e19616c67967374137bae83e950e9b518a9ea8a605069bd6716ada357fd6f"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-actor 0.27.0",
+ "gix-date",
+ "gix-features 0.35.0",
  "gix-hash",
  "gix-validate",
  "itoa",
@@ -1459,10 +1767,29 @@ checksum = "d0446eca295459deb3d6dd6ed7d44a631479f1b7381d8087166605c7a9f717c6"
 dependencies = [
  "arc-swap",
  "gix-date",
- "gix-features",
+ "gix-features 0.34.0",
  "gix-hash",
- "gix-object",
- "gix-pack",
+ "gix-object 0.36.0",
+ "gix-pack 0.42.0",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6a392c6ba3a2f133cdc63120e9bc7aec81eef763db372c817de31febfe64bf"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features 0.35.0",
+ "gix-hash",
+ "gix-object 0.37.0",
+ "gix-pack 0.43.0",
  "gix-path",
  "gix-quote",
  "parking_lot",
@@ -1478,17 +1805,37 @@ checksum = "be19ee650300d7cbac5829b637685ec44a8d921a7c2eaff8a245d8f2f008870c"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-features",
+ "gix-features 0.34.0",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.36.0",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 9.0.0",
  "memmap2",
  "parking_lot",
  "smallvec",
  "thiserror",
  "uluru",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7536203a45b31e1bc5694bbf90ba8da1b736c77040dd6a520db369f371eb1ab3"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features 0.35.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.37.0",
+ "gix-path",
+ "gix-tempfile 10.0.0",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -1534,9 +1881,24 @@ checksum = "90a7885b4ccdc8c80740e465747bf961a8110043fdc1fda3ee80bc81885f42df"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
- "gix-attributes",
+ "gix-attributes 0.18.0",
  "gix-config-value",
- "gix-glob",
+ "gix-glob 0.12.0",
+ "gix-path",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e26c9b47c51be73f98d38c84494bd5fb99334c5d6fda14ef5d036d50a9e5fd"
+dependencies = [
+ "bitflags 2.3.3",
+ "bstr",
+ "gix-attributes 0.19.0",
+ "gix-config-value",
+ "gix-glob 0.13.0",
  "gix-path",
  "thiserror",
 ]
@@ -1562,11 +1924,29 @@ checksum = "5d6ee7fc3f80140ea0651d483ecb9e680403be244849c16237fce45ac80163df"
 dependencies = [
  "bstr",
  "btoi",
- "gix-credentials",
+ "gix-credentials 0.19.0",
  "gix-date",
- "gix-features",
+ "gix-features 0.34.0",
  "gix-hash",
- "gix-transport",
+ "gix-transport 0.36.1",
+ "maybe-async",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7b700dc20cc9be8a5130a1fd7e10c34117ffa7068431c8c24d963f0a2e0c9b"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-credentials 0.20.0",
+ "gix-date",
+ "gix-features 0.35.0",
+ "gix-hash",
+ "gix-transport 0.37.0",
  "maybe-async",
  "thiserror",
  "winnow",
@@ -1589,15 +1969,36 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cccbfa8d5cd9b86465f27a521e0c017de54b92d9fd37c143e49c658a2f04f3a"
 dependencies = [
- "gix-actor",
+ "gix-actor 0.26.0",
  "gix-date",
- "gix-features",
- "gix-fs",
+ "gix-features 0.34.0",
+ "gix-fs 0.6.0",
  "gix-hash",
- "gix-lock",
- "gix-object",
+ "gix-lock 9.0.0",
+ "gix-object 0.36.0",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 9.0.0",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e6b749660b613641769edc1954132eb8071a13c32224891686091bef078de4"
+dependencies = [
+ "gix-actor 0.27.0",
+ "gix-date",
+ "gix-features 0.35.0",
+ "gix-fs 0.7.0",
+ "gix-hash",
+ "gix-lock 10.0.0",
+ "gix-object 0.37.0",
+ "gix-path",
+ "gix-tempfile 10.0.0",
  "gix-validate",
  "memmap2",
  "thiserror",
@@ -1612,7 +2013,21 @@ checksum = "678ba30d95baa5462df9875628ed40655d5f5b8aba7028de86ed57f36e762c6c"
 dependencies = [
  "bstr",
  "gix-hash",
- "gix-revision",
+ "gix-revision 0.21.0",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0895cb7b1e70f3c3bd4550c329e9f5caf2975f97fcd4238e05754e72208ef61e"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision 0.22.0",
  "gix-validate",
  "smallvec",
  "thiserror",
@@ -1628,8 +2043,24 @@ dependencies = [
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.36.0",
+ "gix-revwalk 0.7.0",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8c4b15cf2ab7a35f5bcb3ef146187c8d36df0177e171ca061913cbaaa890e89"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.37.0",
+ "gix-revwalk 0.8.0",
  "gix-trace",
  "thiserror",
 ]
@@ -1640,11 +2071,26 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b806349bc1f668e09035800e07ac8045da4e39a8925a245d93142c4802224ec1"
 dependencies = [
- "gix-commitgraph",
+ "gix-commitgraph 0.20.0",
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.36.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9870c6b1032f2084567710c3b2106ac603377f8d25766b8a6b7c33e6e3ca279"
+dependencies = [
+ "gix-commitgraph 0.21.0",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.37.0",
  "smallvec",
  "thiserror",
 ]
@@ -1668,11 +2114,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ff6b99d735842a3a7fb162b660fa97acec39d576c0ca1700d9eff9344f8625d"
 dependencies = [
  "bstr",
- "gix-config",
+ "gix-config 0.29.0",
  "gix-path",
- "gix-pathspec",
- "gix-refspec",
- "gix-url",
+ "gix-pathspec 0.2.0",
+ "gix-refspec 0.17.0",
+ "gix-url 0.23.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0150e82e9282d3f2ab2dd57a22f9f6c3447b9d9856e5321ac92d38e3e0e2b7"
+dependencies = [
+ "bstr",
+ "gix-config 0.30.0",
+ "gix-path",
+ "gix-pathspec 0.3.0",
+ "gix-refspec 0.18.0",
+ "gix-url 0.24.0",
  "thiserror",
 ]
 
@@ -1682,7 +2143,20 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2762b91ff95e27ff3ea95758c0d4efacd7435a1be3629622928b8276de0f72a8"
 dependencies = [
- "gix-fs",
+ "gix-fs 0.6.0",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ae0978f3e11dc57290ee75ac2477c815bca1ce2fa7ed5dc5f16db067410ac4d"
+dependencies = [
+ "gix-fs 0.7.0",
  "libc",
  "once_cell",
  "parking_lot",
@@ -1704,12 +2178,31 @@ dependencies = [
  "base64",
  "bstr",
  "gix-command",
- "gix-credentials",
- "gix-features",
+ "gix-credentials 0.19.0",
+ "gix-features 0.34.0",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
- "gix-url",
+ "gix-url 0.23.0",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-transport"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ec726e6a245e68ace59a34126a1d679de60360676612985e70b0d3b102fb4e"
+dependencies = [
+ "base64",
+ "bstr",
+ "gix-command",
+ "gix-credentials 0.20.0",
+ "gix-features 0.35.0",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url 0.24.0",
  "reqwest",
  "thiserror",
 ]
@@ -1720,12 +2213,28 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ec6358f8373fb018af8fc96c9d2ec6a5b66999e2377dc40b7801351fec409ed"
 dependencies = [
- "gix-commitgraph",
+ "gix-commitgraph 0.20.0",
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.36.0",
+ "gix-revwalk 0.7.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ef04ab3643acba289b5cedd25d6f53c0430770b1d689d1d654511e6fb81ba0"
+dependencies = [
+ "gix-commitgraph 0.21.0",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.37.0",
+ "gix-revwalk 0.8.0",
  "smallvec",
  "thiserror",
 ]
@@ -1737,7 +2246,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c79d595b99a6c7ab274f3c991735a0c0f5a816a3da460f513c48edf1c7bf2cc"
 dependencies = [
  "bstr",
- "gix-features",
+ "gix-features 0.34.0",
+ "gix-path",
+ "home",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6125ecf46e8c68bf7202da6cad239831daebf0247ffbab30210d72f3856e420f"
+dependencies = [
+ "bstr",
+ "gix-features 0.35.0",
  "gix-path",
  "home",
  "thiserror",
@@ -1770,33 +2293,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addabd470ca4ce3ab893e32a5743971a530b8fc0eee5c23844849abf3c9ea6d6"
 dependencies = [
  "bstr",
- "gix-attributes",
- "gix-features",
- "gix-fs",
- "gix-glob",
+ "gix-attributes 0.18.0",
+ "gix-features 0.34.0",
+ "gix-fs 0.6.0",
+ "gix-glob 0.12.0",
  "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
+ "gix-ignore 0.7.0",
+ "gix-index 0.24.0",
+ "gix-object 0.36.0",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f5e32972801bd82d56609e6fc84efc358fa1f11f25c5e83b7807ee2280f14fe"
+dependencies = [
+ "bstr",
+ "gix-attributes 0.19.0",
+ "gix-features 0.35.0",
+ "gix-fs 0.7.0",
+ "gix-glob 0.13.0",
+ "gix-hash",
+ "gix-ignore 0.8.0",
+ "gix-index 0.25.0",
+ "gix-object 0.37.0",
  "gix-path",
 ]
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02daf5a1d381280e3c5803a3745ee2abf09d2873118136aaadc0ed96ed438aeb"
+checksum = "c3aeb06960f2c5ac9e4cdb6b38eb3c2b99d5e525e68285fef21ed17dfbd597ad"
 dependencies = [
  "bstr",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-glob",
+ "gix-features 0.35.0",
+ "gix-filter 0.5.0",
+ "gix-fs 0.7.0",
+ "gix-glob 0.13.0",
  "gix-hash",
- "gix-index",
- "gix-object",
+ "gix-index 0.25.0",
+ "gix-object 0.37.0",
  "gix-path",
- "gix-worktree",
+ "gix-worktree 0.26.0",
  "io-close",
  "thiserror",
 ]
@@ -2868,14 +3409,14 @@ dependencies = [
  "cargo-lock",
  "cvss",
  "fs-err",
- "gix",
+ "gix 0.54.1",
  "home",
  "once_cell",
  "platforms",
  "semver",
  "serde",
  "serde_json",
- "tame-index",
+ "tame-index 0.7.1",
  "tempfile",
  "thiserror",
  "time",
@@ -2893,13 +3434,13 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
- "gix",
+ "gix 0.53.1",
  "once_cell",
  "rust-embed",
  "rustsec",
  "serde",
  "serde_json",
- "tame-index",
+ "tame-index 0.6.0",
  "termcolor",
  "thiserror",
  "toml 0.7.6",
@@ -3189,10 +3730,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6b3fea0e225ef36939de3613334dbbc02da041c1830e4a84260b0137b3bc0c7"
 dependencies = [
  "camino",
- "crossbeam-channel",
- "gix",
+ "gix 0.53.1",
  "home",
  "http",
+ "memchr",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "thiserror",
+ "toml 0.7.6",
+ "twox-hash",
+]
+
+[[package]]
+name = "tame-index"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75ff46a667346d9db1705c17d7bab0e73c9b8a4b7ea60ad3a7cddc74d665c6f"
+dependencies = [
+ "camino",
+ "crossbeam-channel",
+ "gix 0.54.1",
+ "home",
+ "http",
+ "libc",
  "memchr",
  "rayon",
  "reqwest",
@@ -3202,8 +3765,9 @@ dependencies = [
  "smol_str",
  "thiserror",
  "tokio",
- "toml 0.7.6",
+ "toml 0.8.1",
  "twox-hash",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3386,6 +3950,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc1433177506450fe920e46a4f9812d0c211f5dd556da10e731a0a3dfa151f0"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.1",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +3988,19 @@ name = "toml_edit"
 version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca676d9ba1a322c1b64eb8045a5ec5c0cfb0c9d08e15e9ff622589ad5221c8fe"
 dependencies = [
  "indexmap 2.0.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,14 +1450,11 @@ checksum = "f414c99e1a7abc69b21f3225a6539d203b0513f1d1d448607c4ea81cdcf9ee59"
 dependencies = [
  "bytes",
  "crc32fast",
- "crossbeam-channel",
  "flate2",
  "gix-hash",
  "gix-trace",
- "jwalk",
  "libc",
  "once_cell",
- "parking_lot",
  "prodash",
  "sha1_smol",
  "thiserror",
@@ -1472,11 +1469,14 @@ checksum = "9b9ff423ae4983f762659040d13dd7a5defbd54b6a04ac3cc7347741cec828cd"
 dependencies = [
  "bytes",
  "crc32fast",
+ "crossbeam-channel",
  "flate2",
  "gix-hash",
  "gix-trace",
+ "jwalk",
  "libc",
  "once_cell",
+ "parking_lot",
  "prodash",
  "sha1_smol",
  "thiserror",
@@ -1815,7 +1815,6 @@ dependencies = [
  "parking_lot",
  "smallvec",
  "thiserror",
- "uluru",
 ]
 
 [[package]]
@@ -1836,6 +1835,7 @@ dependencies = [
  "parking_lot",
  "smallvec",
  "thiserror",
+ "uluru",
 ]
 
 [[package]]
@@ -3434,7 +3434,7 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
- "gix 0.53.1",
+ "gix 0.54.1",
  "once_cell",
  "rust-embed",
  "rustsec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,123 +1069,56 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a8c9f9452078f474fecd2880de84819b8c77224ab62273275b646bf785f906"
-dependencies = [
- "gix-actor 0.26.0",
- "gix-attributes 0.18.0",
- "gix-commitgraph 0.20.0",
- "gix-config 0.29.0",
- "gix-credentials 0.19.0",
- "gix-date",
- "gix-diff 0.35.0",
- "gix-discover 0.24.0",
- "gix-features 0.34.0",
- "gix-filter 0.4.0",
- "gix-fs 0.6.0",
- "gix-glob 0.12.0",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore 0.7.0",
- "gix-index 0.24.0",
- "gix-lock 9.0.0",
- "gix-macros",
- "gix-negotiate 0.7.0",
- "gix-object 0.36.0",
- "gix-odb 0.52.0",
- "gix-pack 0.42.0",
- "gix-path",
- "gix-pathspec 0.2.0",
- "gix-prompt",
- "gix-protocol 0.39.0",
- "gix-ref 0.36.0",
- "gix-refspec 0.17.0",
- "gix-revision 0.21.0",
- "gix-revwalk 0.7.0",
- "gix-sec",
- "gix-submodule 0.3.0",
- "gix-tempfile 9.0.0",
- "gix-trace",
- "gix-transport 0.36.1",
- "gix-traverse 0.32.0",
- "gix-url 0.23.0",
- "gix-utils",
- "gix-validate",
- "gix-worktree 0.25.0",
- "once_cell",
- "parking_lot",
- "smallvec",
- "thiserror",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix"
 version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6d32e74454459690d57d18ea4ebec1629936e6b130b51d12cb4a81630ac953"
 dependencies = [
- "gix-actor 0.27.0",
- "gix-attributes 0.19.0",
- "gix-commitgraph 0.21.0",
- "gix-config 0.30.0",
- "gix-credentials 0.20.0",
+ "gix-actor",
+ "gix-attributes",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
  "gix-date",
- "gix-diff 0.36.0",
- "gix-discover 0.25.0",
- "gix-features 0.35.0",
- "gix-filter 0.5.0",
- "gix-fs 0.7.0",
- "gix-glob 0.13.0",
+ "gix-diff",
+ "gix-discover",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
  "gix-hash",
  "gix-hashtable",
- "gix-ignore 0.8.0",
- "gix-index 0.25.0",
- "gix-lock 10.0.0",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
  "gix-macros",
- "gix-negotiate 0.8.0",
- "gix-object 0.37.0",
- "gix-odb 0.53.0",
- "gix-pack 0.43.0",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
  "gix-path",
- "gix-pathspec 0.3.0",
+ "gix-pathspec",
  "gix-prompt",
- "gix-protocol 0.40.0",
- "gix-ref 0.37.0",
- "gix-refspec 0.18.0",
- "gix-revision 0.22.0",
- "gix-revwalk 0.8.0",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
  "gix-sec",
- "gix-submodule 0.4.0",
- "gix-tempfile 10.0.0",
+ "gix-submodule",
+ "gix-tempfile",
  "gix-trace",
- "gix-transport 0.37.0",
- "gix-traverse 0.33.0",
- "gix-url 0.24.0",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
  "gix-utils",
  "gix-validate",
- "gix-worktree 0.26.0",
+ "gix-worktree",
  "gix-worktree-state",
  "once_cell",
  "parking_lot",
  "smallvec",
  "thiserror",
  "unicode-normalization",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8c6778cc03bca978b2575a03e04e5ba6f430a9dd9b0f1259f0a8a9a5e5cc66"
-dependencies = [
- "bstr",
- "btoi",
- "gix-date",
- "itoa",
- "thiserror",
- "winnow",
 ]
 
 [[package]]
@@ -1204,30 +1137,13 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3548b76829d33a7160a4685134df16de0cc3b77418302e8a9969f0b662e698f"
-dependencies = [
- "bstr",
- "gix-glob 0.12.0",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "kstring 2.0.0",
- "smallvec",
- "thiserror",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-attributes"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2451665e70709ba4753b623ef97511ee98c4a73816b2c5b5df25678d607ed820"
 dependencies = [
  "bstr",
  "byteyarn",
- "gix-glob 0.13.0",
+ "gix-glob",
  "gix-path",
  "gix-quote",
  "gix-trace",
@@ -1265,51 +1181,16 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4676ede3a7d37e7028e2889830349a6aca22efc1d2f2dd9fa3351c1a8ddb0c6a"
-dependencies = [
- "bstr",
- "gix-chunk",
- "gix-features 0.34.0",
- "gix-hash",
- "memmap2",
- "thiserror",
-]
-
-[[package]]
-name = "gix-commitgraph"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75a975ee22cf0a002bfe9b5d5cb3d2a88e263a8a178cd7509133cff10f4df8a"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-features 0.35.0",
+ "gix-features",
  "gix-hash",
  "memmap2",
  "thiserror",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1108c4ac88248dd25cc8ab0d0dae796e619fb72d92f88e30e00b29d61bb93cc4"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features 0.34.0",
- "gix-glob 0.12.0",
- "gix-path",
- "gix-ref 0.36.0",
- "gix-sec",
- "memchr",
- "once_cell",
- "smallvec",
- "thiserror",
- "unicode-bom",
- "winnow",
 ]
 
 [[package]]
@@ -1320,10 +1201,10 @@ checksum = "c171514b40487d3f677ae37efc0f45ac980e3169f23c27eb30a70b47fdf88ab5"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.35.0",
- "gix-glob 0.13.0",
+ "gix-features",
+ "gix-glob",
  "gix-path",
- "gix-ref 0.37.0",
+ "gix-ref",
  "gix-sec",
  "memchr",
  "once_cell",
@@ -1348,22 +1229,6 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363e16428096b7311c380afe972831ea8b58fc1a1d1621dbdd865caf34921a54"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-config-value",
- "gix-path",
- "gix-prompt",
- "gix-sec",
- "gix-url 0.23.0",
- "thiserror",
-]
-
-[[package]]
-name = "gix-credentials"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46900b884cc5af6a6c141ee741607c0c651a4e1d33614b8d888a1ba81cc0bc8a"
@@ -1374,7 +1239,7 @@ dependencies = [
  "gix-path",
  "gix-prompt",
  "gix-sec",
- "gix-url 0.24.0",
+ "gix-url",
  "thiserror",
 ]
 
@@ -1392,38 +1257,12 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45e342d148373bd9070d557e6fb1280aeae29a3e05e32506682d027278501eb"
-dependencies = [
- "gix-hash",
- "gix-object 0.36.0",
- "thiserror",
-]
-
-[[package]]
-name = "gix-diff"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "788ddb152c388206e81f36bcbb574e7ed7827c27d8fa62227b34edc333d8928c"
 dependencies = [
  "gix-hash",
- "gix-object 0.37.0",
- "thiserror",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4cacda5ee9dd1b38b0e2506834e40e66c08cf050ef55c344334c76745f277b"
-dependencies = [
- "bstr",
- "dunce",
- "gix-hash",
- "gix-path",
- "gix-ref 0.36.0",
- "gix-sec",
+ "gix-object",
  "thiserror",
 ]
 
@@ -1437,28 +1276,9 @@ dependencies = [
  "dunce",
  "gix-hash",
  "gix-path",
- "gix-ref 0.37.0",
+ "gix-ref",
  "gix-sec",
  "thiserror",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f414c99e1a7abc69b21f3225a6539d203b0513f1d1d448607c4ea81cdcf9ee59"
-dependencies = [
- "bytes",
- "crc32fast",
- "flate2",
- "gix-hash",
- "gix-trace",
- "libc",
- "once_cell",
- "prodash",
- "sha1_smol",
- "thiserror",
- "walkdir",
 ]
 
 [[package]]
@@ -1485,51 +1305,22 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbdb2ffae9e595d70f8c7b40953a82706d536bb8107874c258fe6368389832b"
-dependencies = [
- "bstr",
- "encoding_rs",
- "gix-attributes 0.18.0",
- "gix-command",
- "gix-hash",
- "gix-object 0.36.0",
- "gix-packetline-blocking",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-filter"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be40d28cd41445bb6cd52c4d847d915900e5466f7433eaee6a9e0a3d1d88b08"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.19.0",
+ "gix-attributes",
  "gix-command",
  "gix-hash",
- "gix-object 0.37.0",
+ "gix-object",
  "gix-packetline-blocking",
  "gix-path",
  "gix-quote",
  "gix-trace",
  "smallvec",
  "thiserror",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404795da3d4c660c9ab6c3b2ad76d459636d1e1e4b37b0c7ff68eee898c298d4"
-dependencies = [
- "gix-features 0.34.0",
 ]
 
 [[package]]
@@ -1538,19 +1329,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09815faba62fe9b32d918b75a554686c98e43f7d48c43a80df58eb718e5c6635"
 dependencies = [
- "gix-features 0.35.0",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ac79c444193b0660fe0c0925d338bd338bd643e32138784dccfb12c628b892"
-dependencies = [
- "bitflags 2.3.3",
- "bstr",
- "gix-features 0.34.0",
- "gix-path",
+ "gix-features",
 ]
 
 [[package]]
@@ -1561,7 +1340,7 @@ checksum = "a9d76e85f11251dcf751d2c5e918a14f562db5be6f727fd24775245653e9b19d"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
- "gix-features 0.35.0",
+ "gix-features",
  "gix-path",
 ]
 
@@ -1588,49 +1367,14 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ff3ec0fd9fb5bb0ae36b252976b0bc94b45ba969b1639f7402425d9d6baf67"
-dependencies = [
- "bstr",
- "gix-glob 0.12.0",
- "gix-path",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-ignore"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048f443a1f6b02da4205c34d2e287e3fd45d75e8e2f06cfb216630ea9bff5e3"
 dependencies = [
  "bstr",
- "gix-glob 0.13.0",
+ "gix-glob",
  "gix-path",
  "unicode-bom",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9599fc30b3d6aad231687a403f85dfa36ae37ccf1b68ee1f621ad5b7fc7a0d"
-dependencies = [
- "bitflags 2.3.3",
- "bstr",
- "btoi",
- "filetime",
- "gix-bitmap",
- "gix-features 0.34.0",
- "gix-fs 0.6.0",
- "gix-hash",
- "gix-lock 9.0.0",
- "gix-object 0.36.0",
- "gix-traverse 0.32.0",
- "itoa",
- "memmap2",
- "smallvec",
- "thiserror",
 ]
 
 [[package]]
@@ -1644,26 +1388,15 @@ dependencies = [
  "btoi",
  "filetime",
  "gix-bitmap",
- "gix-features 0.35.0",
- "gix-fs 0.7.0",
+ "gix-features",
+ "gix-fs",
  "gix-hash",
- "gix-lock 10.0.0",
- "gix-object 0.37.0",
- "gix-traverse 0.33.0",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
  "itoa",
  "memmap2",
  "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-lock"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1568c3d90594c60d52670f325f5db88c2d572e85c8dd45fabc23d91cadb0fd52"
-dependencies = [
- "gix-tempfile 9.0.0",
- "gix-utils",
  "thiserror",
 ]
 
@@ -1673,7 +1406,7 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47fc96fa8b6b6d33555021907c81eb3b27635daecf6e630630bdad44f8feaa95"
 dependencies = [
- "gix-tempfile 10.0.0",
+ "gix-tempfile",
  "gix-utils",
  "thiserror",
 ]
@@ -1691,53 +1424,18 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208b25af0e59d04e7313479fc949bd68e11a065b51718995139cefac498e24df"
-dependencies = [
- "bitflags 2.3.3",
- "gix-commitgraph 0.20.0",
- "gix-date",
- "gix-hash",
- "gix-object 0.36.0",
- "gix-revwalk 0.7.0",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-negotiate"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f1697bf9911c6d1b8d709b9e6ef718cb5ea5821a1b7991520125a8134448004"
 dependencies = [
  "bitflags 2.3.3",
- "gix-commitgraph 0.21.0",
+ "gix-commitgraph",
  "gix-date",
  "gix-hash",
- "gix-object 0.37.0",
- "gix-revwalk 0.8.0",
+ "gix-object",
+ "gix-revwalk",
  "smallvec",
  "thiserror",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5528d5b2c984044d547e696e44a8c45fa122e83cd8c2ac1da69bd474336be8"
-dependencies = [
- "bstr",
- "btoi",
- "gix-actor 0.26.0",
- "gix-date",
- "gix-features 0.34.0",
- "gix-hash",
- "gix-validate",
- "itoa",
- "smallvec",
- "thiserror",
- "winnow",
 ]
 
 [[package]]
@@ -1748,9 +1446,9 @@ checksum = "1e7e19616c67967374137bae83e950e9b518a9ea8a605069bd6716ada357fd6f"
 dependencies = [
  "bstr",
  "btoi",
- "gix-actor 0.27.0",
+ "gix-actor",
  "gix-date",
- "gix-features 0.35.0",
+ "gix-features",
  "gix-hash",
  "gix-validate",
  "itoa",
@@ -1761,59 +1459,20 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0446eca295459deb3d6dd6ed7d44a631479f1b7381d8087166605c7a9f717c6"
-dependencies = [
- "arc-swap",
- "gix-date",
- "gix-features 0.34.0",
- "gix-hash",
- "gix-object 0.36.0",
- "gix-pack 0.42.0",
- "gix-path",
- "gix-quote",
- "parking_lot",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "gix-odb"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d6a392c6ba3a2f133cdc63120e9bc7aec81eef763db372c817de31febfe64bf"
 dependencies = [
  "arc-swap",
  "gix-date",
- "gix-features 0.35.0",
+ "gix-features",
  "gix-hash",
- "gix-object 0.37.0",
- "gix-pack 0.43.0",
+ "gix-object",
+ "gix-pack",
  "gix-path",
  "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "gix-pack"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be19ee650300d7cbac5829b637685ec44a8d921a7c2eaff8a245d8f2f008870c"
-dependencies = [
- "clru",
- "gix-chunk",
- "gix-features 0.34.0",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.36.0",
- "gix-path",
- "gix-tempfile 9.0.0",
- "memmap2",
- "parking_lot",
- "smallvec",
  "thiserror",
 ]
 
@@ -1825,12 +1484,12 @@ checksum = "7536203a45b31e1bc5694bbf90ba8da1b736c77040dd6a520db369f371eb1ab3"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-features 0.35.0",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-object 0.37.0",
+ "gix-object",
  "gix-path",
- "gix-tempfile 10.0.0",
+ "gix-tempfile",
  "memmap2",
  "parking_lot",
  "smallvec",
@@ -1875,30 +1534,15 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a7885b4ccdc8c80740e465747bf961a8110043fdc1fda3ee80bc81885f42df"
-dependencies = [
- "bitflags 2.3.3",
- "bstr",
- "gix-attributes 0.18.0",
- "gix-config-value",
- "gix-glob 0.12.0",
- "gix-path",
- "thiserror",
-]
-
-[[package]]
-name = "gix-pathspec"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e26c9b47c51be73f98d38c84494bd5fb99334c5d6fda14ef5d036d50a9e5fd"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
- "gix-attributes 0.19.0",
+ "gix-attributes",
  "gix-config-value",
- "gix-glob 0.13.0",
+ "gix-glob",
  "gix-path",
  "thiserror",
 ]
@@ -1918,35 +1562,17 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6ee7fc3f80140ea0651d483ecb9e680403be244849c16237fce45ac80163df"
-dependencies = [
- "bstr",
- "btoi",
- "gix-credentials 0.19.0",
- "gix-date",
- "gix-features 0.34.0",
- "gix-hash",
- "gix-transport 0.36.1",
- "maybe-async",
- "thiserror",
- "winnow",
-]
-
-[[package]]
-name = "gix-protocol"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7b700dc20cc9be8a5130a1fd7e10c34117ffa7068431c8c24d963f0a2e0c9b"
 dependencies = [
  "bstr",
  "btoi",
- "gix-credentials 0.20.0",
+ "gix-credentials",
  "gix-date",
- "gix-features 0.35.0",
+ "gix-features",
  "gix-hash",
- "gix-transport 0.37.0",
+ "gix-transport",
  "maybe-async",
  "thiserror",
  "winnow",
@@ -1965,58 +1591,23 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cccbfa8d5cd9b86465f27a521e0c017de54b92d9fd37c143e49c658a2f04f3a"
-dependencies = [
- "gix-actor 0.26.0",
- "gix-date",
- "gix-features 0.34.0",
- "gix-fs 0.6.0",
- "gix-hash",
- "gix-lock 9.0.0",
- "gix-object 0.36.0",
- "gix-path",
- "gix-tempfile 9.0.0",
- "gix-validate",
- "memmap2",
- "thiserror",
- "winnow",
-]
-
-[[package]]
-name = "gix-ref"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e6b749660b613641769edc1954132eb8071a13c32224891686091bef078de4"
 dependencies = [
- "gix-actor 0.27.0",
+ "gix-actor",
  "gix-date",
- "gix-features 0.35.0",
- "gix-fs 0.7.0",
+ "gix-features",
+ "gix-fs",
  "gix-hash",
- "gix-lock 10.0.0",
- "gix-object 0.37.0",
+ "gix-lock",
+ "gix-object",
  "gix-path",
- "gix-tempfile 10.0.0",
+ "gix-tempfile",
  "gix-validate",
  "memmap2",
  "thiserror",
  "winnow",
-]
-
-[[package]]
-name = "gix-refspec"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678ba30d95baa5462df9875628ed40655d5f5b8aba7028de86ed57f36e762c6c"
-dependencies = [
- "bstr",
- "gix-hash",
- "gix-revision 0.21.0",
- "gix-validate",
- "smallvec",
- "thiserror",
 ]
 
 [[package]]
@@ -2027,25 +1618,9 @@ checksum = "0895cb7b1e70f3c3bd4550c329e9f5caf2975f97fcd4238e05754e72208ef61e"
 dependencies = [
  "bstr",
  "gix-hash",
- "gix-revision 0.22.0",
+ "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e80a5992ae446fe1745dd26523b86084e3f1b6b3e35377fe09b4f35ac8f151"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.36.0",
- "gix-revwalk 0.7.0",
- "gix-trace",
  "thiserror",
 ]
 
@@ -2059,24 +1634,9 @@ dependencies = [
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object 0.37.0",
- "gix-revwalk 0.8.0",
+ "gix-object",
+ "gix-revwalk",
  "gix-trace",
- "thiserror",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b806349bc1f668e09035800e07ac8045da4e39a8925a245d93142c4802224ec1"
-dependencies = [
- "gix-commitgraph 0.20.0",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.36.0",
- "smallvec",
  "thiserror",
 ]
 
@@ -2086,11 +1646,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9870c6b1032f2084567710c3b2106ac603377f8d25766b8a6b7c33e6e3ca279"
 dependencies = [
- "gix-commitgraph 0.21.0",
+ "gix-commitgraph",
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object 0.37.0",
+ "gix-object",
  "smallvec",
  "thiserror",
 ]
@@ -2109,45 +1669,17 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff6b99d735842a3a7fb162b660fa97acec39d576c0ca1700d9eff9344f8625d"
-dependencies = [
- "bstr",
- "gix-config 0.29.0",
- "gix-path",
- "gix-pathspec 0.2.0",
- "gix-refspec 0.17.0",
- "gix-url 0.23.0",
- "thiserror",
-]
-
-[[package]]
-name = "gix-submodule"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0150e82e9282d3f2ab2dd57a22f9f6c3447b9d9856e5321ac92d38e3e0e2b7"
 dependencies = [
  "bstr",
- "gix-config 0.30.0",
+ "gix-config",
  "gix-path",
- "gix-pathspec 0.3.0",
- "gix-refspec 0.18.0",
- "gix-url 0.24.0",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
  "thiserror",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2762b91ff95e27ff3ea95758c0d4efacd7435a1be3629622928b8276de0f72a8"
-dependencies = [
- "gix-fs 0.6.0",
- "libc",
- "once_cell",
- "parking_lot",
- "tempfile",
 ]
 
 [[package]]
@@ -2156,7 +1688,7 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ae0978f3e11dc57290ee75ac2477c815bca1ce2fa7ed5dc5f16db067410ac4d"
 dependencies = [
- "gix-fs 0.7.0",
+ "gix-fs",
  "libc",
  "once_cell",
  "parking_lot",
@@ -2171,25 +1703,6 @@ checksum = "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836"
 
 [[package]]
 name = "gix-transport"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95892eedefd65a6b4312aa5e166d2f740558adfb6854a2b7de73e82e54ef064c"
-dependencies = [
- "base64",
- "bstr",
- "gix-command",
- "gix-credentials 0.19.0",
- "gix-features 0.34.0",
- "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url 0.23.0",
- "reqwest",
- "thiserror",
-]
-
-[[package]]
-name = "gix-transport"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ec726e6a245e68ace59a34126a1d679de60360676612985e70b0d3b102fb4e"
@@ -2197,29 +1710,13 @@ dependencies = [
  "base64",
  "bstr",
  "gix-command",
- "gix-credentials 0.20.0",
- "gix-features 0.35.0",
+ "gix-credentials",
+ "gix-features",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
- "gix-url 0.24.0",
+ "gix-url",
  "reqwest",
- "thiserror",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec6358f8373fb018af8fc96c9d2ec6a5b66999e2377dc40b7801351fec409ed"
-dependencies = [
- "gix-commitgraph 0.20.0",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.36.0",
- "gix-revwalk 0.7.0",
- "smallvec",
  "thiserror",
 ]
 
@@ -2229,28 +1726,14 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ef04ab3643acba289b5cedd25d6f53c0430770b1d689d1d654511e6fb81ba0"
 dependencies = [
- "gix-commitgraph 0.21.0",
+ "gix-commitgraph",
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object 0.37.0",
- "gix-revwalk 0.8.0",
+ "gix-object",
+ "gix-revwalk",
  "smallvec",
  "thiserror",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c79d595b99a6c7ab274f3c991735a0c0f5a816a3da460f513c48edf1c7bf2cc"
-dependencies = [
- "bstr",
- "gix-features 0.34.0",
- "gix-path",
- "home",
- "thiserror",
- "url",
 ]
 
 [[package]]
@@ -2260,7 +1743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6125ecf46e8c68bf7202da6cad239831daebf0247ffbab30210d72f3856e420f"
 dependencies = [
  "bstr",
- "gix-features 0.35.0",
+ "gix-features",
  "gix-path",
  "home",
  "thiserror",
@@ -2288,37 +1771,19 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addabd470ca4ce3ab893e32a5743971a530b8fc0eee5c23844849abf3c9ea6d6"
-dependencies = [
- "bstr",
- "gix-attributes 0.18.0",
- "gix-features 0.34.0",
- "gix-fs 0.6.0",
- "gix-glob 0.12.0",
- "gix-hash",
- "gix-ignore 0.7.0",
- "gix-index 0.24.0",
- "gix-object 0.36.0",
- "gix-path",
-]
-
-[[package]]
-name = "gix-worktree"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f5e32972801bd82d56609e6fc84efc358fa1f11f25c5e83b7807ee2280f14fe"
 dependencies = [
  "bstr",
- "gix-attributes 0.19.0",
- "gix-features 0.35.0",
- "gix-fs 0.7.0",
- "gix-glob 0.13.0",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
  "gix-hash",
- "gix-ignore 0.8.0",
- "gix-index 0.25.0",
- "gix-object 0.37.0",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
  "gix-path",
 ]
 
@@ -2329,15 +1794,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3aeb06960f2c5ac9e4cdb6b38eb3c2b99d5e525e68285fef21ed17dfbd597ad"
 dependencies = [
  "bstr",
- "gix-features 0.35.0",
- "gix-filter 0.5.0",
- "gix-fs 0.7.0",
- "gix-glob 0.13.0",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
  "gix-hash",
- "gix-index 0.25.0",
- "gix-object 0.37.0",
+ "gix-index",
+ "gix-object",
  "gix-path",
- "gix-worktree 0.26.0",
+ "gix-worktree",
  "io-close",
  "thiserror",
 ]
@@ -2661,15 +2126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "kstring"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
-dependencies = [
- "static_assertions",
 ]
 
 [[package]]
@@ -3409,14 +2865,14 @@ dependencies = [
  "cargo-lock",
  "cvss",
  "fs-err",
- "gix 0.54.1",
+ "gix",
  "home",
  "once_cell",
  "platforms",
  "semver",
  "serde",
  "serde_json",
- "tame-index 0.7.1",
+ "tame-index",
  "tempfile",
  "thiserror",
  "time",
@@ -3434,13 +2890,13 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
- "gix 0.54.1",
+ "gix",
  "once_cell",
  "rust-embed",
  "rustsec",
  "serde",
  "serde_json",
- "tame-index 0.6.0",
+ "tame-index",
  "termcolor",
  "thiserror",
  "toml 0.7.6",
@@ -3725,34 +3181,13 @@ dependencies = [
 
 [[package]]
 name = "tame-index"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b3fea0e225ef36939de3613334dbbc02da041c1830e4a84260b0137b3bc0c7"
-dependencies = [
- "camino",
- "gix 0.53.1",
- "home",
- "http",
- "memchr",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "smol_str",
- "thiserror",
- "toml 0.7.6",
- "twox-hash",
-]
-
-[[package]]
-name = "tame-index"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75ff46a667346d9db1705c17d7bab0e73c9b8a4b7ea60ad3a7cddc74d665c6f"
 dependencies = [
  "camino",
  "crossbeam-channel",
- "gix 0.54.1",
+ "gix",
  "home",
  "http",
  "libc",
@@ -3979,7 +3414,7 @@ dependencies = [
  "combine",
  "indexmap 1.9.3",
  "itertools",
- "kstring 1.0.6",
+ "kstring",
  "serde",
 ]
 

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -19,7 +19,7 @@ atom_syndication = "0.12"
 chrono = { version = "0.4", default-features = false, features = ["clock"]  }
 clap = "3"
 comrak = { version = "0.18", default-features = false }
-tame-index = { version = "0.6.0", features = ["git"] }
+tame-index = { version = "0.7.1", features = ["git"] }
 # NOTE: Keep in sync with `gix` used by `tame-index`.
 gix = { version = "0.54", default-features = false, optional = true }
 rust-embed = "6.8.1"

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -21,7 +21,7 @@ clap = "3"
 comrak = { version = "0.18", default-features = false }
 tame-index = { version = "0.6.0", features = ["git"] }
 # NOTE: Keep in sync with `gix` used by `tame-index`.
-gix = { version = "0.53.1", default-features = false, optional = true }
+gix = { version = "0.54", default-features = false, optional = true }
 rust-embed = "6.8.1"
 rustsec = { version = "0.28.0", features = ["osv-export"] }
 serde = { version = "1", features = ["serde_derive"] }

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod error;
 pub mod linter;
 pub mod list_versions;
+pub mod lock;
 pub mod osv_export;
 pub mod prelude;
 pub mod web;

--- a/admin/src/linter.rs
+++ b/admin/src/linter.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     error::{Error, ErrorKind},
-    prelude::*, lock::acquire_cargo_package_lock,
+    lock::acquire_cargo_package_lock,
+    prelude::*,
 };
 use std::{
     fs,
@@ -41,9 +42,12 @@ impl Linter {
     ) -> Result<Self, Error> {
         let repo_path = repo_path.into();
         let cargo_package_lock = acquire_cargo_package_lock()?;
-        let mut crates_index = RemoteGitIndex::new(tame_index::GitIndex::new(
-            tame_index::IndexLocation::new(tame_index::IndexUrl::CratesIoGit),
-        )?, &cargo_package_lock)?;
+        let mut crates_index = RemoteGitIndex::new(
+            tame_index::GitIndex::new(tame_index::IndexLocation::new(
+                tame_index::IndexUrl::CratesIoGit,
+            ))?,
+            &cargo_package_lock,
+        )?;
         crates_index.fetch(&cargo_package_lock)?;
         let advisory_db = rustsec::Database::open(&repo_path)?;
 
@@ -156,7 +160,11 @@ impl Linter {
 
     /// Checks if a crate with this name is present on crates.io
     fn name_exists_on_crates_io(&self, name: &str) -> bool {
-        if let Ok(Some(crate_)) = self.crates_index.krate(name.try_into().unwrap(), true, &acquire_cargo_package_lock().unwrap()) {
+        if let Ok(Some(crate_)) = self.crates_index.krate(
+            name.try_into().unwrap(),
+            true,
+            &acquire_cargo_package_lock().unwrap(),
+        ) {
             // This check verifies name normalization.
             // A request for "serde-json" might return "serde_json",
             // and we want to catch use a non-canonical name and report it as an error.

--- a/admin/src/lock.rs
+++ b/admin/src/lock.rs
@@ -1,0 +1,24 @@
+//! Utiltity functions for file locking
+
+use std::time::Duration;
+
+use tame_index::{utils::flock::LockOptions, index::FileLock};
+
+/// Acquires the Cargo package lock, or fails immediately
+pub fn acquire_cargo_package_lock() -> Result<FileLock, tame_index::Error> {
+    let lock_opts = LockOptions::cargo_package_lock(None)?.exclusive(false);
+    acquire_lock(lock_opts, Duration::from_secs(0))
+}
+
+/// Acquires the provided lock with a speicifed timeout
+pub fn acquire_lock(
+    lock_opts: LockOptions<'_>,
+    lock_timeout: Duration,
+) -> Result<FileLock, tame_index::Error> {
+    if lock_timeout == Duration::from_secs(0) {
+        lock_opts.try_lock()
+    } else {
+        lock_opts.lock(|_| Some(lock_timeout))
+    }
+}
+

--- a/admin/src/lock.rs
+++ b/admin/src/lock.rs
@@ -10,7 +10,7 @@ pub fn acquire_cargo_package_lock() -> Result<FileLock, tame_index::Error> {
     acquire_lock(lock_opts, Duration::from_secs(0))
 }
 
-/// Acquires the provided lock with a speicifed timeout
+/// Acquires the provided lock with a specified timeout
 pub fn acquire_lock(
     lock_opts: LockOptions<'_>,
     lock_timeout: Duration,

--- a/admin/src/lock.rs
+++ b/admin/src/lock.rs
@@ -1,4 +1,4 @@
-//! Utiltity functions for file locking
+//! Utility functions for file locking
 
 use std::time::Duration;
 

--- a/admin/src/lock.rs
+++ b/admin/src/lock.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tame_index::{utils::flock::LockOptions, index::FileLock};
+use tame_index::{index::FileLock, utils::flock::LockOptions};
 
 /// Acquires the Cargo package lock, or fails immediately
 pub fn acquire_cargo_package_lock() -> Result<FileLock, tame_index::Error> {
@@ -21,4 +21,3 @@ pub fn acquire_lock(
         lock_opts.lock(|_| Some(lock_timeout))
     }
 }
-

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -27,10 +27,10 @@ url = { version = "2", features = ["serde"] }
 cargo-edit = { version = "0.9", package = "cargo-edit-9", optional = true, default-features = false, features = [
     "upgrade",
 ] }
-tame-index = { version = "0.6.0", default-features = false, features = ["git", "sparse", "native-certs"], optional = true }
+tame-index = { version = "0.7.1", default-features = false, features = ["git", "sparse", "native-certs"], optional = true }
 home = { version = "0.5", optional = true }
 time = { version = "0.3", default-features = false, features = ["formatting", "serde"], optional = true }
-gix = { version = "0.53.1", default-features = false, features = ["worktree-mutation", "revision"], optional = true}
+gix = { version = "0.54", default-features = false, features = ["worktree-mutation", "revision"], optional = true}
 
 [dev-dependencies]
 tempfile = "3"

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -42,6 +42,10 @@ impl Index {
 /// Operations on crates.io index are rather slow.
 /// Instead of peforming an index lookup for every version of every crate,
 /// this implementation looks up each crate only once and caches the result in memory.
+///
+/// Please note that this struct will hold a global Cargo package lock while it exists.
+/// Cargo operations that download crates (e.g. `cargo update` or even `cargo build`)
+/// will not be possible while this lock is held.
 pub struct CachedIndex {
     index: Index,
     /// The inner hash map is logically HashMap<Version, IsYanked>

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -64,10 +64,6 @@ impl CachedIndex {
     ///
     /// If `lock_timeout` is set to `std::time::Duration::from_secs(0)`, it will not wait at all,
     /// and instead return an error immediately if it fails to aquire the lock.
-    ///
-    /// Regardless of the timeout, this function relies on `panic = unwind` to avoid leaving stale locks
-    /// if the process is interrupted with Ctrl+C. To support `panic = abort` you also need to register
-    /// the `gix` signal handler to clean up the locks, see `gix::interrupt::init_handler`.
     pub fn fetch(client: Option<ClientBuilder>, lock_timeout: Duration) -> Result<Self, Error> {
         Self::fetch_inner(client, lock_timeout).map_err(Error::from_tame)
     }
@@ -121,10 +117,6 @@ impl CachedIndex {
     ///
     /// If `lock_timeout` is set to `std::time::Duration::from_secs(0)`, it will not wait at all,
     /// and instead return an error immediately if it fails to aquire the lock.
-    ///
-    /// Regardless of the timeout, this function relies on `panic = unwind` to avoid leaving stale locks
-    /// if the process is interrupted with Ctrl+C. To support `panic = abort` you also need to register
-    /// the `gix` signal handler to clean up the locks, see `gix::interrupt::init_handler`.
     pub fn open(lock_timeout: Duration) -> Result<Self, Error> {
         Self::open_inner(lock_timeout).map_err(Error::from_tame)
     }

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -288,6 +288,7 @@ impl CachedIndex {
     }
 }
 
+// We cannot expose these publicly because that would leak the `tame_index` SemVer into the public API
 fn acquire_cargo_package_lock(lock_timeout: Duration) -> Result<FileLock, tame_index::Error> {
     let lock_opts = LockOptions::cargo_package_lock(None)?.exclusive(false);
     acquire_lock(lock_opts, lock_timeout)

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -153,7 +153,9 @@ impl Error {
     pub(crate) fn from_tame(err: tame_index::Error) -> Self {
         // Separate lock timeouts into their own LockTimeout variant.
         match err {
-            tame_index::Error::Lock(lock_err) => format_err!(ErrorKind::LockTimeout, "{}", lock_err),
+            tame_index::Error::Lock(lock_err) => {
+                format_err!(ErrorKind::LockTimeout, "{}", lock_err)
+            }
             other => format_err!(ErrorKind::Registry, "{}", other),
         }
     }

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -156,10 +156,7 @@ impl Error {
     pub(crate) fn from_tame(err: tame_index::Error) -> Self {
         // Separate lock timeouts into their own LockTimeout variant.
         match err {
-            tame_index::Error::Git(git_err) => match git_err {
-                tame_index::error::GitError::Lock(lock_err) => Self::from_gix_lock(lock_err),
-                other => format_err!(ErrorKind::Registry, "{}", other),
-            },
+            tame_index::Error::Lock(lock_err) => format_err!(ErrorKind::LockTimeout, "{}", lock_err),
             other => format_err!(ErrorKind::Registry, "{}", other),
         }
     }

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -99,13 +99,15 @@ impl Repository {
         // Lock the directory to avoid several checkouts running at the same time trampling on each other.
         // We do not use Git locks because they are very poorly designed - they leave stale locks on SIGKILL or power loss
         // with no way to recover. They don't even write the PID to the lockfile.
-        let tame_index_path = tame_index::Path::from_path(&path).expect("Non-UTF-8 path to the database");
+        let tame_index_path =
+            tame_index::Path::from_path(&path).expect("Non-UTF-8 path to the database");
         let lock_opts = LockOptions::new(tame_index_path).exclusive(false);
         let _lock = if lock_timeout == Duration::from_secs(0) {
             lock_opts.try_lock()
         } else {
             lock_opts.lock(|_| Some(lock_timeout))
-        }.map_err(Error::from_tame)?;
+        }
+        .map_err(Error::from_tame)?;
 
         let open_or_clone_repo = || -> Result<_, Error> {
             let mut mapping = gix::sec::trust::Mapping::default();

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -100,8 +100,8 @@ impl Repository {
         // We do not use Git locks because they are very poorly designed - they leave stale locks on SIGKILL or power loss
         // with no way to recover. They don't even write the PID to the lockfile.
         let lock_path = tame_index::Path::from_path(&path)
-            .expect("Non-UTF-8 path to the database")
-            .with_extension(".lock"); // TODO: format_err!
+            .ok_or_else(|| format_err!(ErrorKind::BadParam, "Path to the advisory DB directory is not valid UTF-8!"))?
+            .with_extension(".lock");
         let lock_opts = LockOptions::new(&lock_path).exclusive(false);
         let _lock = if lock_timeout == Duration::from_secs(0) {
             lock_opts.try_lock()

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -100,7 +100,12 @@ impl Repository {
         // We do not use Git locks because they are very poorly designed - they leave stale locks on SIGKILL or power loss
         // with no way to recover. They don't even write the PID to the lockfile.
         let lock_path = tame_index::Path::from_path(&path)
-            .ok_or_else(|| format_err!(ErrorKind::BadParam, "Path to the advisory DB directory is not valid UTF-8!"))?
+            .ok_or_else(|| {
+                format_err!(
+                    ErrorKind::BadParam,
+                    "Path to the advisory DB directory is not valid UTF-8!"
+                )
+            })?
             .with_extension(".lock");
         let lock_opts = LockOptions::new(&lock_path).exclusive(false);
         let _lock = if lock_timeout == Duration::from_secs(0) {

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -1,5 +1,5 @@
 //! Git repositories
-use tame_index::external::gix;
+use tame_index::{external::gix, utils::flock::LockOptions};
 
 use super::{Commit, DEFAULT_URL};
 use crate::{
@@ -45,10 +45,6 @@ impl Repository {
     /// This function will wait for up to 5 minutes for the filesystem lock on the repository.
     /// It will fail with [`rustsec::Error::LockTimeout`](Error) if the lock is still held
     /// after that time. Use [Repository::fetch] if you need to configure locking behavior.
-    ///
-    /// Regardless of the timeout, this function relies on `panic = unwind` to avoid leaving stale locks
-    /// if the process is interrupted with Ctrl+C. To support `panic = abort` you also need to register
-    /// the `gix` signal handler to clean up the locks, see `gix::interrupt::init_handler`.
     pub fn fetch_default_repo() -> Result<Self, Error> {
         Self::fetch(
             DEFAULT_URL,
@@ -68,10 +64,6 @@ impl Repository {
     ///
     /// If `lock_timeout` is set to `std::time::Duration::from_secs(0)`, it will not wait at all,
     /// and instead return an error immediately if it fails to aquire the lock.
-    ///
-    /// Regardless of the timeout, this function relies on `panic = unwind` to avoid leaving stale locks
-    /// if the process is interrupted with Ctrl+C. To support `panic = abort` you also need to register
-    /// the `gix` signal handler to clean up the locks, see `gix::interrupt::init_handler`.
     pub fn fetch<P: Into<PathBuf>>(
         url: &str,
         into_path: P,
@@ -104,20 +96,16 @@ impl Repository {
             fs::remove_dir(&path)?;
         }
 
-        // Acquire the lock on the checkout directory
-        let lock_policy = if lock_timeout == Duration::from_secs(0) {
-            gix::lock::acquire::Fail::Immediately
+        // Lock the directory to avoid several checkouts running at the same time trampling on each other.
+        // We do not use Git locks because they are very poorly designed - they leave stale locks on SIGKILL or power loss
+        // with no way to recover. They don't even write the PID to the lockfile.
+        let tame_index_path = tame_index::Path::from_path(&path).expect("Non-UTF-8 path to the database");
+        let lock_opts = LockOptions::new(tame_index_path).exclusive(false);
+        let _lock = if lock_timeout == Duration::from_secs(0) {
+            lock_opts.try_lock()
         } else {
-            gix::lock::acquire::Fail::AfterDurationWithBackoff(lock_timeout)
-        };
-        let _lock = gix::lock::Marker::acquire_to_hold_resource(
-            path.with_extension("rustsec"),
-            lock_policy,
-            Some(std::path::PathBuf::from_iter(Some(
-                std::path::Component::RootDir,
-            ))),
-        )
-        .map_err(Error::from_gix_lock)?;
+            lock_opts.lock(|_| Some(lock_timeout))
+        }.map_err(Error::from_tame)?;
 
         let open_or_clone_repo = || -> Result<_, Error> {
             let mut mapping = gix::sec::trust::Mapping::default();

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -97,7 +97,7 @@ impl Repository {
         }
 
         // Lock the directory to avoid several checkouts running at the same time trampling on each other.
-        // We do not use Git locks because they are very poorly designed - they leave stale locks on SIGKILL or power loss
+        // We do not use Git locks because they have undesirable properties - they leave stale locks on SIGKILL or power loss
         // with no way to recover. They don't even write the PID to the lockfile.
         let lock_path = tame_index::Path::from_path(&path)
             .ok_or_else(|| {

--- a/rustsec/src/repository/git/repository.rs
+++ b/rustsec/src/repository/git/repository.rs
@@ -99,9 +99,10 @@ impl Repository {
         // Lock the directory to avoid several checkouts running at the same time trampling on each other.
         // We do not use Git locks because they are very poorly designed - they leave stale locks on SIGKILL or power loss
         // with no way to recover. They don't even write the PID to the lockfile.
-        let tame_index_path =
-            tame_index::Path::from_path(&path).expect("Non-UTF-8 path to the database");
-        let lock_opts = LockOptions::new(tame_index_path).exclusive(false);
+        let lock_path = tame_index::Path::from_path(&path)
+            .expect("Non-UTF-8 path to the database")
+            .with_extension(".lock"); // TODO: format_err!
+        let lock_opts = LockOptions::new(&lock_path).exclusive(false);
         let _lock = if lock_timeout == Duration::from_secs(0) {
             lock_opts.try_lock()
         } else {


### PR DESCRIPTION
Switch from Git-compatible locks provided by `gix` to an interface around OS locks provided by `tame-index`. Git locks are very poorly designed, being plain lock files without even a PID written into them; so stale locks are left behind on SIGKILL or power loss with no way to recover.

Also acquire the global Cargo package lock when doing crates.io index lookups, to avoid racing with Cargo itself when fetching crates index.

Fixes #1011