### PR TITLE
chore: regenerate platform support and bump to platforms@3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
  "is-terminal",
  "once_cell",
  "quitters",
- "rustsec 0.29.0",
+ "rustsec 0.29.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -2585,7 +2585,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "platforms"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "serde",
 ]
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "cargo-lock",
  "cvss",
@@ -2919,7 +2919,7 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
- "gix 0.60.0",
+ "gix 0.58.0",
  "once_cell",
  "rust-embed",
  "rustsec 0.28.6",

--- a/platforms/Cargo.toml
+++ b/platforms/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from the Rust compiler.
 """
-version    = "3.3.0"
+version    = "3.4.0"
 authors    = ["Tony Arcieri <bascule@gmail.com>", "Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://rustsec.org"

--- a/platforms/README.md
+++ b/platforms/README.md
@@ -85,6 +85,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [aarch64-pc-windows-msvc]              | aarch64     | windows    | msvc       |
 | [aarch64-unknown-fuchsia]              | aarch64     | fuchsia    |            |
 | [aarch64-unknown-linux-musl]           | aarch64     | linux      | musl       |
+| [aarch64-unknown-linux-ohos]           | aarch64     | linux      | ohos       |
 | [aarch64-unknown-none]                 | aarch64     | none       |            |
 | [aarch64-unknown-none-softfloat]       | aarch64     | none       |            |
 | [aarch64-unknown-uefi]                 | aarch64     | uefi       |            |
@@ -102,13 +103,13 @@ If we remove platforms, we will bump the minor version of this crate.
 | [armv7-unknown-linux-gnueabihf]        | arm         | linux      | gnu        |
 | [armv7-unknown-linux-musleabi]         | arm         | linux      | musl       |
 | [armv7-unknown-linux-musleabihf]       | arm         | linux      | musl       |
+| [armv7-unknown-linux-ohos]             | arm         | linux      | ohos       |
 | [armv7a-none-eabi]                     | arm         | none       |            |
 | [armv7r-none-eabi]                     | arm         | none       |            |
 | [armv7r-none-eabihf]                   | arm         | none       |            |
 | [i586-pc-windows-msvc]                 | x86         | windows    | msvc       |
 | [i586-unknown-linux-gnu]               | x86         | linux      | gnu        |
 | [i586-unknown-linux-musl]              | x86         | linux      | musl       |
-| [i586-unknown-netbsd]                  | x86         | netbsd     |            |
 | [i686-linux-android]                   | x86         | android    |            |
 | [i686-unknown-freebsd]                 | x86         | freebsd    |            |
 | [i686-unknown-linux-musl]              | x86         | linux      | musl       |
@@ -121,7 +122,9 @@ If we remove platforms, we will bump the minor version of this crate.
 | [powerpc64-unknown-linux-gnu]          | powerpc64   | linux      | gnu        |
 | [powerpc64le-unknown-linux-gnu]        | powerpc64   | linux      | gnu        |
 | [riscv32i-unknown-none-elf]            | riscv32     | none       |            |
+| [riscv32im-unknown-none-elf]           | riscv32     | none       |            |
 | [riscv32imac-unknown-none-elf]         | riscv32     | none       |            |
+| [riscv32imafc-unknown-none-elf]        | riscv32     | none       |            |
 | [riscv32imc-unknown-none-elf]          | riscv32     | none       |            |
 | [riscv64gc-unknown-linux-gnu]          | riscv64     | linux      | gnu        |
 | [riscv64gc-unknown-none-elf]           | riscv64     | none       |            |
@@ -141,7 +144,8 @@ If we remove platforms, we will bump the minor version of this crate.
 | [wasm32-unknown-emscripten]            | wasm32      | emscripten |            |
 | [wasm32-unknown-unknown]               | wasm32      | unknown    |            |
 | [wasm32-wasi]                          | wasm32      | wasi       |            |
-| [wasm32-wasi-preview1-threads]         | wasm32      | wasi       |            |
+| [wasm32-wasip1]                        | wasm32      | wasi       |            |
+| [wasm32-wasip1-threads]                | wasm32      | wasi       |            |
 | [x86_64-apple-ios]                     | x86_64      | ios        |            |
 | [x86_64-fortanix-unknown-sgx]          | x86_64      | unknown    | sgx        |
 | [x86_64-fuchsia]                       | x86_64      | fuchsia    |            |
@@ -152,6 +156,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [x86_64-unknown-illumos]               | x86_64      | illumos    |            |
 | [x86_64-unknown-linux-gnux32]          | x86_64      | linux      | gnu        |
 | [x86_64-unknown-linux-musl]            | x86_64      | linux      | musl       |
+| [x86_64-unknown-linux-ohos]            | x86_64      | linux      | ohos       |
 | [x86_64-unknown-netbsd]                | x86_64      | netbsd     |            |
 | [x86_64-unknown-none]                  | x86_64      | none       |            |
 | [x86_64-unknown-redox]                 | x86_64      | redox      | relibc     |
@@ -173,7 +178,6 @@ If we remove platforms, we will bump the minor version of this crate.
 | [aarch64-unknown-hermit]               | aarch64     | hermit     |            |
 | [aarch64-unknown-illumos]              | aarch64     | illumos    |            |
 | [aarch64-unknown-linux-gnu_ilp32]      | aarch64     | linux      | gnu        |
-| [aarch64-unknown-linux-ohos]           | aarch64     | linux      | ohos       |
 | [aarch64-unknown-netbsd]               | aarch64     | netbsd     |            |
 | [aarch64-unknown-nto-qnx710]           | aarch64     | nto        | nto71      |
 | [aarch64-unknown-openbsd]              | aarch64     | openbsd    |            |
@@ -187,26 +191,27 @@ If we remove platforms, we will bump the minor version of this crate.
 | [arm64_32-apple-watchos]               | aarch64     | watchos    |            |
 | [arm64e-apple-darwin]                  | aarch64     | macos      |            |
 | [arm64e-apple-ios]                     | aarch64     | ios        |            |
+| [arm64ec-pc-windows-msvc]              | arm64ec     | windows    | msvc       |
 | [armeb-unknown-linux-gnueabi]          | arm         | linux      | gnu        |
 | [armv4t-none-eabi]                     | arm         | none       |            |
 | [armv4t-unknown-linux-gnueabi]         | arm         | linux      | gnu        |
 | [armv5te-none-eabi]                    | arm         | none       |            |
 | [armv5te-unknown-linux-uclibceabi]     | arm         | linux      | uclibc     |
-| [armv6-unknown-freebsd]                | arm         | freebsd    | gnueabihf  |
-| [armv6-unknown-netbsd-eabihf]          | arm         | netbsd     | eabihf     |
+| [armv6-unknown-freebsd]                | arm         | freebsd    | gnu        |
+| [armv6-unknown-netbsd-eabihf]          | arm         | netbsd     |            |
 | [armv6k-nintendo-3ds]                  | arm         | horizon    | newlib     |
 | [armv7-sony-vita-newlibeabihf]         | arm         | vita       | newlib     |
-| [armv7-unknown-freebsd]                | arm         | freebsd    | gnueabihf  |
-| [armv7-unknown-linux-ohos]             | arm         | linux      | ohos       |
+| [armv7-unknown-freebsd]                | arm         | freebsd    | gnu        |
 | [armv7-unknown-linux-uclibceabi]       | arm         | linux      | uclibc     |
 | [armv7-unknown-linux-uclibceabihf]     | arm         | linux      | uclibc     |
-| [armv7-unknown-netbsd-eabihf]          | arm         | netbsd     | eabihf     |
+| [armv7-unknown-netbsd-eabihf]          | arm         | netbsd     |            |
 | [armv7-wrs-vxworks-eabihf]             | arm         | vxworks    | gnu        |
 | [armv7a-kmc-solid_asp3-eabi]           | arm         | solid_asp3 |            |
 | [armv7a-kmc-solid_asp3-eabihf]         | arm         | solid_asp3 |            |
 | [armv7a-none-eabihf]                   | arm         | none       |            |
 | [armv7k-apple-watchos]                 | arm         | watchos    |            |
 | [armv7s-apple-ios]                     | arm         | ios        |            |
+| [armv8r-none-eabihf]                   | arm         | none       |            |
 | [avr-unknown-gnu-atmega328]            | avr         | none       |            |
 | [bpfeb-unknown-none]                   | bpf         | none       |            |
 | [bpfel-unknown-none]                   | bpf         | none       |            |
@@ -216,6 +221,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [hexagon-unknown-none-elf]             | hexagon     | none       |            |
 | [i386-apple-ios]                       | x86         | ios        |            |
 | [i586-pc-nto-qnx700]                   | x86         | nto        | nto70      |
+| [i586-unknown-netbsd]                  | x86         | netbsd     |            |
 | [i686-apple-darwin]                    | x86         | macos      |            |
 | [i686-pc-windows-gnullvm]              | x86         | windows    | gnu        |
 | [i686-unknown-haiku]                   | x86         | haiku      |            |
@@ -226,6 +232,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [i686-uwp-windows-msvc]                | x86         | windows    | msvc       |
 | [i686-win7-windows-msvc]               | x86         | windows    | msvc       |
 | [i686-wrs-vxworks]                     | x86         | vxworks    | gnu        |
+| [loongarch64-unknown-linux-musl]       | loongarch64 | linux      | musl       |
 | [m68k-unknown-linux-gnu]               | m68k        | linux      | gnu        |
 | [mips-unknown-linux-gnu]               | mips        | linux      | gnu        |
 | [mips-unknown-linux-musl]              | mips        | linux      | musl       |
@@ -263,10 +270,11 @@ If we remove platforms, we will bump the minor version of this crate.
 | [powerpc64le-unknown-linux-musl]       | powerpc64   | linux      | musl       |
 | [riscv32gc-unknown-linux-gnu]          | riscv32     | linux      | gnu        |
 | [riscv32gc-unknown-linux-musl]         | riscv32     | linux      | musl       |
-| [riscv32im-unknown-none-elf]           | riscv32     | none       |            |
+| [riscv32im-risc0-zkvm-elf]             | riscv32     | zkvm       |            |
+| [riscv32ima-unknown-none-elf]          | riscv32     | none       |            |
 | [riscv32imac-esp-espidf]               | riscv32     | espidf     | newlib     |
 | [riscv32imac-unknown-xous-elf]         | riscv32     | xous       |            |
-| [riscv32imafc-unknown-none-elf]        | riscv32     | none       |            |
+| [riscv32imafc-esp-espidf]              | riscv32     | espidf     | newlib     |
 | [riscv32imc-esp-espidf]                | riscv32     | espidf     | newlib     |
 | [riscv64-linux-android]                | riscv64     | android    |            |
 | [riscv64gc-unknown-freebsd]            | riscv64     | freebsd    |            |
@@ -285,6 +293,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [thumbv7a-pc-windows-msvc]             | arm         | windows    | msvc       |
 | [thumbv7a-uwp-windows-msvc]            | arm         | windows    | msvc       |
 | [thumbv7neon-unknown-linux-musleabihf] | arm         | linux      | musl       |
+| [wasm32-wasip2]                        | wasm32      | wasi       | p2         |
 | [wasm64-unknown-unknown]               | wasm64      | unknown    |            |
 | [x86_64-apple-ios-macabi]              | x86_64      | ios        |            |
 | [x86_64-apple-tvos]                    | x86_64      | tvos       |            |
@@ -296,7 +305,6 @@ If we remove platforms, we will bump the minor version of this crate.
 | [x86_64-unknown-haiku]                 | x86_64      | haiku      |            |
 | [x86_64-unknown-hermit]                | x86_64      | hermit     |            |
 | [x86_64-unknown-l4re-uclibc]           | x86_64      | l4re       | uclibc     |
-| [x86_64-unknown-linux-ohos]            | x86_64      | linux      | ohos       |
 | [x86_64-unknown-openbsd]               | x86_64      | openbsd    |            |
 | [x86_64-uwp-windows-gnu]               | x86_64      | windows    | gnu        |
 | [x86_64-uwp-windows-msvc]              | x86_64      | windows    | msvc       |
@@ -347,6 +355,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [arm64_32-apple-watchos]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64_32_APPLE_WATCHOS.html
 [arm64e-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64E_APPLE_DARWIN.html
 [arm64e-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64E_APPLE_IOS.html
+[arm64ec-pc-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64EC_PC_WINDOWS_MSVC.html
 [armeb-unknown-linux-gnueabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMEB_UNKNOWN_LINUX_GNUEABI.html
 [armebv7r-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMEBV7R_NONE_EABI.html
 [armebv7r-none-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMEBV7R_NONE_EABIHF.html
@@ -379,6 +388,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [armv7r-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7R_NONE_EABI.html
 [armv7r-none-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7R_NONE_EABIHF.html
 [armv7s-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7S_APPLE_IOS.html
+[armv8r-none-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV8R_NONE_EABIHF.html
 [avr-unknown-gnu-atmega328]: https://docs.rs/platforms/latest/platforms/platform/constant.AVR_UNKNOWN_GNU_ATMEGA328.html
 [bpfeb-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.BPFEB_UNKNOWN_NONE.html
 [bpfel-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.BPFEL_UNKNOWN_NONE.html
@@ -410,6 +420,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [i686-win7-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_WIN7_WINDOWS_MSVC.html
 [i686-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_WRS_VXWORKS.html
 [loongarch64-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_LINUX_GNU.html
+[loongarch64-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_LINUX_MUSL.html
 [loongarch64-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_NONE.html
 [loongarch64-unknown-none-softfloat]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_NONE_SOFTFLOAT.html
 [m68k-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.M68K_UNKNOWN_LINUX_GNU.html
@@ -454,10 +465,13 @@ If we remove platforms, we will bump the minor version of this crate.
 [riscv32gc-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32GC_UNKNOWN_LINUX_GNU.html
 [riscv32gc-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32GC_UNKNOWN_LINUX_MUSL.html
 [riscv32i-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32I_UNKNOWN_NONE_ELF.html
+[riscv32im-risc0-zkvm-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IM_RISC0_ZKVM_ELF.html
 [riscv32im-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IM_UNKNOWN_NONE_ELF.html
+[riscv32ima-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMA_UNKNOWN_NONE_ELF.html
 [riscv32imac-esp-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAC_ESP_ESPIDF.html
 [riscv32imac-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAC_UNKNOWN_NONE_ELF.html
 [riscv32imac-unknown-xous-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAC_UNKNOWN_XOUS_ELF.html
+[riscv32imafc-esp-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAFC_ESP_ESPIDF.html
 [riscv32imafc-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAFC_UNKNOWN_NONE_ELF.html
 [riscv32imc-esp-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMC_ESP_ESPIDF.html
 [riscv32imc-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMC_UNKNOWN_NONE_ELF.html
@@ -496,7 +510,9 @@ If we remove platforms, we will bump the minor version of this crate.
 [wasm32-unknown-emscripten]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_UNKNOWN_EMSCRIPTEN.html
 [wasm32-unknown-unknown]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_UNKNOWN_UNKNOWN.html
 [wasm32-wasi]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASI.html
-[wasm32-wasi-preview1-threads]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASI_PREVIEW1_THREADS.html
+[wasm32-wasip1]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP1.html
+[wasm32-wasip1-threads]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP1_THREADS.html
+[wasm32-wasip2]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP2.html
 [wasm64-unknown-unknown]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM64_UNKNOWN_UNKNOWN.html
 [x86_64-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_APPLE_DARWIN.html
 [x86_64-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_APPLE_IOS.html

--- a/platforms/src/platform/platforms.rs
+++ b/platforms/src/platform/platforms.rs
@@ -58,6 +58,7 @@ pub(crate) const ALL: &[Platform] = &[
     ARM64_32_APPLE_WATCHOS,
     ARM64E_APPLE_DARWIN,
     ARM64E_APPLE_IOS,
+    ARM64EC_PC_WINDOWS_MSVC,
     ARMEB_UNKNOWN_LINUX_GNUEABI,
     ARMEBV7R_NONE_EABI,
     ARMEBV7R_NONE_EABIHF,
@@ -90,6 +91,7 @@ pub(crate) const ALL: &[Platform] = &[
     ARMV7R_NONE_EABI,
     ARMV7R_NONE_EABIHF,
     ARMV7S_APPLE_IOS,
+    ARMV8R_NONE_EABIHF,
     AVR_UNKNOWN_GNU_ATMEGA328,
     BPFEB_UNKNOWN_NONE,
     BPFEL_UNKNOWN_NONE,
@@ -121,6 +123,7 @@ pub(crate) const ALL: &[Platform] = &[
     I686_WIN7_WINDOWS_MSVC,
     I686_WRS_VXWORKS,
     LOONGARCH64_UNKNOWN_LINUX_GNU,
+    LOONGARCH64_UNKNOWN_LINUX_MUSL,
     LOONGARCH64_UNKNOWN_NONE,
     LOONGARCH64_UNKNOWN_NONE_SOFTFLOAT,
     M68K_UNKNOWN_LINUX_GNU,
@@ -165,10 +168,13 @@ pub(crate) const ALL: &[Platform] = &[
     RISCV32GC_UNKNOWN_LINUX_GNU,
     RISCV32GC_UNKNOWN_LINUX_MUSL,
     RISCV32I_UNKNOWN_NONE_ELF,
+    RISCV32IM_RISC0_ZKVM_ELF,
     RISCV32IM_UNKNOWN_NONE_ELF,
+    RISCV32IMA_UNKNOWN_NONE_ELF,
     RISCV32IMAC_ESP_ESPIDF,
     RISCV32IMAC_UNKNOWN_NONE_ELF,
     RISCV32IMAC_UNKNOWN_XOUS_ELF,
+    RISCV32IMAFC_ESP_ESPIDF,
     RISCV32IMAFC_UNKNOWN_NONE_ELF,
     RISCV32IMC_ESP_ESPIDF,
     RISCV32IMC_UNKNOWN_NONE_ELF,
@@ -207,7 +213,9 @@ pub(crate) const ALL: &[Platform] = &[
     WASM32_UNKNOWN_EMSCRIPTEN,
     WASM32_UNKNOWN_UNKNOWN,
     WASM32_WASI,
-    WASM32_WASI_PREVIEW1_THREADS,
+    WASM32_WASIP1,
+    WASM32_WASIP1_THREADS,
+    WASM32_WASIP2,
     WASM64_UNKNOWN_UNKNOWN,
     X86_64_APPLE_DARWIN,
     X86_64_APPLE_IOS,
@@ -443,7 +451,7 @@ pub(crate) const AARCH64_UNKNOWN_ILLUMOS: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARM64 Linux (kernel 4.1, glibc 2.17+) [^missing-stack-probes]
+/// ARM64 Linux (kernel 4.1, glibc 2.17+)
 pub(crate) const AARCH64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "aarch64-unknown-linux-gnu",
     target_arch: Arch::AArch64,
@@ -465,7 +473,7 @@ pub(crate) const AARCH64_UNKNOWN_LINUX_GNU_ILP32: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARM64 Linux with MUSL
+/// ARM64 Linux with musl 1.2.3
 pub(crate) const AARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "aarch64-unknown-linux-musl",
     target_arch: Arch::AArch64,
@@ -476,6 +484,7 @@ pub(crate) const AARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// ARM64 OpenHarmony
 pub(crate) const AARCH64_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_triple: "aarch64-unknown-linux-ohos",
     target_arch: Arch::AArch64,
@@ -483,7 +492,7 @@ pub(crate) const AARCH64_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_env: Env::OhOS,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// ARM64 NetBSD
@@ -658,7 +667,7 @@ pub(crate) const ARM_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv6 Linux with MUSL
+/// ARMv6 Linux with musl 1.2.3
 pub(crate) const ARM_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "arm-unknown-linux-musleabi",
     target_arch: Arch::Arm,
@@ -669,7 +678,7 @@ pub(crate) const ARM_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv6 Linux with MUSL, hardfloat
+/// ARMv6 Linux with musl 1.2.3, hardfloat
 pub(crate) const ARM_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     target_triple: "arm-unknown-linux-musleabihf",
     target_arch: Arch::Arm,
@@ -708,6 +717,17 @@ pub(crate) const ARM64E_APPLE_IOS: Platform = Platform {
     target_arch: Arch::AArch64,
     target_os: OS::iOS,
     target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
+/// Arm64EC Windows MSVC
+pub(crate) const ARM64EC_PC_WINDOWS_MSVC: Platform = Platform {
+    target_triple: "arm64ec-pc-windows-msvc",
+    target_arch: Arch::Arm64ec,
+    target_os: OS::Windows,
+    target_env: Env::Msvc,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
@@ -790,7 +810,7 @@ pub(crate) const ARMV5TE_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv5TE Linux with MUSL
+/// ARMv5TE Linux with musl 1.2.3
 pub(crate) const ARMV5TE_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "armv5te-unknown-linux-musleabi",
     target_arch: Arch::Arm,
@@ -817,7 +837,7 @@ pub(crate) const ARMV6_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "armv6-unknown-freebsd",
     target_arch: Arch::Arm,
     target_os: OS::FreeBSD,
-    target_env: Env::Gnueabihf,
+    target_env: Env::Gnu,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Three,
@@ -828,7 +848,7 @@ pub(crate) const ARMV6_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     target_triple: "armv6-unknown-netbsd-eabihf",
     target_arch: Arch::Arm,
     target_os: OS::NetBSD,
-    target_env: Env::Eabihf,
+    target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Three,
@@ -872,7 +892,7 @@ pub(crate) const ARMV7_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "armv7-unknown-freebsd",
     target_arch: Arch::Arm,
     target_os: OS::FreeBSD,
-    target_env: Env::Gnueabihf,
+    target_env: Env::Gnu,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Three,
@@ -900,7 +920,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A Linux with MUSL
+/// ARMv7-A Linux with musl 1.2.3
 pub(crate) const ARMV7_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "armv7-unknown-linux-musleabi",
     target_arch: Arch::Arm,
@@ -911,7 +931,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A Linux with MUSL, hardfloat
+/// ARMv7-A Linux with musl 1.2.3, hardfloat
 pub(crate) const ARMV7_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     target_triple: "armv7-unknown-linux-musleabihf",
     target_arch: Arch::Arm,
@@ -922,6 +942,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// ARMv7-A OpenHarmony
 pub(crate) const ARMV7_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_triple: "armv7-unknown-linux-ohos",
     target_arch: Arch::Arm,
@@ -929,7 +950,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_env: Env::OhOS,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// ARMv7-A Linux with uClibc, softfloat
@@ -959,7 +980,7 @@ pub(crate) const ARMV7_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     target_triple: "armv7-unknown-netbsd-eabihf",
     target_arch: Arch::Arm,
     target_os: OS::NetBSD,
-    target_env: Env::Eabihf,
+    target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Three,
@@ -1064,6 +1085,17 @@ pub(crate) const ARMV7S_APPLE_IOS: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// Bare ARMv8-R, hardfloat
+pub(crate) const ARMV8R_NONE_EABIHF: Platform = Platform {
+    target_triple: "armv8r-none-eabihf",
+    target_arch: Arch::Arm,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// AVR. Requires `-Z build-std=core`
 pub(crate) const AVR_UNKNOWN_GNU_ATMEGA328: Platform = Platform {
     target_triple: "avr-unknown-gnu-atmega328",
@@ -1119,6 +1151,7 @@ pub(crate) const CSKY_UNKNOWN_LINUX_GNUABIV2HF: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// Hexagon Linux with musl 1.2.3
 pub(crate) const HEXAGON_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "hexagon-unknown-linux-musl",
     target_arch: Arch::Hexagon,
@@ -1184,7 +1217,7 @@ pub(crate) const I586_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// 32-bit Linux w/o SSE, MUSL [^x86_32-floats-x87]
+/// 32-bit Linux w/o SSE, musl 1.2.3 [^x86_32-floats-x87]
 pub(crate) const I586_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "i586-unknown-linux-musl",
     target_arch: Arch::X86,
@@ -1203,7 +1236,7 @@ pub(crate) const I586_UNKNOWN_NETBSD: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
-    tier: Tier::Two,
+    tier: Tier::Three,
 };
 
 /// 32-bit macOS (10.12+, Sierra+) [^x86_32-floats-return-ABI]
@@ -1228,7 +1261,7 @@ pub(crate) const I686_LINUX_ANDROID: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// 32-bit MinGW (Windows 7+) [^windows-support] [^x86_32-floats-return-ABI]
+/// 32-bit MinGW (Windows 10+) [^x86_32-floats-return-ABI]
 pub(crate) const I686_PC_WINDOWS_GNU: Platform = Platform {
     target_triple: "i686-pc-windows-gnu",
     target_arch: Arch::X86,
@@ -1250,7 +1283,7 @@ pub(crate) const I686_PC_WINDOWS_GNULLVM: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// 32-bit MSVC (Windows 7+) [^windows-support] [^x86_32-floats-return-ABI]
+/// 32-bit MSVC (Windows 10+) [^x86_32-floats-return-ABI]
 pub(crate) const I686_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "i686-pc-windows-msvc",
     target_arch: Arch::X86,
@@ -1305,7 +1338,7 @@ pub(crate) const I686_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::One,
 };
 
-/// 32-bit Linux with MUSL [^x86_32-floats-return-ABI]
+/// 32-bit Linux with musl 1.2.3 [^x86_32-floats-return-ABI]
 pub(crate) const I686_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "i686-unknown-linux-musl",
     target_arch: Arch::X86,
@@ -1404,6 +1437,17 @@ pub(crate) const LOONGARCH64_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// LoongArch64 Linux (LP64D ABI) with musl 1.2.3
+pub(crate) const LOONGARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
+    target_triple: "loongarch64-unknown-linux-musl",
+    target_arch: Arch::Loongarch64,
+    target_os: OS::Linux,
+    target_env: Env::Musl,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// LoongArch64 Bare-metal (LP64D ABI)
 pub(crate) const LOONGARCH64_UNKNOWN_NONE: Platform = Platform {
     target_triple: "loongarch64-unknown-none",
@@ -1448,7 +1492,7 @@ pub(crate) const MIPS_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// MIPS Linux with musl libc
+/// MIPS Linux with musl 1.2.3
 pub(crate) const MIPS_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "mips-unknown-linux-musl",
     target_arch: Arch::Mips,
@@ -1470,7 +1514,7 @@ pub(crate) const MIPS_UNKNOWN_LINUX_UCLIBC: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// MIPS64 for OpenWrt Linux MUSL
+/// MIPS64 for OpenWrt Linux musl 1.2.3
 pub(crate) const MIPS64_OPENWRT_LINUX_MUSL: Platform = Platform {
     target_triple: "mips64-openwrt-linux-musl",
     target_arch: Arch::Mips64,
@@ -1492,7 +1536,7 @@ pub(crate) const MIPS64_UNKNOWN_LINUX_GNUABI64: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// MIPS64 Linux, N64 ABI, musl libc
+/// MIPS64 Linux, N64 ABI, musl 1.2.3
 pub(crate) const MIPS64_UNKNOWN_LINUX_MUSLABI64: Platform = Platform {
     target_triple: "mips64-unknown-linux-muslabi64",
     target_arch: Arch::Mips64,
@@ -1514,7 +1558,7 @@ pub(crate) const MIPS64EL_UNKNOWN_LINUX_GNUABI64: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// MIPS64 (little endian) Linux, N64 ABI, musl libc
+/// MIPS64 (little endian) Linux, N64 ABI, musl 1.2.3
 pub(crate) const MIPS64EL_UNKNOWN_LINUX_MUSLABI64: Platform = Platform {
     target_triple: "mips64el-unknown-linux-muslabi64",
     target_arch: Arch::Mips64,
@@ -1558,7 +1602,7 @@ pub(crate) const MIPSEL_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// MIPS (little endian) Linux with musl libc
+/// MIPS (little endian) Linux with musl 1.2.3
 pub(crate) const MIPSEL_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "mipsel-unknown-linux-musl",
     target_arch: Arch::Mips,
@@ -1701,6 +1745,7 @@ pub(crate) const POWERPC_UNKNOWN_LINUX_GNUSPE: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// PowerPC Linux with musl 1.2.3
 pub(crate) const POWERPC_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "powerpc-unknown-linux-musl",
     target_arch: Arch::PowerPc,
@@ -1785,6 +1830,7 @@ pub(crate) const POWERPC64_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// 64-bit PowerPC Linux with musl 1.2.3
 pub(crate) const POWERPC64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "powerpc64-unknown-linux-musl",
     target_arch: Arch::PowerPc64,
@@ -1838,6 +1884,7 @@ pub(crate) const POWERPC64LE_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// 64-bit PowerPC Linux with musl 1.2.3, Little Endian
 pub(crate) const POWERPC64LE_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "powerpc64le-unknown-linux-musl",
     target_arch: Arch::PowerPc64,
@@ -1859,7 +1906,7 @@ pub(crate) const RISCV32GC_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// RISC-V Linux (kernel 5.4, musl + RISCV32 support patches)
+/// RISC-V Linux (kernel 5.4, musl 1.2.3 + RISCV32 support patches)
 pub(crate) const RISCV32GC_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "riscv32gc-unknown-linux-musl",
     target_arch: Arch::Riscv32,
@@ -1881,9 +1928,31 @@ pub(crate) const RISCV32I_UNKNOWN_NONE_ELF: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// RISC Zero's zero-knowledge Virtual Machine (RV32IM ISA)
+pub(crate) const RISCV32IM_RISC0_ZKVM_ELF: Platform = Platform {
+    target_triple: "riscv32im-risc0-zkvm-elf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::Zkvm,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// Bare RISC-V (RV32IM ISA)
 pub(crate) const RISCV32IM_UNKNOWN_NONE_ELF: Platform = Platform {
     target_triple: "riscv32im-unknown-none-elf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Two,
+};
+
+/// Bare RISC-V (RV32IMA ISA)
+pub(crate) const RISCV32IMA_UNKNOWN_NONE_ELF: Platform = Platform {
+    target_triple: "riscv32ima-unknown-none-elf",
     target_arch: Arch::Riscv32,
     target_os: OS::None,
     target_env: Env::None,
@@ -1925,6 +1994,17 @@ pub(crate) const RISCV32IMAC_UNKNOWN_XOUS_ELF: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// RISC-V ESP-IDF
+pub(crate) const RISCV32IMAFC_ESP_ESPIDF: Platform = Platform {
+    target_triple: "riscv32imafc-esp-espidf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::Espidf,
+    target_env: Env::Newlib,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// Bare RISC-V (RV32IMAFC ISA)
 pub(crate) const RISCV32IMAFC_UNKNOWN_NONE_ELF: Platform = Platform {
     target_triple: "riscv32imafc-unknown-none-elf",
@@ -1933,7 +2013,7 @@ pub(crate) const RISCV32IMAFC_UNKNOWN_NONE_ELF: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// RISC-V ESP-IDF
@@ -2013,7 +2093,7 @@ pub(crate) const RISCV64GC_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// RISC-V Linux (kernel 4.20, musl 1.2.0)
+/// RISC-V Linux (kernel 4.20, musl 1.2.3)
 pub(crate) const RISCV64GC_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "riscv64gc-unknown-linux-musl",
     target_arch: Arch::Riscv64,
@@ -2079,7 +2159,7 @@ pub(crate) const S390X_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// S390x Linux (kernel 3.2, MUSL)
+/// S390x Linux (kernel 3.2, musl 1.2.3)
 pub(crate) const S390X_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "s390x-unknown-linux-musl",
     target_arch: Arch::S390X,
@@ -2264,7 +2344,7 @@ pub(crate) const THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Thumb2-mode ARMv7-A Linux with NEON, MUSL
+/// Thumb2-mode ARMv7-A Linux with NEON, musl 1.2.3
 pub(crate) const THUMBV7NEON_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     target_triple: "thumbv7neon-unknown-linux-musleabihf",
     target_arch: Arch::Arm,
@@ -2330,7 +2410,7 @@ pub(crate) const WASM32_UNKNOWN_UNKNOWN: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// WebAssembly with WASI
+/// WebAssembly with WASI (undergoing a [rename to `wasm32-wasip1`][wasi-rename])
 pub(crate) const WASM32_WASI: Platform = Platform {
     target_triple: "wasm32-wasi",
     target_arch: Arch::Wasm32,
@@ -2341,15 +2421,37 @@ pub(crate) const WASM32_WASI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// WebAssembly with WASI Preview 1 and threads
-pub(crate) const WASM32_WASI_PREVIEW1_THREADS: Platform = Platform {
-    target_triple: "wasm32-wasi-preview1-threads",
+/// WebAssembly with WASI
+pub(crate) const WASM32_WASIP1: Platform = Platform {
+    target_triple: "wasm32-wasip1",
     target_arch: Arch::Wasm32,
     target_os: OS::Wasi,
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Two,
+};
+
+/// WebAssembly with WASI Preview 1 and threads
+pub(crate) const WASM32_WASIP1_THREADS: Platform = Platform {
+    target_triple: "wasm32-wasip1-threads",
+    target_arch: Arch::Wasm32,
+    target_os: OS::Wasi,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Two,
+};
+
+/// WebAssembly
+pub(crate) const WASM32_WASIP2: Platform = Platform {
+    target_triple: "wasm32-wasip2",
+    target_arch: Arch::Wasm32,
+    target_os: OS::Wasi,
+    target_env: Env::P2,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
 };
 
 /// WebAssembly
@@ -2472,7 +2574,7 @@ pub(crate) const X86_64_PC_SOLARIS: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// 64-bit MinGW (Windows 7+) [^windows-support]
+/// 64-bit MinGW (Windows 10+)
 pub(crate) const X86_64_PC_WINDOWS_GNU: Platform = Platform {
     target_triple: "x86_64-pc-windows-gnu",
     target_arch: Arch::X86_64,
@@ -2493,7 +2595,7 @@ pub(crate) const X86_64_PC_WINDOWS_GNULLVM: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// 64-bit MSVC (Windows 7+) [^windows-support]
+/// 64-bit MSVC (Windows 10+)
 pub(crate) const X86_64_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "x86_64-pc-windows-msvc",
     target_arch: Arch::X86_64,
@@ -2504,7 +2606,7 @@ pub(crate) const X86_64_PC_WINDOWS_MSVC: Platform = Platform {
     tier: Tier::One,
 };
 
-/// 64-bit Unikraft with musl
+/// 64-bit Unikraft with musl 1.2.3
 pub(crate) const X86_64_UNIKRAFT_LINUX_MUSL: Platform = Platform {
     target_triple: "x86_64-unikraft-linux-musl",
     target_arch: Arch::X86_64,
@@ -2613,7 +2715,7 @@ pub(crate) const X86_64_UNKNOWN_LINUX_GNUX32: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// 64-bit Linux with MUSL
+/// 64-bit Linux with musl 1.2.3
 pub(crate) const X86_64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "x86_64-unknown-linux-musl",
     target_arch: Arch::X86_64,
@@ -2624,6 +2726,7 @@ pub(crate) const X86_64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// x86_64 OpenHarmony
 pub(crate) const X86_64_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_triple: "x86_64-unknown-linux-ohos",
     target_arch: Arch::X86_64,
@@ -2631,7 +2734,7 @@ pub(crate) const X86_64_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_env: Env::OhOS,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// NetBSD/amd64

--- a/platforms/src/target/arch.rs
+++ b/platforms/src/target/arch.rs
@@ -16,6 +16,9 @@ pub enum Arch {
     /// `arm`: 32-bit ARM architecture
     Arm,
 
+    /// `arm64ec`
+    Arm64ec,
+
     /// `avr`
     Avr,
 
@@ -92,6 +95,7 @@ impl Arch {
         match self {
             Arch::AArch64 => "aarch64",
             Arch::Arm => "arm",
+            Arch::Arm64ec => "arm64ec",
             Arch::Avr => "avr",
             Arch::Bpf => "bpf",
             Arch::Csky => "csky",
@@ -127,6 +131,7 @@ impl FromStr for Arch {
         let result = match name {
             "aarch64" => Arch::AArch64,
             "arm" => Arch::Arm,
+            "arm64ec" => Arch::Arm64ec,
             "avr" => Arch::Avr,
             "bpf" => Arch::Bpf,
             "csky" => Arch::Csky,

--- a/platforms/src/target/env.rs
+++ b/platforms/src/target/env.rs
@@ -17,14 +17,8 @@ pub enum Env {
     /// ``: None
     None,
 
-    /// `eabihf`
-    Eabihf,
-
     /// `gnu`: The GNU C Library (glibc)
     Gnu,
-
-    /// `gnueabihf`
-    Gnueabihf,
 
     /// `msvc`: Microsoft Visual C(++)
     Msvc,
@@ -44,6 +38,9 @@ pub enum Env {
     /// `ohos`
     OhOS,
 
+    /// `p2`
+    P2,
+
     /// `psx`
     Psx,
 
@@ -62,15 +59,14 @@ impl Env {
     pub fn as_str(self) -> &'static str {
         match self {
             Env::None => "",
-            Env::Eabihf => "eabihf",
             Env::Gnu => "gnu",
-            Env::Gnueabihf => "gnueabihf",
             Env::Msvc => "msvc",
             Env::Musl => "musl",
             Env::Newlib => "newlib",
             Env::Nto70 => "nto70",
             Env::Nto71 => "nto71",
             Env::OhOS => "ohos",
+            Env::P2 => "p2",
             Env::Psx => "psx",
             Env::Relibc => "relibc",
             Env::Sgx => "sgx",
@@ -86,15 +82,14 @@ impl FromStr for Env {
     fn from_str(name: &str) -> Result<Self, Self::Err> {
         let result = match name {
             "" => Env::None,
-            "eabihf" => Env::Eabihf,
             "gnu" => Env::Gnu,
-            "gnueabihf" => Env::Gnueabihf,
             "msvc" => Env::Msvc,
             "musl" => Env::Musl,
             "newlib" => Env::Newlib,
             "nto70" => Env::Nto70,
             "nto71" => Env::Nto71,
             "ohos" => Env::OhOS,
+            "p2" => Env::P2,
             "psx" => Env::Psx,
             "relibc" => Env::Relibc,
             "sgx" => Env::Sgx,

--- a/platforms/src/target/os.rs
+++ b/platforms/src/target/os.rs
@@ -118,6 +118,9 @@ pub enum OS {
 
     /// `xous`
     Xous,
+
+    /// `zkvm`
+    Zkvm,
 }
 
 impl OS {
@@ -159,6 +162,7 @@ impl OS {
             OS::WatchOS => "watchos",
             OS::Windows => "windows",
             OS::Xous => "xous",
+            OS::Zkvm => "zkvm",
         }
     }
 }
@@ -204,6 +208,7 @@ impl FromStr for OS {
             "watchos" => OS::WatchOS,
             "windows" => OS::Windows,
             "xous" => OS::Xous,
+            "zkvm" => OS::Zkvm,
             _ => return Err(Error),
         };
 


### PR DESCRIPTION
Ran `regenerate-platforms-crate.sh`. Would be great if we can release a new version.