### PR TITLE
Do not run `cargo update` when auditing

### DIFF
--- a/cargo-audit/src/lockfile.rs
+++ b/cargo-audit/src/lockfile.rs
@@ -26,7 +26,10 @@ pub fn locate_or_generate(maybe_lockfile_path: Option<&Path>) -> rustsec::Result
 
 /// Run `cargo generate-lockfile`
 pub fn generate() -> rustsec::Result<()> {
-    let status = Command::new("cargo").arg("update").arg("--workspace").status();
+    let status = Command::new("cargo")
+        .arg("update")
+        .arg("--workspace")
+        .status();
 
     if let Err(e) = status {
         return Err(Error::with_source(

--- a/cargo-audit/src/lockfile.rs
+++ b/cargo-audit/src/lockfile.rs
@@ -26,12 +26,12 @@ pub fn locate_or_generate(maybe_lockfile_path: Option<&Path>) -> rustsec::Result
 
 /// Run `cargo generate-lockfile`
 pub fn generate() -> rustsec::Result<()> {
-    let status = Command::new("cargo").arg("generate-lockfile").status();
+    let status = Command::new("cargo").arg("update").arg("--workspace").status();
 
     if let Err(e) = status {
         return Err(Error::with_source(
             ErrorKind::Io,
-            "couldn't run `cargo generate-lockfile`".to_string(),
+            "couldn't run `cargo update --workspace` to generate a lockfile".to_string(),
             e,
         ));
     }
@@ -40,10 +40,10 @@ pub fn generate() -> rustsec::Result<()> {
     if !status.success() {
         let msg = match status.code() {
             Some(code) => format!(
-                "non-zero exit status running `cargo generate-lockfile`: {}",
+                "non-zero exit status running `cargo update --workspace`: {}",
                 code
             ),
-            _ => "no exit status running `cargo generate-lockfile`!".to_string(),
+            _ => "no exit status running `cargo update --workspace`!".to_string(),
         };
 
         return Err(Error::new(ErrorKind::Io, &msg));


### PR DESCRIPTION
`cargo generate-lockfile` behaves like `cargo update` according to its documentation:

> This command will create the Cargo.lock lockfile for the current package or workspace. If the lockfile already exists, it will be rebuilt with the latest available version of every package.

Instead use `cargo update --workspace` that is documented as:

> Attempt to update only packages defined in the workspace. Other packages are updated only if they don’t already exist in the lockfile. This option is useful for updating Cargo.lock after you’ve changed version numbers in Cargo.toml.

I have verified that the `--workspace` option works even there is no workspace.