### PR TITLE
New rustsec v0.28.4 release with updated `gix` and `tame-index`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.28.3"
+version = "0.28.4"
 dependencies = [
  "cargo-edit-9",
  "cargo-lock",

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.28.4 (2023-11-17)
+
+### Changed
+
+ - Upgraded dependencies `gix` to 0.55.x and `tame-index` to 0.8.x ([#1061])
+
+[#1061]: https://github.com/rustsec/rustsec/pull/1061
+
 ## 0.28.3 (2023-10-14)
 
 ### Changed

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "rustsec"
 description  = "Client library for the RustSec security advisory database"
-version      = "0.28.3"
+version      = "0.28.4"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"


### PR DESCRIPTION
Motivated by  #1065