### PR TITLE
Add a `source` field to `rustsec::Error`, and use it in simple cases.

### DIFF
--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -173,9 +173,10 @@ impl Auditor {
         let lockfile = match self.load_lockfile(lockfile_path) {
             Ok(l) => l,
             Err(e) => {
-                return Err(Error::new(
+                return Err(Error::with_source(
                     ErrorKind::NotFound,
-                    &format!("Couldn't load {}: {}", lockfile_path.display(), e),
+                    format!("Couldn't load {}", lockfile_path.display()),
+                    e,
                 ))
             }
         };

--- a/cargo-audit/src/binary_deps.rs
+++ b/cargo-audit/src/binary_deps.rs
@@ -42,10 +42,24 @@ pub fn load_deps_from_binary(binary_path: &Path) -> rustsec::Result<(BinaryForma
             // The error handling boilerplate is in here instead of the `rustsec` crate because as of this writing
             // the public APIs of the crates involved are still somewhat unstable,
             // and this way we don't expose the error types in any public APIs
-            Io(_) => Err(Error::new(ErrorKind::Io, &e.to_string())),
+            Io(_) => Err(Error::with_source(
+                ErrorKind::Io,
+                format!(
+                    "could not extract dependencies from binary {}",
+                    binary_path.display()
+                ),
+                e,
+            )),
             // Everything else is just Parse, but we enumerate them explicitly in case variant list changes
             InputLimitExceeded | OutputLimitExceeded | BinaryParsing(_) | Decompression(_)
-            | Json(_) | Utf8(_) => Err(Error::new(ErrorKind::Parse, &e.to_string())),
+            | Json(_) | Utf8(_) => Err(Error::with_source(
+                ErrorKind::Parse,
+                format!(
+                    "could not extract dependencies from binary {}",
+                    binary_path.display()
+                ),
+                e,
+            )),
         },
     }
 }

--- a/cargo-audit/src/lockfile.rs
+++ b/cargo-audit/src/lockfile.rs
@@ -29,9 +29,10 @@ pub fn generate() -> rustsec::Result<()> {
     let status = Command::new("cargo").arg("generate-lockfile").status();
 
     if let Err(e) = status {
-        return Err(Error::new(
+        return Err(Error::with_source(
             ErrorKind::Io,
-            &format!("couldn't run `cargo generate-lockfile`: {}", e),
+            "couldn't run `cargo generate-lockfile`".to_string(),
+            e,
         ));
     }
     let status = status.unwrap();

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -275,8 +275,12 @@ impl CachedIndex {
         let package_names: BTreeSet<&package::Name> =
             dedup_packages.iter().map(|p| &p.name).collect();
         if let Err(e) = self.populate_cache(package_names) {
-            yanked.push(Err(Error::new(ErrorKind::Registry,
-                &format!("Failed to download crates.io index: {}\nData may be missing or stale when checking for yanked packages.", e)
+            yanked.push(Err(Error::with_source(
+                ErrorKind::Registry,
+                "Failed to download crates.io index. \
+                    Data may be missing or stale when checking for yanked packages."
+                    .to_owned(),
+                e,
             )));
         }
 


### PR DESCRIPTION
As discussed in https://github.com/rustsec/rustsec/issues/1029#issuecomment-1815785981

This is a semver-compatible change because it only adds a private field and a new constructor: `rustsec::Error::with_source()`.

Note that there are many remaining cases where `Error` is constructed with `format_err!`, that stringify a source error; this PR only addresses the easy cases of the `Error::new()` calls.
