### PR TITLE
Fix typo `then` -> `them` in index.html

### DIFF
--- a/admin/src/web/templates/index.html
+++ b/admin/src/web/templates/index.html
@@ -103,7 +103,7 @@ error: 1 vulnerability found!
             <div class="column">
                 <a href="https://github.com/advisories"><img src="/img/github.png"/></a>
                 <p>
-                    The <a href="https://github.com/advisories">Github Advisory Database</a> imports our advisories and makes then available in its
+                    The <a href="https://github.com/advisories">Github Advisory Database</a> imports our advisories and makes them available in its
                     <a href="https://docs.github.com/en/graphql/reference/objects#securityadvisory">public API</a>.
                 </p>
                 <p>This allows <a href="https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates">dependabot</a>


### PR DESCRIPTION
Just a small fix for a trivial typo I noticed while looking at the site.

Thanks for all the work you do here!