### PR TITLE
Display the chain of sources for errors in `cargo audit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "binfarce",
  "cargo-lock",
  "clap",
+ "display-error-chain",
  "home",
  "is-terminal",
  "once_cell",
@@ -799,6 +800,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "display-error-chain"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f77af9e75578c1ab34f5f04545a8b05be0c36fbd7a9bb3cf2d2a971e435fdbb9"
 
 [[package]]
 name = "dunce"

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -33,6 +33,7 @@ quitters = { version = "0.1", optional = true }
 once_cell = { version = "1.5", optional = true }
 binfarce = { version = "0.2", optional = true }
 is-terminal = "0.4.9"
+display-error-chain = "0.2.0"
 
 [dev-dependencies]
 once_cell = "1.5"

--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -1,6 +1,9 @@
 //! Core auditing functionality
 
-use crate::{binary_format::BinaryFormat, config::AuditConfig, prelude::*, presenter::Presenter};
+use crate::{
+    binary_format::BinaryFormat, config::AuditConfig, error::display_err_with_source, prelude::*,
+    presenter::Presenter,
+};
 use rustsec::{registry, report, Error, ErrorKind, Lockfile, Warning, WarningKind};
 use std::{
     io::{self, Read},
@@ -70,17 +73,26 @@ impl Auditor {
             }
 
             let advisory_db_repo = result.unwrap_or_else(|e| {
-                status_err!("couldn't fetch advisory database: {}", e);
+                status_err!(
+                    "couldn't fetch advisory database: {}",
+                    display_err_with_source(&e)
+                );
                 exit(1);
             });
 
             rustsec::Database::load_from_repo(&advisory_db_repo).unwrap_or_else(|e| {
-                status_err!("error loading advisory database: {}", e);
+                status_err!(
+                    "error loading advisory database: {}",
+                    display_err_with_source(&e)
+                );
                 exit(1);
             })
         } else {
             rustsec::Database::open(&advisory_db_path).unwrap_or_else(|e| {
-                status_err!("error loading advisory database: {}", e);
+                status_err!(
+                    "error loading advisory database: {}",
+                    display_err_with_source(&e)
+                );
                 exit(1);
             })
         };
@@ -195,7 +207,7 @@ impl Auditor {
                     }
                 }
                 Err(e) => {
-                    status_err!("{}", e);
+                    status_err!("{}", display_err_with_source(&e));
                     summary.errors_encountered = true;
                 }
             }
@@ -282,7 +294,10 @@ impl Auditor {
                         let warning = Warning::new(WarningKind::Yanked, pkg, None, None, None);
                         result.push(warning);
                     }
-                    Err(e) => status_err!("couldn't check if the package is yanked: {}", e),
+                    Err(e) => status_err!(
+                        "couldn't check if the package is yanked: {}",
+                        display_err_with_source(&e)
+                    ),
                 }
             }
         }

--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -12,6 +12,7 @@ use crate::{
     auditor::Auditor,
     cli_config::CliConfig,
     config::{AuditConfig, DenyOption},
+    error::display_err_with_source,
     lockfile,
     prelude::*,
 };
@@ -216,7 +217,7 @@ impl Runnable for AuditCommand {
         // It is important to generate the lockfile before initializing the auditor,
         // otherwise we might deadlock because both need the Cargo package lock
         let path = lockfile::locate_or_generate(maybe_path).unwrap_or_else(|e| {
-            status_err!("{}", e);
+            status_err!("{}", display_err_with_source(&e));
             exit(2);
         });
         let mut auditor = self.auditor();
@@ -229,7 +230,7 @@ impl Runnable for AuditCommand {
                 exit(0);
             }
             Err(e) => {
-                status_err!("{}", e);
+                status_err!("{}", display_err_with_source(&e));
                 exit(2);
             }
         };

--- a/cargo-audit/src/error.rs
+++ b/cargo-audit/src/error.rs
@@ -2,6 +2,7 @@
 
 use abscissa_core::error::{BoxError, Context};
 use std::{
+    error::Error as ErrorTrait,
     fmt::{self, Display},
     io,
     ops::Deref,
@@ -111,4 +112,13 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.0.source()
     }
+}
+
+/// Displays the error and also follows the chain of the `.source` fields,
+/// printing any errors that caused the top-level error.
+///
+/// This is required to properly present some `gix` errors to the user:
+/// https://github.com/rustsec/rustsec/issues/1029#issuecomment-1777487808
+pub fn display_err_with_source<E: ErrorTrait>(error: &E) -> String {
+    display_error_chain::DisplayErrorChain::new(error).to_string()
 }

--- a/cargo-audit/src/error.rs
+++ b/cargo-audit/src/error.rs
@@ -118,7 +118,7 @@ impl std::error::Error for Error {
 /// printing any errors that caused the top-level error.
 ///
 /// This is required to properly present some `gix` errors to the user:
-/// https://github.com/rustsec/rustsec/issues/1029#issuecomment-1777487808
+/// <https://github.com/rustsec/rustsec/issues/1029#issuecomment-1777487808>
 pub fn display_err_with_source<E: ErrorTrait>(error: &E) -> String {
     display_error_chain::DisplayErrorChain::new(error).to_string()
 }


### PR DESCRIPTION
Should fix #1053

I'm not proud of this code but I don't see a way to do it better.

We often operate on `rustsec`  errors without converting them to `cargo-audit` errors, so a custom formatting routine for `cargo_audit::Error` would not help much - we'd have to introduce an extra magic conversion for no apparent reason, which would be confusing. And hijacking the `Display` impl in `rustsec` seems wrong, it's library code after all.

This could also be solved with a macro, but Rust macros aren't exactly readable. It's a whole separate DSL embedded inside Rust, and I'd rather keep it simple and stupid.