### PR TITLE
Cargo.toml: use `resolver = "2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "admin",
     "cargo-audit",


### PR DESCRIPTION
Eliminates the warnings we're getting about using an old resolver