### PR TITLE
fix typo html in advisory scores

### DIFF
--- a/admin/src/web/templates/advisory-content.html
+++ b/admin/src/web/templates/advisory-content.html
@@ -168,7 +168,7 @@
 
           {% match cvss.ac %}
           {% when Some with (ac) %}
-          <dt>Attack complexity</dt><dd>{{ "{:?}"|format(ac) }}</d>
+          <dt>Attack complexity</dt><dd>{{ "{:?}"|format(ac) }}</dd>
           {% when None %}
           {% endmatch %}
 


### PR DESCRIPTION
discovered by atom feed validator: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Frustsec.org%2Ffeed.xml