### PR TITLE
Fix deadlock on missing lockfile

### DIFF
--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -1,8 +1,6 @@
 //! Core auditing functionality
 
-use crate::{
-    binary_format::BinaryFormat, config::AuditConfig, lockfile, prelude::*, presenter::Presenter,
-};
+use crate::{binary_format::BinaryFormat, config::AuditConfig, prelude::*, presenter::Presenter};
 use rustsec::{registry, report, Error, ErrorKind, Lockfile, Warning, WarningKind};
 use std::{
     io::{self, Read},
@@ -10,9 +8,6 @@ use std::{
     process::exit,
     time::Duration,
 };
-
-/// Name of `Cargo.lock`
-const CARGO_LOCK_FILE: &str = "Cargo.lock";
 
 // TODO: make configurable
 const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
@@ -162,21 +157,7 @@ impl Auditor {
     }
 
     /// Perform an audit of a textual `Cargo.lock` file
-    pub fn audit_lockfile(
-        &mut self,
-        maybe_lockfile_path: Option<&Path>,
-    ) -> rustsec::Result<rustsec::Report> {
-        let lockfile_path = match maybe_lockfile_path {
-            Some(p) => p,
-            None => {
-                let path = Path::new(CARGO_LOCK_FILE);
-                if !path.exists() && Path::new("Cargo.toml").exists() {
-                    lockfile::generate()?;
-                }
-                path
-            }
-        };
-
+    pub fn audit_lockfile(&mut self, lockfile_path: &Path) -> rustsec::Result<rustsec::Report> {
         let lockfile = match self.load_lockfile(lockfile_path) {
             Ok(l) => l,
             Err(e) => {

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -41,8 +41,12 @@ impl FixCommand {
 
 impl Runnable for FixCommand {
     fn run(&self) {
-        let report = self.auditor().audit_lockfile(self.cargo_lock_path());
+        let path = lockfile::locate_or_generate(self.cargo_lock_path()).unwrap_or_else(|e| {
+            status_err!("{}", e);
+            exit(2);
+        });
 
+        let report = self.auditor().audit_lockfile(&path);
         let report = match report {
             Ok(report) => {
                 if report.vulnerabilities.list.is_empty() {

--- a/cargo-audit/src/lockfile.rs
+++ b/cargo-audit/src/lockfile.rs
@@ -1,7 +1,28 @@
 //! Cargo.lock-related utilities
 
 use rustsec::{Error, ErrorKind};
-use std::process::Command;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Name of `Cargo.lock`
+const CARGO_LOCK_FILE: &str = "Cargo.lock";
+
+/// Tries to locate the lockfile at the specified file path. If it's missing, tries to generate it from `Cargo.toml`.
+/// Defaults to `Cargo.lock` in the current directory if passed `None` as the path.
+pub fn locate_or_generate(maybe_lockfile_path: Option<&Path>) -> rustsec::Result<PathBuf> {
+    match maybe_lockfile_path {
+        Some(p) => Ok(p.into()),
+        None => {
+            let path = Path::new(CARGO_LOCK_FILE);
+            if !path.exists() && Path::new("Cargo.toml").exists() {
+                generate()?;
+            }
+            Ok(path.into())
+        }
+    }
+}
 
 /// Run `cargo generate-lockfile`
 pub fn generate() -> rustsec::Result<()> {


### PR DESCRIPTION
Fixes #1050

Sadly no tests because `abscissa::Runner` does not let you set the working directory, and adding it would require not only a new Abscissa release but also a migration from Abscissa v3 to v4 in `cargo-audit`, which is non-trivial.