### PR TITLE
Support auditing WASM binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,18 +230,19 @@ dependencies = [
 
 [[package]]
 name = "auditable-extract"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a62a6f4a522a2ab30b5fca049b9587228d17e4ac648106aeaf7da9b70b5e2b"
+checksum = "7f79bae6b318209234a31bcd440c69d921cfeb8beab53e40834a43c74a32c046"
 dependencies = [
  "binfarce",
+ "wasmparser",
 ]
 
 [[package]]
 name = "auditable-info"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e563c9e31a71d1a6f2ab7a5a168cdb0d387f59bde891aac5957b9ebaaf03f602"
+checksum = "776d65568b8d0cd81437bf14295937fef9e6d3c23ca4fa13430c6a460cc63020"
 dependencies = [
  "auditable-extract",
  "auditable-serde",
@@ -3432,6 +3433,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+
+[[package]]
+name = "wasmparser"
+version = "0.206.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39192edb55d55b41963db40fd49b0b542156f04447b5b512744a91d38567bdbc"
+dependencies = [
+ "ahash",
+ "bitflags 2.4.2",
+ "hashbrown",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "auditable-extract"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f79bae6b318209234a31bcd440c69d921cfeb8beab53e40834a43c74a32c046"
+checksum = "6728a67cb6ba3998b16a84c3bc2fcc0554bca9cf79fbe3c2d4082e8cac32f96e"
 dependencies = [
  "binfarce",
  "wasmparser",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "auditable-info"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776d65568b8d0cd81437bf14295937fef9e6d3c23ca4fa13430c6a460cc63020"
+checksum = "0d0d13c05dccf8623bdd1a86359100b35738575c30e4401a503d2b7e6c1ccc70"
 dependencies = [
  "auditable-extract",
  "auditable-serde",
@@ -3436,15 +3436,11 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasmparser"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39192edb55d55b41963db40fd49b0b542156f04447b5b512744a91d38567bdbc"
+checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
 dependencies = [
- "ahash",
  "bitflags 2.4.2",
- "hashbrown",
- "indexmap",
- "semver",
 ]
 
 [[package]]

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1"
 thiserror = "1"
 
 # for scanning binary files
-auditable-info = { version = "0.7.1", optional = true, features = ["wasm"] }
+auditable-info = { version = "0.7.2", optional = true, features = ["wasm"] }
 cargo-lock = { version = "9", optional = true }
 auditable-serde = { version = "0.6",  optional = true, features = ["toml"] }
 quitters = { version = "0.1", optional = true }

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1"
 thiserror = "1"
 
 # for scanning binary files
-auditable-info = { version = "0.7", optional = true }
+auditable-info = { version = "0.7.1", optional = true, features = ["wasm"] }
 cargo-lock = { version = "9", optional = true }
 auditable-serde = { version = "0.6",  optional = true, features = ["toml"] }
 quitters = { version = "0.1", optional = true }

--- a/cargo-audit/src/binary_deps.rs
+++ b/cargo-audit/src/binary_deps.rs
@@ -65,7 +65,7 @@ pub fn load_deps_from_binary(binary_path: &Path) -> rustsec::Result<(BinaryForma
 }
 
 fn detect_format(data: &[u8]) -> BinaryFormat {
-    match binfarce::detect_format(&data) {
+    match binfarce::detect_format(data) {
         binfarce::Format::Unknown => {
             // binfarce doesn't detect WASM
             if data.starts_with(b"\0asm") {

--- a/cargo-audit/src/binary_format.rs
+++ b/cargo-audit/src/binary_format.rs
@@ -5,6 +5,7 @@ pub enum BinaryFormat {
     Elf64,
     Macho,
     PE,
+    Wasm,
     Unknown,
 }
 

--- a/cargo-audit/src/binary_type_filter.rs
+++ b/cargo-audit/src/binary_type_filter.rs
@@ -60,6 +60,7 @@ fn at_least_one_os_runs_binary(binary_type: &BinaryFormat, os_list: &[OS]) -> bo
             // Perhaps we can make `platforms` expose the `family` which can be `windows` or `unix` or `unknown`?
             // That way we can capture all the unix-likes as using ELF and discard everything else
         }
+        Wasm => true,    // TODO
         Unknown => true, // might be possible for detection based on panic messages?
     }
 }

--- a/cargo-audit/src/binary_type_filter.rs
+++ b/cargo-audit/src/binary_type_filter.rs
@@ -60,7 +60,17 @@ fn at_least_one_os_runs_binary(binary_type: &BinaryFormat, os_list: &[OS]) -> bo
             // Perhaps we can make `platforms` expose the `family` which can be `windows` or `unix` or `unknown`?
             // That way we can capture all the unix-likes as using ELF and discard everything else
         }
-        Wasm => true,    // TODO
+        Wasm => {
+            // WASM doesn't have an OS, so OS-specific vulns should not be an issue.
+            // There isn't really a way to indicate WASM-specific vulns,
+            // because in Rustc's terms WASM is not an OS.
+            // Assume vulns with `Unknown` and `None` OS still apply,
+            // just to have some last-ditch way to indicate WASM is affected
+            // other than including all the platforms ever.
+            os_list
+                .iter()
+                .any(|os| os == &OS::Unknown || os == &OS::None)
+        }
         Unknown => true, // might be possible for detection based on panic messages?
     }
 }

--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -48,7 +48,9 @@ impl AuditConfig {
         };
 
         if let Some(informational_warnings) = &self.advisories.informational_warnings {
-            settings.informational_warnings = informational_warnings.clone();
+            settings
+                .informational_warnings
+                .clone_from(informational_warnings);
         } else {
             // Alert for all informational packages by default
             settings.informational_warnings = vec![


### PR DESCRIPTION
Support auditing WASM files in `cargo audit bin`, either by using data embedded by `cargo auditable` or based on panic messages.

I added WASM support to `cargo auditable` in https://github.com/rust-secure-code/cargo-auditable/pull/145, and this PR enables auditing WASM blobs to make the embedded data actually useful.