### PR TITLE
Rewrite `cargo audit fix`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "arc-swap",
  "backtrace",
  "canonical-path",
- "clap 4.4.18",
+ "clap",
  "color-eyre",
  "fs-err",
  "once_cell",
@@ -129,12 +129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
-
-[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,17 +212,6 @@ dependencies = [
  "diligent-date-parser",
  "never",
  "quick-xml",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -346,12 +329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,9 +339,6 @@ name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "canonical-path"
@@ -381,7 +355,7 @@ dependencies = [
  "auditable-serde",
  "binfarce",
  "cargo-lock",
- "clap 4.4.18",
+ "clap",
  "display-error-chain",
  "home",
  "is-terminal",
@@ -393,37 +367,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml 0.7.8",
-]
-
-[[package]]
-name = "cargo-edit-9"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01376e3919650540a7a8d58d280e358d0db5a041b225ef4556c95cba58b091bb"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "clap 3.2.25",
- "concolor-control",
- "crates-index",
- "dirs-next",
- "dunce",
- "env_proxy",
- "git2",
- "hex",
- "indexmap 1.9.3",
- "native-tls",
- "pathdiff",
- "regex",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "subprocess",
- "termcolor",
- "toml_edit 0.13.4",
- "ureq",
- "url",
 ]
 
 [[package]]
@@ -439,34 +382,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-platform"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -490,30 +410,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim",
- "termcolor",
- "terminal_size",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.7",
+ "clap_derive",
 ]
 
 [[package]]
@@ -524,21 +426,8 @@ checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
+ "clap_lex",
  "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -551,15 +440,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -594,16 +474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "comrak"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,23 +488,6 @@ dependencies = [
  "typed-arena",
  "unicode_categories",
 ]
-
-[[package]]
-name = "concolor-control"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7104119c2f80d887239879d0c50e033cd40eac9a3f3561e0684ba7d5d654f4da"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "concolor-query",
-]
-
-[[package]]
-name = "concolor-query"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad159cc964ac8f9d407cbc0aa44b02436c054b541f2b4b5f06972e1efdc54bc7"
 
 [[package]]
 name = "core-foundation"
@@ -659,26 +512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crates-index"
-version = "0.19.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3cab38e209d6ba8bd5b0d41c784ec63a5a9ea3adf866b820d377588960f1ded"
-dependencies = [
- "git2",
- "hex",
- "home",
- "memchr",
- "rayon",
- "rustc-hash",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "smol_str",
- "toml 0.7.8",
 ]
 
 [[package]]
@@ -865,27 +698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "display-error-chain"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,16 +729,6 @@ name = "entities"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
-
-[[package]]
-name = "env_proxy"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
-dependencies = [
- "log",
- "url",
-]
 
 [[package]]
 name = "equivalent"
@@ -1002,21 +804,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1112,21 +899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "git2"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
-
-[[package]]
 name = "gix"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,7 +977,7 @@ dependencies = [
  "gix-path",
  "gix-quote",
  "gix-trace",
- "kstring 2.0.0",
+ "kstring",
  "smallvec",
  "thiserror",
  "unicode-bom",
@@ -1429,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe47d8c0887f82355e2e9e16b6cecaa4d5e5346a7a474ca78ff94de1db35a5b"
 dependencies = [
  "gix-hash",
- "hashbrown 0.14.3",
+ "hashbrown",
  "parking_lot",
 ]
 
@@ -1466,7 +1238,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix 0.38.31",
+ "rustix",
  "smallvec",
  "thiserror",
 ]
@@ -1630,7 +1402,7 @@ dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot",
- "rustix 0.38.31",
+ "rustix",
  "thiserror",
 ]
 
@@ -1915,18 +1687,12 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1942,27 +1708,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "home"
@@ -2098,22 +1846,12 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2124,17 +1862,6 @@ checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.4",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2149,18 +1876,9 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe8f25ce1159c7740ff0b9b2f5cdf4a8428742ba7c112b9f20f22cd5219c7dab"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2168,15 +1886,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2199,15 +1908,6 @@ dependencies = [
 
 [[package]]
 name = "kstring"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "kstring"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
@@ -2226,63 +1926,6 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.14.2+1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libredox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
-dependencies = [
- "bitflags 2.4.2",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2393,24 +2036,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "never"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,7 +2082,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2486,54 +2111,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "openssl"
-version = "0.10.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "overload"
@@ -2571,12 +2152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,7 +2164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap",
 ]
 
 [[package]]
@@ -2605,12 +2180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
-
-[[package]]
 name = "platforms"
 version = "3.3.0"
 dependencies = [
@@ -2622,30 +2191,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -2717,17 +2262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -2873,26 +2407,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,7 +2415,7 @@ dependencies = [
  "bitflags 2.4.2",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -2952,7 +2466,6 @@ dependencies = [
 name = "rustsec"
 version = "0.28.6"
 dependencies = [
- "cargo-edit-9",
  "cargo-lock",
  "cvss",
  "fs-err",
@@ -2979,7 +2492,7 @@ dependencies = [
  "askama",
  "atom_syndication",
  "chrono",
- "clap 4.4.18",
+ "clap",
  "comrak",
  "gix",
  "once_cell",
@@ -3206,17 +2719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,16 +2735,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "subprocess"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "syn"
@@ -3339,7 +2831,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix 0.38.31",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -3350,25 +2842,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
-dependencies = [
- "rustix 0.37.27",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-dependencies = [
- "terminal_size",
 ]
 
 [[package]]
@@ -3533,24 +3006,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744e9ed5b352340aa47ce033716991b5589e23781acb97cad37d4ea70560f55b"
-dependencies = [
- "combine",
- "indexmap 1.9.3",
- "itertools",
- "kstring 1.0.6",
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3563,7 +3023,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3746,25 +3206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
-dependencies = [
- "base64",
- "log",
- "native-tls",
- "once_cell",
- "rustls",
- "rustls-webpki",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots",
-]
-
-[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3787,12 +3228,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -46,5 +46,5 @@ features = ["testing"]
 
 [features]
 default = ["binary-scanning"]
-fix = ["rustsec/fix"]
+fix = []
 binary-scanning = ["dep:auditable-info", "dep:cargo-lock", "dep:auditable-serde", "dep:binfarce", "dep:quitters", "dep:once_cell"]

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -45,6 +45,6 @@ version = "0.7"
 features = ["testing"]
 
 [features]
-default = ["binary-scanning"]
+default = ["binary-scanning", "fix"]
 fix = ["rustsec/fix"]
 binary-scanning = ["dep:auditable-info", "dep:cargo-lock", "dep:auditable-serde", "dep:binfarce", "dep:quitters", "dep:once_cell"]

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -45,6 +45,6 @@ version = "0.7"
 features = ["testing"]
 
 [features]
-default = ["binary-scanning", "fix"]
+default = ["binary-scanning"]
 fix = ["rustsec/fix"]
 binary-scanning = ["dep:auditable-info", "dep:cargo-lock", "dep:auditable-serde", "dep:binfarce", "dep:quitters", "dep:once_cell"]

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -81,6 +81,14 @@ impl Runnable for FixCommand {
                 );
             } else {
                 let mut command = fixer.get_fix_command(vulnerability, dry_run);
+                // If the path to Cargo.lock has been specified explicitly,
+                // run the `cargo update` command in that directory
+                if let Some(path) = self.cargo_lock_path() {
+                    // documentation on .current_dir() recommends canonicalizing the path
+                    let canonical_path = path.canonicalize().unwrap();
+                    let dir = canonical_path.parent().unwrap();
+                    command.current_dir(dir);
+                }
                 // When calling `.status()` the stdout and stderr are inherited from the parent,
                 // so any status or error messages from `cargo update` will automatically be forwarded
                 // to the user of `cargo audit fix`.

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -94,13 +94,12 @@ impl Runnable for FixCommand {
                 // to the user of `cargo audit fix`.
                 let status = command.status();
                 if let Err(e) = status {
-                        failed_patches += 1;
-                        status_warn!(
-                            "Failed to run `cargo update` for package {}: {}",
-                            vulnerability.package.name,
-                            e
-                        );
-                    }
+                    failed_patches += 1;
+                    status_warn!(
+                        "Failed to run `cargo update` for package {}: {}",
+                        vulnerability.package.name,
+                        e
+                    );
                 }
             }
         }

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -60,8 +60,9 @@ impl Runnable for FixCommand {
         // This should always succeed because the auditor loaded it successfully already
         let lockfile = Lockfile::load(&path).expect("Failed to load Cargo.lock");
 
-        // TODO: allow specifying mnanifest path
-        let fixer = Fixer::new(None, lockfile);
+        // TODO: allow specifying manifest path
+        let path_to_cargo: Option<PathBuf> = std::env::var_os("CARGO").map(|path| path.into());
+        let fixer = Fixer::new(lockfile, None, path_to_cargo);
 
         let dry_run = self.dry_run;
         if dry_run {

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -93,9 +93,7 @@ impl Runnable for FixCommand {
                 // so any status or error messages from `cargo update` will automatically be forwarded
                 // to the user of `cargo audit fix`.
                 let status = command.status();
-                match status {
-                    Ok(_) => (),
-                    Err(e) => {
+                if let Err(e) = status {
                         failed_patches += 1;
                         status_warn!(
                             "Failed to run `cargo update` for package {}: {}",

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -103,6 +103,18 @@ impl Runnable for FixCommand {
             }
         }
 
-        // TODO: determine exit status depending on whether any vulnerabilities remain
+        // When performing a dry run, the exit status is determined by whether we had any issues along the way
+        if dry_run {
+            if failed_patches != 0 {
+                exit(2);
+            } else if unpatchable_vulns != 0 {
+                exit(1);
+            } else {
+                exit(0)
+            }
+        } else {
+            // TODO: determine exit status depending on whether any vulnerabilities remain
+            // because some commands may not have been sufficient due to patched versions not being semver-compatible
+        }
     }
 }

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -2,6 +2,7 @@
 
 use crate::{auditor::Auditor, lockfile, prelude::*};
 use abscissa_core::{Command, Runnable};
+use cargo_lock::Lockfile;
 use clap::Parser;
 use rustsec::Fixer;
 use std::{
@@ -60,14 +61,11 @@ impl Runnable for FixCommand {
             }
         };
 
-        let mut fixer = Fixer::new(self.cargo_toml_path()).unwrap_or_else(|e| {
-            status_err!(
-                "couldn't load manifest from {}: {}",
-                self.cargo_toml_path().display(),
-                e
-            );
-            exit(1);
-        });
+        // This should always succeed because the auditor loaded it successfully already
+        let lockfile =
+            Lockfile::load("tests/examples/Cargo.lock").expect("Failed to load Cargo.lock");
+
+        let fixer = Fixer::new(self.cargo_toml_path(), lockfile);
 
         let dry_run = self.dry_run;
         let dry_run_info = if dry_run { " (dry run)" } else { "" };
@@ -80,8 +78,16 @@ impl Runnable for FixCommand {
         );
 
         for vulnerability in &report.vulnerabilities.list {
-            if let Err(e) = fixer.fix(vulnerability, dry_run) {
-                status_warn!("{}", e);
+            let results = fixer.fix(vulnerability, dry_run);
+            for outcome in results.outcomes {
+                match outcome.output {
+                    Ok(_) => todo!(),
+                    Err(e) => status_warn!(
+                        "Failed to run `cargo update` for package {}: {}",
+                        &outcome.package.name,
+                        e
+                    ),
+                }
             }
         }
 

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -50,6 +50,7 @@ impl Runnable for FixCommand {
         let report = self.auditor().audit_lockfile(&path);
         let report = match report {
             Ok(report) => {
+                // TODO: also handle warnings
                 if report.vulnerabilities.list.is_empty() {
                     exit(0);
                 }
@@ -64,7 +65,8 @@ impl Runnable for FixCommand {
         // This should always succeed because the auditor loaded it successfully already
         let lockfile = Lockfile::load(path).expect("Failed to load Cargo.lock");
 
-        let fixer = Fixer::new(self.cargo_toml_path(), lockfile);
+        // TODO: allow specifying mnanifest path
+        let fixer = Fixer::new(None, lockfile);
 
         let dry_run = self.dry_run;
         let dry_run_info = if dry_run { " (dry run)" } else { "" };

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -90,10 +90,5 @@ impl Runnable for FixCommand {
                 }
             }
         }
-
-        if let Err(e) = lockfile::generate() {
-            status_err!("{}", e);
-            exit(2);
-        }
     }
 }

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -6,7 +6,6 @@ use cargo_lock::Lockfile;
 use clap::Parser;
 use rustsec::Fixer;
 use std::{
-    io::{stderr, stdout},
     path::{Path, PathBuf},
     process::exit,
 };
@@ -63,8 +62,7 @@ impl Runnable for FixCommand {
         };
 
         // This should always succeed because the auditor loaded it successfully already
-        let lockfile =
-            Lockfile::load(path).expect("Failed to load Cargo.lock");
+        let lockfile = Lockfile::load(path).expect("Failed to load Cargo.lock");
 
         let fixer = Fixer::new(self.cargo_toml_path(), lockfile);
 

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -72,8 +72,12 @@ impl Runnable for FixCommand {
             dry_run_info
         );
 
+        let mut unpatchable_vulns: u32 = 0;
+        let mut failed_patches = 0;
+
         for vulnerability in &report.vulnerabilities.list {
             if vulnerability.versions.patched().is_empty() {
+                unpatchable_vulns += 1;
                 status_warn!(
                     "No patched versions available for {} in crate {}",
                     vulnerability.advisory.id,
@@ -87,11 +91,14 @@ impl Runnable for FixCommand {
                 let status = command.status();
                 match status {
                     Ok(_) => (),
-                    Err(e) => status_warn!(
-                        "Failed to run `cargo update` for package {}: {}",
-                        vulnerability.package.name,
-                        e
-                    ),
+                    Err(e) => {
+                        failed_patches += 1;
+                        status_warn!(
+                            "Failed to run `cargo update` for package {}: {}",
+                            vulnerability.package.name,
+                            e
+                        );
+                    }
                 }
             }
         }

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -133,8 +133,7 @@ impl Runnable for FixCommand {
                     "The following advisories could not be fixed:\n    {}\n\
                     This usually occurs when the fixed version is not semver-compatible,\n\
                     or the version range in specified in your `Cargo.toml` is too restrictive\n\
-                    (e.g. uses `=` or `=<` operators) so the fixed version would not match it.
-                    ",
+                    (e.g. uses `=` or `=<` operators) so the fixed version would not match it.",
                     fixable_but_unfixed.join(", ")
                 );
             }

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -6,8 +6,7 @@ use cargo_lock::Lockfile;
 use clap::Parser;
 use rustsec::Fixer;
 use std::{
-    path::{Path, PathBuf},
-    process::exit,
+    io::{stderr, stdout}, path::{Path, PathBuf}, process::exit
 };
 
 #[derive(Command, Clone, Default, Debug, Parser)]
@@ -77,11 +76,17 @@ impl Runnable for FixCommand {
             dry_run_info
         );
 
+        let stdout = stdout().lock();
+        let stderr = stderr().lock();
+
         for vulnerability in &report.vulnerabilities.list {
             let results = fixer.fix(vulnerability, dry_run);
             for outcome in results.outcomes {
                 match outcome.output {
-                    Ok(_) => todo!(),
+                    Ok(output) => match output.status.success() {
+                        true => todo!(),
+                        false => todo!(),
+                    },
                     Err(e) => status_warn!(
                         "Failed to run `cargo update` for package {}: {}",
                         &outcome.package.name,

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -6,7 +6,9 @@ use cargo_lock::Lockfile;
 use clap::Parser;
 use rustsec::Fixer;
 use std::{
-    io::{stderr, stdout}, path::{Path, PathBuf}, process::exit
+    io::{stderr, stdout},
+    path::{Path, PathBuf},
+    process::exit,
 };
 
 #[derive(Command, Clone, Default, Debug, Parser)]

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -140,7 +140,7 @@ impl Runnable for FixCommand {
                 status_warn!(
                     "The following advisories have patched versions but could not be fixed:\n    {}\n\
                     This usually occurs when the fixed version is not semver-compatible,\n\
-                    or the version range in specified in your `Cargo.toml` is too restrictive\n\
+                    or the version range specified in your `Cargo.toml` is too restrictive\n\
                     (e.g. uses `=` or `=<` operators) so the fixed version would not match it.",
                     fixable_but_unfixed.join(", ")
                 );

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -130,7 +130,7 @@ impl Runnable for FixCommand {
                 .collect();
             if !fixable_but_unfixed.is_empty() {
                 status_warn!(
-                    "The following advisories could not be fixed:\n    {}\n\
+                    "The following advisories have patched versions but could not be fixed:\n    {}\n\
                     This usually occurs when the fixed version is not semver-compatible,\n\
                     or the version range in specified in your `Cargo.toml` is too restrictive\n\
                     (e.g. uses `=` or `=<` operators) so the fixed version would not match it.",

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -28,12 +28,6 @@ impl FixCommand {
         Auditor::new(&APP.config())
     }
 
-    /// Locate `Cargo.toml`
-    // TODO(tarcieri): ability to specify path
-    pub fn cargo_toml_path(&self) -> PathBuf {
-        PathBuf::from("Cargo.toml")
-    }
-
     /// Locate `Cargo.lock`
     pub fn cargo_lock_path(&self) -> Option<&Path> {
         self.file.as_deref()
@@ -63,7 +57,7 @@ impl Runnable for FixCommand {
         };
 
         // This should always succeed because the auditor loaded it successfully already
-        let lockfile = Lockfile::load(path).expect("Failed to load Cargo.lock");
+        let lockfile = Lockfile::load(&path).expect("Failed to load Cargo.lock");
 
         // TODO: allow specifying mnanifest path
         let fixer = Fixer::new(None, lockfile);
@@ -74,7 +68,7 @@ impl Runnable for FixCommand {
         status_ok!(
             "Fixing",
             "vulnerable dependencies in `{}`{}",
-            self.cargo_toml_path().display(),
+            &path.display(),
             dry_run_info
         );
 

--- a/cargo-audit/src/commands/audit/fix.rs
+++ b/cargo-audit/src/commands/audit/fix.rs
@@ -137,6 +137,24 @@ impl Runnable for FixCommand {
                     fixable_but_unfixed.join(", ")
                 );
             }
+
+            let remaining_vulns_count = report_after_fix.vulnerabilities.list.len();
+            let fixed_vulns_count = report
+                .vulnerabilities
+                .list
+                .len()
+                .saturating_sub(remaining_vulns_count);
+            if fixed_vulns_count != 0 {
+                if remaining_vulns_count == 0 {
+                    status_ok!("Fixed", "{} vulnerabilities", fixed_vulns_count);
+                } else {
+                    status_warn!(
+                        "Fixed {} vulnerabilities but {} remain",
+                        fixed_vulns_count,
+                        remaining_vulns_count
+                    );
+                }
+            }
         }
     }
 }

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -24,9 +24,6 @@ toml = "0.7"
 url = { version = "2", features = ["serde"] }
 
 # optional dependencies
-cargo-edit = { version = "0.9", package = "cargo-edit-9", optional = true, default-features = false, features = [
-    "upgrade",
-] }
 tame-index = { version = "0.9.3", default-features = false, features = ["git", "sparse", "native-certs"], optional = true }
 home = { version = "0.5", optional = true }
 time = { version = "0.3", default-features = false, features = ["formatting", "serde"], optional = true }
@@ -39,7 +36,7 @@ serde_json = "1"
 
 [features]
 default = ["git"]
-fix = ["dep:cargo-edit"]
+fix = []
 git = [
     "dep:tame-index",
     "dep:home",

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -36,7 +36,6 @@ serde_json = "1"
 
 [features]
 default = ["git"]
-fix = []
 git = [
     "dep:tame-index",
     "dep:home",

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -158,14 +158,6 @@ impl From<Utf8Error> for Error {
     }
 }
 
-#[cfg(feature = "fix")]
-#[cfg_attr(docsrs, doc(cfg(feature = "fix")))]
-impl From<cargo_edit::Error> for Error {
-    fn from(other: cargo_edit::Error) -> Self {
-        format_err!(ErrorKind::Fix, &other)
-    }
-}
-
 impl From<cargo_lock::Error> for Error {
     fn from(other: cargo_lock::Error) -> Self {
         format_err!(ErrorKind::Io, &other)

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -14,7 +14,7 @@ pub struct Fixer<'a> {
     lockfile: &'a Lockfile,
 }
 
-impl <'a> Fixer<'a> {
+impl<'a> Fixer<'a> {
     /// Create a new [`Fixer`] for the given `Cargo.toml` file
     pub fn new(cargo_toml: &'a Path, cargo_lock: &'a Lockfile) -> Self {
         Self {
@@ -24,11 +24,13 @@ impl <'a> Fixer<'a> {
     }
 
     /// Attempt to fix the given vulnerability
-    pub fn fix(
-        &self,
-        vulnerability: &Vulnerability,
-        dry_run: bool,
-    ) -> Result<(), Error> {
+    pub fn fix(&self, vulnerability: &Vulnerability, dry_run: bool) -> Result<(), Error> {
+        let cargo_path = std::env::var_os("CARGO").unwrap_or("cargo".into());
+        let pkg_name = &vulnerability.package.name;
+        // there can be more than one version of a given package in the lockfile, so we need to iterate over all of them
+        for pkg in self.lockfile.packages.iter().filter(|pkg| &pkg.name == pkg_name) {
+            
+        }
         // let version_req = match vulnerability.versions.patched().get(0) {
         //     Some(req) => req,
         //     None => fail!(ErrorKind::Version, "no fixed version available"),

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -33,6 +33,7 @@ impl Fixer {
         let cargo_path = std::env::var_os("CARGO").unwrap_or("cargo".into());
         let pkg_name = &vulnerability.package.name;
         let mut command = Command::new(&cargo_path);
+        command.arg("update");
         if let Some(path) = self.manifest_path.as_ref() {
             command.arg("--manifest-path").arg(path);
         }

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -48,8 +48,8 @@ impl Fixer {
 ///
 /// We need to pass these to `cargo update` because otherwise
 /// the package specification will be ambiguous, and it will refuse to do anything.
-fn pkgid(pkg: cargo_lock::Package) -> String {
-    match pkg.source {
+fn pkgid(pkg: &cargo_lock::Package) -> String {
+    match pkg.source.as_ref() {
         Some(source) => format!("{}#{}@{}", source, pkg.name, pkg.version),
         None => format!("{}@{}", pkg.name, pkg.version),
     }

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -1,4 +1,6 @@
 //! Automatically attempt to fix vulnerable dependencies
+//!
+//! This module is **experimental**, and its behavior may change in the future.
 
 use crate::vulnerability::Vulnerability;
 use cargo_lock::{Lockfile, Package};

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -41,13 +41,9 @@ impl Fixer {
             command.arg("--dry-run");
         }
         // there can be more than one version of a given package in the lockfile, so we need to iterate over all of them
-        // TODO: only consider vulnerable versions
-        for pkg in self
-            .lockfile
-            .packages
-            .iter()
-            .filter(|pkg| &pkg.name == pkg_name)
-        {
+        for pkg in self.lockfile.packages.iter().filter(|pkg| {
+            &pkg.name == pkg_name && vulnerability.versions.is_vulnerable(&pkg.version)
+        }) {
             let pkgid = pkgid(pkg);
             command.arg(&pkgid);
         }

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -3,18 +3,18 @@
 use crate::vulnerability::Vulnerability;
 use cargo_lock::{Lockfile, Package};
 use std::process::Command;
-use std::{path::Path, process::Output};
+use std::{path::PathBuf, process::Output};
 
 /// Auto-fixer for vulnerable dependencies
 #[cfg_attr(docsrs, doc(cfg(feature = "fix")))]
-pub struct Fixer<'a> {
-    manifest_path: &'a Path,
-    lockfile: &'a Lockfile,
+pub struct Fixer {
+    manifest_path: PathBuf,
+    lockfile: Lockfile,
 }
 
-impl<'a> Fixer<'a> {
+impl Fixer {
     /// Create a new [`Fixer`] for the given `Cargo.toml` file
-    pub fn new(cargo_toml: &'a Path, cargo_lock: &'a Lockfile) -> Self {
+    pub fn new(cargo_toml: PathBuf, cargo_lock: Lockfile) -> Self {
         Self {
             manifest_path: cargo_toml,
             lockfile: cargo_lock,
@@ -36,7 +36,7 @@ impl<'a> Fixer<'a> {
             .filter(|pkg| &pkg.name == pkg_name)
         {
             let mut command = Command::new(&cargo_path);
-            command.arg("--manifest-path").arg(self.manifest_path);
+            command.arg("--manifest-path").arg(&self.manifest_path);
             if dry_run {
                 command.arg("--dry-run");
             }

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -1,11 +1,9 @@
 //! Automatically attempt to fix vulnerable dependencies
 
-use crate::{
-    error::{Error, ErrorKind},
-    vulnerability::Vulnerability,
-};
-use cargo_lock::Lockfile;
-use std::path::{Path, PathBuf};
+use crate::vulnerability::Vulnerability;
+use cargo_lock::{Lockfile, Package};
+use std::process::Command;
+use std::{path::Path, process::Output};
 
 /// Auto-fixer for vulnerable dependencies
 #[cfg_attr(docsrs, doc(cfg(feature = "fix")))]
@@ -23,27 +21,52 @@ impl<'a> Fixer<'a> {
         }
     }
 
-    /// Attempt to fix the given vulnerability
-    pub fn fix(&self, vulnerability: &Vulnerability, dry_run: bool) -> Result<(), Error> {
+    /// Attempt to fix the given vulnerability.
+    /// This function will succeed even if there is no semver-compatible fix available.
+    pub fn fix(&self, vulnerability: &Vulnerability, dry_run: bool) -> FixReport {
+        let mut outcomes = Vec::new();
         let cargo_path = std::env::var_os("CARGO").unwrap_or("cargo".into());
         let pkg_name = &vulnerability.package.name;
         // there can be more than one version of a given package in the lockfile, so we need to iterate over all of them
         // TODO: only consider vulnerable versions
-        for pkg in self.lockfile.packages.iter().filter(|pkg| &pkg.name == pkg_name) {
-            
+        for pkg in self
+            .lockfile
+            .packages
+            .iter()
+            .filter(|pkg| &pkg.name == pkg_name)
+        {
+            let mut command = Command::new(&cargo_path);
+            command.arg("--manifest-path").arg(self.manifest_path);
+            if dry_run {
+                command.arg("--dry-run");
+            }
+            let pkgid = pkgid(pkg);
+            command.arg(&pkgid);
+            // Sadly `cargo update` has no JSON output so we cannot reliably know the outcome
+            let output = command.output();
+            outcomes.push(FixOutcome {
+                package: pkg.to_owned(),
+                output: output,
+            })
         }
-        // let version_req = match vulnerability.versions.patched().get(0) {
-        //     Some(req) => req,
-        //     None => fail!(ErrorKind::Version, "no fixed version available"),
-        // };
 
-        // let dependency = cargo_edit::Dependency::new(vulnerability.package.name.as_str())
-        //     .set_version(&version_req.to_string());
-
-        // self.manifest.upgrade(&dependency, dry_run, false)?;
-
-        Ok(())
+        FixReport { outcomes }
     }
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct FixReport {
+    pub outcomes: Vec<FixOutcome>,
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct FixOutcome {
+    pub package: Package,
+    /// Output of the `cargo update` command,
+    /// including the stdout, stderr and exit code.
+    pub output: Result<Output, std::io::Error>,
 }
 
 /// Returns a Cargo unique identifier for a package.
@@ -51,7 +74,7 @@ impl<'a> Fixer<'a> {
 ///
 /// We need to pass these to `cargo update` because otherwise
 /// the package specification will be ambiguous, and it will refuse to do anything.
-fn pkgid(pkg: &cargo_lock::Package) -> String {
+fn pkgid(pkg: &Package) -> String {
     match pkg.source.as_ref() {
         Some(source) => format!("{}#{}@{}", source, pkg.name, pkg.version),
         None => format!("{}@{}", pkg.name, pkg.version),

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -10,15 +10,15 @@ use std::path::{Path, PathBuf};
 /// Auto-fixer for vulnerable dependencies
 #[cfg_attr(docsrs, doc(cfg(feature = "fix")))]
 pub struct Fixer<'a> {
-    manifest_path: PathBuf,
+    manifest_path: &'a Path,
     lockfile: &'a Lockfile,
 }
 
 impl <'a> Fixer<'a> {
     /// Create a new [`Fixer`] for the given `Cargo.toml` file
-    pub fn new(cargo_toml: &Path, cargo_lock: &'a Lockfile) -> Self {
+    pub fn new(cargo_toml: &'a Path, cargo_lock: &'a Lockfile) -> Self {
         Self {
-            manifest_path: cargo_toml.to_owned(),
+            manifest_path: cargo_toml,
             lockfile: cargo_lock,
         }
     }

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -8,13 +8,13 @@ use std::process::Command;
 /// Auto-fixer for vulnerable dependencies
 #[cfg_attr(docsrs, doc(cfg(feature = "fix")))]
 pub struct Fixer {
-    manifest_path: PathBuf,
+    manifest_path: Option<PathBuf>,
     lockfile: Lockfile,
 }
 
 impl Fixer {
     /// Create a new [`Fixer`] for the given `Cargo.toml` file
-    pub fn new(cargo_toml: PathBuf, cargo_lock: Lockfile) -> Self {
+    pub fn new(cargo_toml: Option<PathBuf>, cargo_lock: Lockfile) -> Self {
         Self {
             manifest_path: cargo_toml,
             lockfile: cargo_lock,
@@ -31,7 +31,9 @@ impl Fixer {
         let cargo_path = std::env::var_os("CARGO").unwrap_or("cargo".into());
         let pkg_name = &vulnerability.package.name;
         let mut command = Command::new(&cargo_path);
-        command.arg("--manifest-path").arg(&self.manifest_path);
+        if let Some(path) = self.manifest_path.as_ref() {
+            command.arg("--manifest-path").arg(path);
+        }
         if dry_run {
             command.arg("--dry-run");
         }

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -22,7 +22,10 @@ impl Fixer {
     }
 
     /// Attempt to fix the given vulnerability.
-    /// This function will succeed even if there is no semver-compatible fix available.
+    ///
+    /// Note that the success of the command in [`FixReport`] does not mean
+    /// the vulnerability was actually fixed!
+    /// It may remain if no semver-compatible fix was available.
     pub fn fix(&self, vulnerability: &Vulnerability, dry_run: bool) -> FixReport {
         let mut outcomes = Vec::new();
         let cargo_path = std::env::var_os("CARGO").unwrap_or("cargo".into());

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -32,7 +32,7 @@ impl Fixer {
     pub fn get_fix_command(&self, vulnerability: &Vulnerability, dry_run: bool) -> Command {
         let cargo_path = std::env::var_os("CARGO").unwrap_or("cargo".into());
         let pkg_name = &vulnerability.package.name;
-        let mut command = Command::new(&cargo_path);
+        let mut command = Command::new(cargo_path);
         command.arg("update");
         if let Some(path) = self.manifest_path.as_ref() {
             command.arg("--manifest-path").arg(path);

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -28,6 +28,7 @@ impl<'a> Fixer<'a> {
         let cargo_path = std::env::var_os("CARGO").unwrap_or("cargo".into());
         let pkg_name = &vulnerability.package.name;
         // there can be more than one version of a given package in the lockfile, so we need to iterate over all of them
+        // TODO: only consider vulnerable versions
         for pkg in self.lockfile.packages.iter().filter(|pkg| &pkg.name == pkg_name) {
             
         }

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -17,6 +17,12 @@ pub struct Fixer {
 
 impl Fixer {
     /// Create a new [`Fixer`] for the given `Cargo.lock` file
+    ///
+    /// `path_to_cargo` defaults to `cargo`, resolved in your `$PATH`.
+    ///
+    /// If the path to `Cargo.toml` is not specified, the `cargo update` command
+    /// will be run in the directory with the `Cargo.lock` file.
+    /// Leaving it blank will fix the entire workspace.
     pub fn new(
         cargo_lock: Lockfile,
         cargo_toml: Option<PathBuf>,

--- a/rustsec/src/fixer.rs
+++ b/rustsec/src/fixer.rs
@@ -42,3 +42,15 @@ impl Fixer {
         Ok(version_req.clone())
     }
 }
+
+/// Returns a Cargo unique identifier for a package.
+/// See `cargo help pkgid` for more info.
+///
+/// We need to pass these to `cargo update` because otherwise
+/// the package specification will be ambiguous, and it will refuse to do anything.
+fn pkgid(pkg: cargo_lock::Package) -> String {
+    match pkg.source {
+        Some(source) => format!("{}#{}@{}", source, pkg.name, pkg.version),
+        None => format!("{}@{}", pkg.name, pkg.version),
+    }
+}

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -10,12 +10,12 @@ mod error;
 pub mod advisory;
 mod collection;
 pub mod database;
+mod fixer;
 pub mod osv;
 pub mod report;
 pub mod repository;
 mod vulnerability;
 mod warning;
-mod fixer;
 
 #[cfg(feature = "git")]
 #[cfg_attr(docsrs, doc(cfg(feature = "git")))]

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -15,8 +15,6 @@ pub mod report;
 pub mod repository;
 mod vulnerability;
 mod warning;
-
-#[cfg(feature = "fix")]
 mod fixer;
 
 #[cfg(feature = "git")]
@@ -45,7 +43,6 @@ pub use crate::{
     warning::{Warning, WarningKind},
 };
 
-#[cfg(feature = "fix")]
 pub use crate::fixer::Fixer;
 
 #[cfg(feature = "git")]


### PR DESCRIPTION
Does away with editing `Cargo.toml`; instead runs `cargo update` behind the scenes to upgrade vulnerable versions.

Fixes  #1107 and  #1109 by ripping out `cargo-edit` which transitively depends on `libgit2-sys` and a bunch of other outdated versions.