### PR TITLE
.cargo/audit.toml: ignore RUSTSEC-2024-0013

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,6 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2020-0071", # `time` localtime_r segfault
-    "RUSTSEC-2020-0159", # `chrono` localtime_r segfault
+    "RUSTSEC-2024-0013", # libgit2-sys RCE, see #1107
 ]
 
 [output]


### PR DESCRIPTION
It has no immediate resolution due to the `fix` feature using unmaintained/out-of-date dependencies.

We're discussing what to do in #1107 and are definitely aware of the issue. This acknowledges it and allows us to move forward on other development without breaking the build.