### PR TITLE
Configure `gix` with `max-performance-safe` feature

### DIFF
--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -30,7 +30,7 @@ cargo-edit = { version = "0.9", package = "cargo-edit-9", optional = true, defau
 tame-index = { version = "0.7.1", default-features = false, features = ["git", "sparse", "native-certs"], optional = true }
 home = { version = "0.5", optional = true }
 time = { version = "0.3", default-features = false, features = ["formatting", "serde"], optional = true }
-gix = { version = "0.54", default-features = false, features = ["worktree-mutation", "revision"], optional = true}
+gix = { version = "0.54", default-features = false, features = ["worktree-mutation", "revision", "max-performance-safe"], optional = true}
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Does not any dependencies that aren't already in the dependency tree.