### PR TITLE
Bump askama to 0.12

### DIFF
--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -14,7 +14,7 @@ default = ["gix?/max-performance-safe"]
 
 [dependencies]
 abscissa_core = "0.7"
-askama = "0.11"
+askama = "0.12"
 atom_syndication = "0.12"
 chrono = { version = "0.4", default-features = false, features = ["clock"]  }
 clap = "4"

--- a/admin/src/web/templates/advisory-content.html
+++ b/admin/src/web/templates/advisory-content.html
@@ -30,18 +30,18 @@
       <dt id="reported">Reported</dt>
       <dd>
         <time datetime="{{ advisory.date().as_str() }}">
-          {{ advisory.date() | friendly_date }}
+          {{ advisory.date()|friendly_date }}
         </time>
       </dd>
 
       <dt id="issued">Issued</dt>
       <dd>
         <time datetime="{{ cdate.as_str() }}">
-          {{ cdate.clone() | friendly_date }}
+          {{ cdate.clone()|friendly_date }}
         </time>
         {% if cdate != mdate %}
         <time datetime="{{ mdate.as_str() }}">
-          (last modified: {{ mdate.clone() | friendly_date }})
+          (last modified: {{ mdate.clone()|friendly_date }})
         </time>
         {% endif %}
       </dd>
@@ -66,7 +66,7 @@
         {% match advisory.metadata.informational %}
         {% when Some with (informational) %}
         <span class="tag info">INFO</span>
-        {{ informational.to_string() | capitalize }}
+        {{ informational.to_string()|capitalize }}
         {% when None %}
         Vulnerability
         {% endmatch %}
@@ -87,7 +87,7 @@
       <dt id="keywords">Keywords</dt>
       <dd>
         {% for keyword in advisory.metadata.keywords %}
-          <a href="/keywords/{{ keyword.as_str() | safe_keyword }}.html">#{{ keyword.as_str() | safe_keyword }}</a>
+          <a href="/keywords/{{ keyword.as_str()|safe_keyword }}.html">#{{ keyword.as_str()|safe_keyword }}</a>
         {% endfor %}
       </dd>
       {% endif %}
@@ -154,7 +154,7 @@
       {% when Some with (cvss) %}
       <dt id="cvss_score">CVSS Score</dt>
       <dd>{{ cvss.score().value() }} <span class="tag {{ advisory.severity().unwrap() }}">
-        {{ advisory.severity().unwrap() | upper }}
+        {{ advisory.severity().unwrap()|upper }}
       </span></dd>
 
       <dt id="cvss_details">CVSS Details</dt>

--- a/admin/src/web/templates/advisory-list-entry.html
+++ b/admin/src/web/templates/advisory-list-entry.html
@@ -1,6 +1,6 @@
 <li>
   <time datetime="{{ cdate.as_str() }}">
-    {{ cdate.clone() | friendly_date }}
+    {{ cdate.clone()|friendly_date }}
   </time>
 
   {% if advisory.withdrawn() %}
@@ -12,7 +12,7 @@
   <h3>
     {% match advisory.severity() %}
       {% when Some with (severity) %}
-      <span class="tag {{ severity }}">{{ advisory.severity().unwrap() | upper }}</span>
+      <span class="tag {{ severity }}">{{ advisory.severity().unwrap()|upper }}</span>
       {% when None %}
         {% if advisory.metadata.informational.is_some() %}
           <span class="tag info">INFO</span>


### PR DESCRIPTION
From https://djc.github.io/askama/filters.html:

> Note that the pipe symbol must not be surrounded by spaces; otherwise, it will be interpreted as the BitOr operator.