### PR TITLE
chore: regenerate platform support and bump to platforms@3.4.1

### DIFF
--- a/platforms/Cargo.toml
+++ b/platforms/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from the Rust compiler.
 """
-version    = "3.4.0"
+version    = "3.4.1"
 authors    = ["Tony Arcieri <bascule@gmail.com>", "Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://rustsec.org"

--- a/platforms/README.md
+++ b/platforms/README.md
@@ -82,6 +82,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [aarch64-apple-ios-sim]                | aarch64     | ios        |            |
 | [aarch64-fuchsia]                      | aarch64     | fuchsia    |            |
 | [aarch64-linux-android]                | aarch64     | android    |            |
+| [aarch64-pc-windows-gnullvm]           | aarch64     | windows    | gnu        |
 | [aarch64-pc-windows-msvc]              | aarch64     | windows    | msvc       |
 | [aarch64-unknown-fuchsia]              | aarch64     | fuchsia    |            |
 | [aarch64-unknown-linux-musl]           | aarch64     | linux      | musl       |
@@ -94,6 +95,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [arm-unknown-linux-gnueabihf]          | arm         | linux      | gnu        |
 | [arm-unknown-linux-musleabi]           | arm         | linux      | musl       |
 | [arm-unknown-linux-musleabihf]         | arm         | linux      | musl       |
+| [arm64ec-pc-windows-msvc]              | arm64ec     | windows    | msvc       |
 | [armebv7r-none-eabi]                   | arm         | none       |            |
 | [armebv7r-none-eabihf]                 | arm         | none       |            |
 | [armv5te-unknown-linux-gnueabi]        | arm         | linux      | gnu        |
@@ -111,10 +113,12 @@ If we remove platforms, we will bump the minor version of this crate.
 | [i586-unknown-linux-gnu]               | x86         | linux      | gnu        |
 | [i586-unknown-linux-musl]              | x86         | linux      | musl       |
 | [i686-linux-android]                   | x86         | android    |            |
+| [i686-pc-windows-gnullvm]              | x86         | windows    | gnu        |
 | [i686-unknown-freebsd]                 | x86         | freebsd    |            |
 | [i686-unknown-linux-musl]              | x86         | linux      | musl       |
 | [i686-unknown-uefi]                    | x86         | uefi       |            |
 | [loongarch64-unknown-linux-gnu]        | loongarch64 | linux      | gnu        |
+| [loongarch64-unknown-linux-musl]       | loongarch64 | linux      | musl       |
 | [loongarch64-unknown-none]             | loongarch64 | none       |            |
 | [loongarch64-unknown-none-softfloat]   | loongarch64 | none       |            |
 | [nvptx64-nvidia-cuda]                  | nvptx64     | cuda       |            |
@@ -143,14 +147,15 @@ If we remove platforms, we will bump the minor version of this crate.
 | [thumbv8m.main-none-eabihf]            | arm         | none       |            |
 | [wasm32-unknown-emscripten]            | wasm32      | emscripten |            |
 | [wasm32-unknown-unknown]               | wasm32      | unknown    |            |
-| [wasm32-wasi]                          | wasm32      | wasi       |            |
-| [wasm32-wasip1]                        | wasm32      | wasi       |            |
-| [wasm32-wasip1-threads]                | wasm32      | wasi       |            |
+| [wasm32-wasi]                          | wasm32      | wasi       | p1         |
+| [wasm32-wasip1]                        | wasm32      | wasi       | p1         |
+| [wasm32-wasip1-threads]                | wasm32      | wasi       | p1         |
 | [x86_64-apple-ios]                     | x86_64      | ios        |            |
 | [x86_64-fortanix-unknown-sgx]          | x86_64      | unknown    | sgx        |
 | [x86_64-fuchsia]                       | x86_64      | fuchsia    |            |
 | [x86_64-linux-android]                 | x86_64      | android    |            |
 | [x86_64-pc-solaris]                    | x86_64      | solaris    |            |
+| [x86_64-pc-windows-gnullvm]            | x86_64      | windows    | gnu        |
 | [x86_64-unknown-freebsd]               | x86_64      | freebsd    |            |
 | [x86_64-unknown-fuchsia]               | x86_64      | fuchsia    |            |
 | [x86_64-unknown-illumos]               | x86_64      | illumos    |            |
@@ -169,11 +174,12 @@ If we remove platforms, we will bump the minor version of this crate.
 | [aarch64-apple-ios-macabi]             | aarch64     | ios        |            |
 | [aarch64-apple-tvos]                   | aarch64     | tvos       |            |
 | [aarch64-apple-tvos-sim]               | aarch64     | tvos       |            |
+| [aarch64-apple-visionos]               | aarch64     | visionos   |            |
+| [aarch64-apple-visionos-sim]           | aarch64     | visionos   |            |
 | [aarch64-apple-watchos]                | aarch64     | watchos    |            |
 | [aarch64-apple-watchos-sim]            | aarch64     | watchos    |            |
 | [aarch64-kmc-solid_asp3]               | aarch64     | solid_asp3 |            |
 | [aarch64-nintendo-switch-freestanding] | aarch64     | horizon    |            |
-| [aarch64-pc-windows-gnullvm]           | aarch64     | windows    | gnu        |
 | [aarch64-unknown-freebsd]              | aarch64     | freebsd    |            |
 | [aarch64-unknown-hermit]               | aarch64     | hermit     |            |
 | [aarch64-unknown-illumos]              | aarch64     | illumos    |            |
@@ -191,7 +197,6 @@ If we remove platforms, we will bump the minor version of this crate.
 | [arm64_32-apple-watchos]               | aarch64     | watchos    |            |
 | [arm64e-apple-darwin]                  | aarch64     | macos      |            |
 | [arm64e-apple-ios]                     | aarch64     | ios        |            |
-| [arm64ec-pc-windows-msvc]              | arm64ec     | windows    | msvc       |
 | [armeb-unknown-linux-gnueabi]          | arm         | linux      | gnu        |
 | [armv4t-none-eabi]                     | arm         | none       |            |
 | [armv4t-unknown-linux-gnueabi]         | arm         | linux      | gnu        |
@@ -223,16 +228,15 @@ If we remove platforms, we will bump the minor version of this crate.
 | [i586-pc-nto-qnx700]                   | x86         | nto        | nto70      |
 | [i586-unknown-netbsd]                  | x86         | netbsd     |            |
 | [i686-apple-darwin]                    | x86         | macos      |            |
-| [i686-pc-windows-gnullvm]              | x86         | windows    | gnu        |
 | [i686-unknown-haiku]                   | x86         | haiku      |            |
 | [i686-unknown-hurd-gnu]                | x86         | hurd       | gnu        |
 | [i686-unknown-netbsd]                  | x86         | netbsd     |            |
 | [i686-unknown-openbsd]                 | x86         | openbsd    |            |
+| [i686-unknown-redox]                   | x86         | redox      | relibc     |
 | [i686-uwp-windows-gnu]                 | x86         | windows    | gnu        |
 | [i686-uwp-windows-msvc]                | x86         | windows    | msvc       |
 | [i686-win7-windows-msvc]               | x86         | windows    | msvc       |
 | [i686-wrs-vxworks]                     | x86         | vxworks    | gnu        |
-| [loongarch64-unknown-linux-musl]       | loongarch64 | linux      | musl       |
 | [m68k-unknown-linux-gnu]               | m68k        | linux      | gnu        |
 | [mips-unknown-linux-gnu]               | mips        | linux      | gnu        |
 | [mips-unknown-linux-musl]              | mips        | linux      | musl       |
@@ -299,18 +303,24 @@ If we remove platforms, we will bump the minor version of this crate.
 | [x86_64-apple-tvos]                    | x86_64      | tvos       |            |
 | [x86_64-apple-watchos-sim]             | x86_64      | watchos    |            |
 | [x86_64-pc-nto-qnx710]                 | x86_64      | nto        | nto71      |
-| [x86_64-pc-windows-gnullvm]            | x86_64      | windows    | gnu        |
 | [x86_64-unikraft-linux-musl]           | x86_64      | linux      | musl       |
 | [x86_64-unknown-dragonfly]             | x86_64      | dragonfly  |            |
 | [x86_64-unknown-haiku]                 | x86_64      | haiku      |            |
 | [x86_64-unknown-hermit]                | x86_64      | hermit     |            |
 | [x86_64-unknown-l4re-uclibc]           | x86_64      | l4re       | uclibc     |
+| [x86_64-unknown-linux-none]            | x86_64      | linux      |            |
 | [x86_64-unknown-openbsd]               | x86_64      | openbsd    |            |
 | [x86_64-uwp-windows-gnu]               | x86_64      | windows    | gnu        |
 | [x86_64-uwp-windows-msvc]              | x86_64      | windows    | msvc       |
 | [x86_64-win7-windows-msvc]             | x86_64      | windows    | msvc       |
 | [x86_64-wrs-vxworks]                   | x86_64      | vxworks    | gnu        |
 | [x86_64h-apple-darwin]                 | x86_64      | macos      |            |
+| [xtensa-esp32-espidf]                  | xtensa      | espidf     | newlib     |
+| [xtensa-esp32-none-elf]                | xtensa      | none       |            |
+| [xtensa-esp32s2-espidf]                | xtensa      | espidf     | newlib     |
+| [xtensa-esp32s2-none-elf]              | xtensa      | none       |            |
+| [xtensa-esp32s3-espidf]                | xtensa      | espidf     | newlib     |
+| [xtensa-esp32s3-none-elf]              | xtensa      | none       |            |
 
 [aarch64-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_DARWIN.html
 [aarch64-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_IOS.html
@@ -318,6 +328,8 @@ If we remove platforms, we will bump the minor version of this crate.
 [aarch64-apple-ios-sim]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_IOS_SIM.html
 [aarch64-apple-tvos]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_TVOS.html
 [aarch64-apple-tvos-sim]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_TVOS_SIM.html
+[aarch64-apple-visionos]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_VISIONOS.html
+[aarch64-apple-visionos-sim]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_VISIONOS_SIM.html
 [aarch64-apple-watchos]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_WATCHOS.html
 [aarch64-apple-watchos-sim]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_WATCHOS_SIM.html
 [aarch64-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_FUCHSIA.html
@@ -414,6 +426,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [i686-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_UNKNOWN_LINUX_MUSL.html
 [i686-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_UNKNOWN_NETBSD.html
 [i686-unknown-openbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_UNKNOWN_OPENBSD.html
+[i686-unknown-redox]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_UNKNOWN_REDOX.html
 [i686-unknown-uefi]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_UNKNOWN_UEFI.html
 [i686-uwp-windows-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_UWP_WINDOWS_GNU.html
 [i686-uwp-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_UWP_WINDOWS_MSVC.html
@@ -538,6 +551,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [x86_64-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_GNU.html
 [x86_64-unknown-linux-gnux32]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_GNUX32.html
 [x86_64-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_MUSL.html
+[x86_64-unknown-linux-none]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_NONE.html
 [x86_64-unknown-linux-ohos]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_OHOS.html
 [x86_64-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_NETBSD.html
 [x86_64-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_NONE.html
@@ -549,3 +563,9 @@ If we remove platforms, we will bump the minor version of this crate.
 [x86_64-win7-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_WIN7_WINDOWS_MSVC.html
 [x86_64-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_WRS_VXWORKS.html
 [x86_64h-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64H_APPLE_DARWIN.html
+[xtensa-esp32-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.XTENSA_ESP32_ESPIDF.html
+[xtensa-esp32-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.XTENSA_ESP32_NONE_ELF.html
+[xtensa-esp32s2-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.XTENSA_ESP32S2_ESPIDF.html
+[xtensa-esp32s2-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.XTENSA_ESP32S2_NONE_ELF.html
+[xtensa-esp32s3-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.XTENSA_ESP32S3_ESPIDF.html
+[xtensa-esp32s3-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.XTENSA_ESP32S3_NONE_ELF.html

--- a/platforms/src/platform/platforms.rs
+++ b/platforms/src/platform/platforms.rs
@@ -21,6 +21,8 @@ pub(crate) const ALL: &[Platform] = &[
     AARCH64_APPLE_IOS_SIM,
     AARCH64_APPLE_TVOS,
     AARCH64_APPLE_TVOS_SIM,
+    AARCH64_APPLE_VISIONOS,
+    AARCH64_APPLE_VISIONOS_SIM,
     AARCH64_APPLE_WATCHOS,
     AARCH64_APPLE_WATCHOS_SIM,
     AARCH64_FUCHSIA,
@@ -117,6 +119,7 @@ pub(crate) const ALL: &[Platform] = &[
     I686_UNKNOWN_LINUX_MUSL,
     I686_UNKNOWN_NETBSD,
     I686_UNKNOWN_OPENBSD,
+    I686_UNKNOWN_REDOX,
     I686_UNKNOWN_UEFI,
     I686_UWP_WINDOWS_GNU,
     I686_UWP_WINDOWS_MSVC,
@@ -241,6 +244,7 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_UNKNOWN_LINUX_GNU,
     X86_64_UNKNOWN_LINUX_GNUX32,
     X86_64_UNKNOWN_LINUX_MUSL,
+    X86_64_UNKNOWN_LINUX_NONE,
     X86_64_UNKNOWN_LINUX_OHOS,
     X86_64_UNKNOWN_NETBSD,
     X86_64_UNKNOWN_NONE,
@@ -252,6 +256,12 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_WIN7_WINDOWS_MSVC,
     X86_64_WRS_VXWORKS,
     X86_64H_APPLE_DARWIN,
+    XTENSA_ESP32_ESPIDF,
+    XTENSA_ESP32_NONE_ELF,
+    XTENSA_ESP32S2_ESPIDF,
+    XTENSA_ESP32S2_NONE_ELF,
+    XTENSA_ESP32S3_ESPIDF,
+    XTENSA_ESP32S3_NONE_ELF,
 ];
 
 /// ARM64 macOS (11.0+, Big Sur+)
@@ -314,6 +324,28 @@ pub(crate) const AARCH64_APPLE_TVOS_SIM: Platform = Platform {
     target_triple: "aarch64-apple-tvos-sim",
     target_arch: Arch::AArch64,
     target_os: OS::TvOS,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
+/// ARM64 Apple visionOS
+pub(crate) const AARCH64_APPLE_VISIONOS: Platform = Platform {
+    target_triple: "aarch64-apple-visionos",
+    target_arch: Arch::AArch64,
+    target_os: OS::VisionOS,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
+/// ARM64 Apple visionOS Simulator
+pub(crate) const AARCH64_APPLE_VISIONOS_SIM: Platform = Platform {
+    target_triple: "aarch64-apple-visionos-sim",
+    target_arch: Arch::AArch64,
+    target_os: OS::VisionOS,
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
@@ -386,6 +418,7 @@ pub(crate) const AARCH64_NINTENDO_SWITCH_FREESTANDING: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// ARM64 MinGW (Windows 10+), LLVM ABI
 pub(crate) const AARCH64_PC_WINDOWS_GNULLVM: Platform = Platform {
     target_triple: "aarch64-pc-windows-gnullvm",
     target_arch: Arch::AArch64,
@@ -393,7 +426,7 @@ pub(crate) const AARCH64_PC_WINDOWS_GNULLVM: Platform = Platform {
     target_env: Env::Gnu,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// ARM64 Windows MSVC
@@ -634,7 +667,7 @@ pub(crate) const AARCH64_BE_UNKNOWN_NETBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv6 Android
+/// Armv6 Android
 pub(crate) const ARM_LINUX_ANDROIDEABI: Platform = Platform {
     target_triple: "arm-linux-androideabi",
     target_arch: Arch::Arm,
@@ -645,7 +678,7 @@ pub(crate) const ARM_LINUX_ANDROIDEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv6 Linux (kernel 3.2, glibc 2.17)
+/// Armv6 Linux (kernel 3.2, glibc 2.17)
 pub(crate) const ARM_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "arm-unknown-linux-gnueabi",
     target_arch: Arch::Arm,
@@ -656,7 +689,7 @@ pub(crate) const ARM_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
+/// Armv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
 pub(crate) const ARM_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "arm-unknown-linux-gnueabihf",
     target_arch: Arch::Arm,
@@ -667,7 +700,7 @@ pub(crate) const ARM_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv6 Linux with musl 1.2.3
+/// Armv6 Linux with musl 1.2.3
 pub(crate) const ARM_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "arm-unknown-linux-musleabi",
     target_arch: Arch::Arm,
@@ -678,7 +711,7 @@ pub(crate) const ARM_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv6 Linux with musl 1.2.3, hardfloat
+/// Armv6 Linux with musl 1.2.3, hardfloat
 pub(crate) const ARM_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     target_triple: "arm-unknown-linux-musleabihf",
     target_arch: Arch::Arm,
@@ -689,7 +722,7 @@ pub(crate) const ARM_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARM Apple WatchOS 64-bit with 32-bit pointers
+/// Arm Apple WatchOS 64-bit with 32-bit pointers
 pub(crate) const ARM64_32_APPLE_WATCHOS: Platform = Platform {
     target_triple: "arm64_32-apple-watchos",
     target_arch: Arch::AArch64,
@@ -730,10 +763,10 @@ pub(crate) const ARM64EC_PC_WINDOWS_MSVC: Platform = Platform {
     target_env: Env::Msvc,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
-/// ARM BE8 the default ARM big-endian architecture since [ARMv6](https://developer.arm.com/documentation/101754/0616/armlink-Reference/armlink-Command-line-Options/--be8?lang=en).
+/// Arm BE8 the default Arm big-endian architecture since [Armv6](https://developer.arm.com/documentation/101754/0616/armlink-Reference/armlink-Command-line-Options/--be8?lang=en).
 pub(crate) const ARMEB_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armeb-unknown-linux-gnueabi",
     target_arch: Arch::Arm,
@@ -744,7 +777,7 @@ pub(crate) const ARMEB_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Bare ARMv7-R, Big Endian
+/// Bare Armv7-R, Big Endian
 pub(crate) const ARMEBV7R_NONE_EABI: Platform = Platform {
     target_triple: "armebv7r-none-eabi",
     target_arch: Arch::Arm,
@@ -755,7 +788,7 @@ pub(crate) const ARMEBV7R_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Bare ARMv7-R, Big Endian, hardfloat
+/// Bare Armv7-R, Big Endian, hardfloat
 pub(crate) const ARMEBV7R_NONE_EABIHF: Platform = Platform {
     target_triple: "armebv7r-none-eabihf",
     target_arch: Arch::Arm,
@@ -766,7 +799,7 @@ pub(crate) const ARMEBV7R_NONE_EABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Bare ARMv4T
+/// Bare Armv4T
 pub(crate) const ARMV4T_NONE_EABI: Platform = Platform {
     target_triple: "armv4t-none-eabi",
     target_arch: Arch::Arm,
@@ -777,7 +810,7 @@ pub(crate) const ARMV4T_NONE_EABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv4T Linux
+/// Armv4T Linux
 pub(crate) const ARMV4T_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armv4t-unknown-linux-gnueabi",
     target_arch: Arch::Arm,
@@ -788,7 +821,7 @@ pub(crate) const ARMV4T_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Bare ARMv5TE
+/// Bare Armv5TE
 pub(crate) const ARMV5TE_NONE_EABI: Platform = Platform {
     target_triple: "armv5te-none-eabi",
     target_arch: Arch::Arm,
@@ -799,7 +832,7 @@ pub(crate) const ARMV5TE_NONE_EABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv5TE Linux (kernel 4.4, glibc 2.23)
+/// Armv5TE Linux (kernel 4.4, glibc 2.23)
 pub(crate) const ARMV5TE_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armv5te-unknown-linux-gnueabi",
     target_arch: Arch::Arm,
@@ -810,7 +843,7 @@ pub(crate) const ARMV5TE_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv5TE Linux with musl 1.2.3
+/// Armv5TE Linux with musl 1.2.3
 pub(crate) const ARMV5TE_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "armv5te-unknown-linux-musleabi",
     target_arch: Arch::Arm,
@@ -821,7 +854,7 @@ pub(crate) const ARMV5TE_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv5TE Linux with uClibc
+/// Armv5TE Linux with uClibc
 pub(crate) const ARMV5TE_UNKNOWN_LINUX_UCLIBCEABI: Platform = Platform {
     target_triple: "armv5te-unknown-linux-uclibceabi",
     target_arch: Arch::Arm,
@@ -832,7 +865,7 @@ pub(crate) const ARMV5TE_UNKNOWN_LINUX_UCLIBCEABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv6 FreeBSD
+/// Armv6 FreeBSD
 pub(crate) const ARMV6_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "armv6-unknown-freebsd",
     target_arch: Arch::Arm,
@@ -843,7 +876,7 @@ pub(crate) const ARMV6_UNKNOWN_FREEBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv6 NetBSD w/hard-float
+/// Armv6 NetBSD w/hard-float
 pub(crate) const ARMV6_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     target_triple: "armv6-unknown-netbsd-eabihf",
     target_arch: Arch::Arm,
@@ -854,7 +887,7 @@ pub(crate) const ARMV6_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv6K Nintendo 3DS, Horizon (Requires devkitARM toolchain)
+/// Armv6k Nintendo 3DS, Horizon (Requires devkitARM toolchain)
 pub(crate) const ARMV6K_NINTENDO_3DS: Platform = Platform {
     target_triple: "armv6k-nintendo-3ds",
     target_arch: Arch::Arm,
@@ -865,7 +898,7 @@ pub(crate) const ARMV6K_NINTENDO_3DS: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv7-A Android
+/// Armv7-A Android
 pub(crate) const ARMV7_LINUX_ANDROIDEABI: Platform = Platform {
     target_triple: "armv7-linux-androideabi",
     target_arch: Arch::Arm,
@@ -876,7 +909,7 @@ pub(crate) const ARMV7_LINUX_ANDROIDEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A Cortex-A9 Sony PlayStation Vita (requires VITASDK toolchain)
+/// Armv7-A Cortex-A9 Sony PlayStation Vita (requires VITASDK toolchain)
 pub(crate) const ARMV7_SONY_VITA_NEWLIBEABIHF: Platform = Platform {
     target_triple: "armv7-sony-vita-newlibeabihf",
     target_arch: Arch::Arm,
@@ -887,7 +920,7 @@ pub(crate) const ARMV7_SONY_VITA_NEWLIBEABIHF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv7-A FreeBSD
+/// Armv7-A FreeBSD
 pub(crate) const ARMV7_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "armv7-unknown-freebsd",
     target_arch: Arch::Arm,
@@ -898,7 +931,7 @@ pub(crate) const ARMV7_UNKNOWN_FREEBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv7-A Linux (kernel 4.15, glibc 2.27)
+/// Armv7-A Linux (kernel 4.15, glibc 2.27)
 pub(crate) const ARMV7_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armv7-unknown-linux-gnueabi",
     target_arch: Arch::Arm,
@@ -909,7 +942,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A Linux, hardfloat (kernel 3.2, glibc 2.17)
+/// Armv7-A Linux, hardfloat (kernel 3.2, glibc 2.17)
 pub(crate) const ARMV7_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "armv7-unknown-linux-gnueabihf",
     target_arch: Arch::Arm,
@@ -920,7 +953,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A Linux with musl 1.2.3
+/// Armv7-A Linux with musl 1.2.3
 pub(crate) const ARMV7_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     target_triple: "armv7-unknown-linux-musleabi",
     target_arch: Arch::Arm,
@@ -931,7 +964,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_MUSLEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A Linux with musl 1.2.3, hardfloat
+/// Armv7-A Linux with musl 1.2.3, hardfloat
 pub(crate) const ARMV7_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     target_triple: "armv7-unknown-linux-musleabihf",
     target_arch: Arch::Arm,
@@ -942,7 +975,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A OpenHarmony
+/// Armv7-A OpenHarmony
 pub(crate) const ARMV7_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_triple: "armv7-unknown-linux-ohos",
     target_arch: Arch::Arm,
@@ -953,7 +986,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_OHOS: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A Linux with uClibc, softfloat
+/// Armv7-A Linux with uClibc, softfloat
 pub(crate) const ARMV7_UNKNOWN_LINUX_UCLIBCEABI: Platform = Platform {
     target_triple: "armv7-unknown-linux-uclibceabi",
     target_arch: Arch::Arm,
@@ -964,7 +997,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_UCLIBCEABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv7-A Linux with uClibc, hardfloat
+/// Armv7-A Linux with uClibc, hardfloat
 pub(crate) const ARMV7_UNKNOWN_LINUX_UCLIBCEABIHF: Platform = Platform {
     target_triple: "armv7-unknown-linux-uclibceabihf",
     target_arch: Arch::Arm,
@@ -975,7 +1008,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_UCLIBCEABIHF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv7-A NetBSD w/hard-float
+/// Armv7-A NetBSD w/hard-float
 pub(crate) const ARMV7_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     target_triple: "armv7-unknown-netbsd-eabihf",
     target_arch: Arch::Arm,
@@ -986,7 +1019,7 @@ pub(crate) const ARMV7_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv7-A for VxWorks
+/// Armv7-A for VxWorks
 pub(crate) const ARMV7_WRS_VXWORKS_EABIHF: Platform = Platform {
     target_triple: "armv7-wrs-vxworks-eabihf",
     target_arch: Arch::Arm,
@@ -1019,7 +1052,7 @@ pub(crate) const ARMV7A_KMC_SOLID_ASP3_EABIHF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Bare ARMv7-A
+/// Bare Armv7-A
 pub(crate) const ARMV7A_NONE_EABI: Platform = Platform {
     target_triple: "armv7a-none-eabi",
     target_arch: Arch::Arm,
@@ -1030,7 +1063,7 @@ pub(crate) const ARMV7A_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Bare ARMv7-A, hardfloat
+/// Bare Armv7-A, hardfloat
 pub(crate) const ARMV7A_NONE_EABIHF: Platform = Platform {
     target_triple: "armv7a-none-eabihf",
     target_arch: Arch::Arm,
@@ -1041,7 +1074,7 @@ pub(crate) const ARMV7A_NONE_EABIHF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARMv7-A Apple WatchOS
+/// Armv7-A Apple WatchOS
 pub(crate) const ARMV7K_APPLE_WATCHOS: Platform = Platform {
     target_triple: "armv7k-apple-watchos",
     target_arch: Arch::Arm,
@@ -1052,7 +1085,7 @@ pub(crate) const ARMV7K_APPLE_WATCHOS: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Bare ARMv7-R
+/// Bare Armv7-R
 pub(crate) const ARMV7R_NONE_EABI: Platform = Platform {
     target_triple: "armv7r-none-eabi",
     target_arch: Arch::Arm,
@@ -1063,7 +1096,7 @@ pub(crate) const ARMV7R_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Bare ARMv7-R, hardfloat
+/// Bare Armv7-R, hardfloat
 pub(crate) const ARMV7R_NONE_EABIHF: Platform = Platform {
     target_triple: "armv7r-none-eabihf",
     target_arch: Arch::Arm,
@@ -1074,7 +1107,7 @@ pub(crate) const ARMV7R_NONE_EABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// ARMv7-A Apple-A6 Apple iOS
+/// Armv7-A Apple-A6 Apple iOS
 pub(crate) const ARMV7S_APPLE_IOS: Platform = Platform {
     target_triple: "armv7s-apple-ios",
     target_arch: Arch::Arm,
@@ -1085,7 +1118,7 @@ pub(crate) const ARMV7S_APPLE_IOS: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Bare ARMv8-R, hardfloat
+/// Bare Armv8-R, hardfloat
 pub(crate) const ARMV8R_NONE_EABIHF: Platform = Platform {
     target_triple: "armv8r-none-eabihf",
     target_arch: Arch::Arm,
@@ -1261,7 +1294,7 @@ pub(crate) const I686_LINUX_ANDROID: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// 32-bit MinGW (Windows 10+) [^x86_32-floats-return-ABI]
+/// 32-bit MinGW (Windows 10+, Windows Server 2016+) [^x86_32-floats-return-ABI]
 pub(crate) const I686_PC_WINDOWS_GNU: Platform = Platform {
     target_triple: "i686-pc-windows-gnu",
     target_arch: Arch::X86,
@@ -1272,7 +1305,7 @@ pub(crate) const I686_PC_WINDOWS_GNU: Platform = Platform {
     tier: Tier::One,
 };
 
-/// [^x86_32-floats-return-ABI]
+/// 32-bit x86 MinGW (Windows 10+), LLVM ABI [^x86_32-floats-return-ABI]
 pub(crate) const I686_PC_WINDOWS_GNULLVM: Platform = Platform {
     target_triple: "i686-pc-windows-gnullvm",
     target_arch: Arch::X86,
@@ -1280,10 +1313,10 @@ pub(crate) const I686_PC_WINDOWS_GNULLVM: Platform = Platform {
     target_env: Env::Gnu,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
-/// 32-bit MSVC (Windows 10+) [^x86_32-floats-return-ABI]
+/// 32-bit MSVC (Windows 10+, Windows Server 2016+) [^x86_32-floats-return-ABI]
 pub(crate) const I686_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "i686-pc-windows-msvc",
     target_arch: Arch::X86,
@@ -1371,6 +1404,17 @@ pub(crate) const I686_UNKNOWN_OPENBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// i686 Redox OS
+pub(crate) const I686_UNKNOWN_REDOX: Platform = Platform {
+    target_triple: "i686-unknown-redox",
+    target_arch: Arch::X86,
+    target_os: OS::Redox,
+    target_env: Env::Relibc,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// 32-bit UEFI
 pub(crate) const I686_UNKNOWN_UEFI: Platform = Platform {
     target_triple: "i686-unknown-uefi",
@@ -1437,7 +1481,7 @@ pub(crate) const LOONGARCH64_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// LoongArch64 Linux (LP64D ABI) with musl 1.2.3
+/// LoongArch64 Linux, LP64D ABI (kernel 5.19, musl 1.2.5)
 pub(crate) const LOONGARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "loongarch64-unknown-linux-musl",
     target_arch: Arch::Loongarch64,
@@ -1445,7 +1489,7 @@ pub(crate) const LOONGARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_env: Env::Musl,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// LoongArch64 Bare-metal (LP64D ABI)
@@ -2236,7 +2280,7 @@ pub(crate) const SPARCV9_SUN_SOLARIS: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Thumb-mode Bare ARMv4T
+/// Thumb-mode Bare Armv4T
 pub(crate) const THUMBV4T_NONE_EABI: Platform = Platform {
     target_triple: "thumbv4t-none-eabi",
     target_arch: Arch::Arm,
@@ -2247,7 +2291,7 @@ pub(crate) const THUMBV4T_NONE_EABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Thumb-mode Bare ARMv5TE
+/// Thumb-mode Bare Armv5TE
 pub(crate) const THUMBV5TE_NONE_EABI: Platform = Platform {
     target_triple: "thumbv5te-none-eabi",
     target_arch: Arch::Arm,
@@ -2258,7 +2302,7 @@ pub(crate) const THUMBV5TE_NONE_EABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Bare ARMv6-M
+/// Bare Armv6-M
 pub(crate) const THUMBV6M_NONE_EABI: Platform = Platform {
     target_triple: "thumbv6m-none-eabi",
     target_arch: Arch::Arm,
@@ -2289,7 +2333,7 @@ pub(crate) const THUMBV7A_UWP_WINDOWS_MSVC: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Bare ARMv7E-M
+/// Bare Armv7E-M
 pub(crate) const THUMBV7EM_NONE_EABI: Platform = Platform {
     target_triple: "thumbv7em-none-eabi",
     target_arch: Arch::Arm,
@@ -2300,7 +2344,7 @@ pub(crate) const THUMBV7EM_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Bare ARMV7E-M, hardfloat
+/// Bare Armv7E-M, hardfloat
 pub(crate) const THUMBV7EM_NONE_EABIHF: Platform = Platform {
     target_triple: "thumbv7em-none-eabihf",
     target_arch: Arch::Arm,
@@ -2311,7 +2355,7 @@ pub(crate) const THUMBV7EM_NONE_EABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Bare ARMv7-M
+/// Bare Armv7-M
 pub(crate) const THUMBV7M_NONE_EABI: Platform = Platform {
     target_triple: "thumbv7m-none-eabi",
     target_arch: Arch::Arm,
@@ -2322,7 +2366,7 @@ pub(crate) const THUMBV7M_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Thumb2-mode ARMv7-A Android with NEON
+/// Thumb2-mode Armv7-A Android with NEON
 pub(crate) const THUMBV7NEON_LINUX_ANDROIDEABI: Platform = Platform {
     target_triple: "thumbv7neon-linux-androideabi",
     target_arch: Arch::Arm,
@@ -2333,7 +2377,7 @@ pub(crate) const THUMBV7NEON_LINUX_ANDROIDEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Thumb2-mode ARMv7-A Linux with NEON (kernel 4.4, glibc 2.23)
+/// Thumb2-mode Armv7-A Linux with NEON (kernel 4.4, glibc 2.23)
 pub(crate) const THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "thumbv7neon-unknown-linux-gnueabihf",
     target_arch: Arch::Arm,
@@ -2344,7 +2388,7 @@ pub(crate) const THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Thumb2-mode ARMv7-A Linux with NEON, musl 1.2.3
+/// Thumb2-mode Armv7-A Linux with NEON, musl 1.2.3
 pub(crate) const THUMBV7NEON_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     target_triple: "thumbv7neon-unknown-linux-musleabihf",
     target_arch: Arch::Arm,
@@ -2355,7 +2399,7 @@ pub(crate) const THUMBV7NEON_UNKNOWN_LINUX_MUSLEABIHF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Bare ARMv8-M Baseline
+/// Bare Armv8-M Baseline
 pub(crate) const THUMBV8M_BASE_NONE_EABI: Platform = Platform {
     target_triple: "thumbv8m.base-none-eabi",
     target_arch: Arch::Arm,
@@ -2366,7 +2410,7 @@ pub(crate) const THUMBV8M_BASE_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Bare ARMv8-M Mainline
+/// Bare Armv8-M Mainline
 pub(crate) const THUMBV8M_MAIN_NONE_EABI: Platform = Platform {
     target_triple: "thumbv8m.main-none-eabi",
     target_arch: Arch::Arm,
@@ -2377,7 +2421,7 @@ pub(crate) const THUMBV8M_MAIN_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Bare ARMv8-M Mainline, hardfloat
+/// Bare Armv8-M Mainline, hardfloat
 pub(crate) const THUMBV8M_MAIN_NONE_EABIHF: Platform = Platform {
     target_triple: "thumbv8m.main-none-eabihf",
     target_arch: Arch::Arm,
@@ -2415,7 +2459,7 @@ pub(crate) const WASM32_WASI: Platform = Platform {
     target_triple: "wasm32-wasi",
     target_arch: Arch::Wasm32,
     target_os: OS::Wasi,
-    target_env: Env::None,
+    target_env: Env::P1,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Two,
@@ -2426,7 +2470,7 @@ pub(crate) const WASM32_WASIP1: Platform = Platform {
     target_triple: "wasm32-wasip1",
     target_arch: Arch::Wasm32,
     target_os: OS::Wasi,
-    target_env: Env::None,
+    target_env: Env::P1,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Two,
@@ -2437,7 +2481,7 @@ pub(crate) const WASM32_WASIP1_THREADS: Platform = Platform {
     target_triple: "wasm32-wasip1-threads",
     target_arch: Arch::Wasm32,
     target_os: OS::Wasi,
-    target_env: Env::None,
+    target_env: Env::P1,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Two,
@@ -2574,7 +2618,7 @@ pub(crate) const X86_64_PC_SOLARIS: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// 64-bit MinGW (Windows 10+)
+/// 64-bit MinGW (Windows 10+, Windows Server 2016+)
 pub(crate) const X86_64_PC_WINDOWS_GNU: Platform = Platform {
     target_triple: "x86_64-pc-windows-gnu",
     target_arch: Arch::X86_64,
@@ -2585,6 +2629,7 @@ pub(crate) const X86_64_PC_WINDOWS_GNU: Platform = Platform {
     tier: Tier::One,
 };
 
+/// 64-bit x86 MinGW (Windows 10+), LLVM ABI
 pub(crate) const X86_64_PC_WINDOWS_GNULLVM: Platform = Platform {
     target_triple: "x86_64-pc-windows-gnullvm",
     target_arch: Arch::X86_64,
@@ -2592,10 +2637,10 @@ pub(crate) const X86_64_PC_WINDOWS_GNULLVM: Platform = Platform {
     target_env: Env::Gnu,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
-/// 64-bit MSVC (Windows 10+)
+/// 64-bit MSVC (Windows 10+, Windows Server 2016+)
 pub(crate) const X86_64_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "x86_64-pc-windows-msvc",
     target_arch: Arch::X86_64,
@@ -2726,6 +2771,17 @@ pub(crate) const X86_64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// 64-bit Linux with no libc
+pub(crate) const X86_64_UNKNOWN_LINUX_NONE: Platform = Platform {
+    target_triple: "x86_64-unknown-linux-none",
+    target_arch: Arch::X86_64,
+    target_os: OS::Linux,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// x86_64 OpenHarmony
 pub(crate) const X86_64_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_triple: "x86_64-unknown-linux-ohos",
@@ -2841,5 +2897,71 @@ pub(crate) const X86_64H_APPLE_DARWIN: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
+/// Xtensa ESP32
+pub(crate) const XTENSA_ESP32_ESPIDF: Platform = Platform {
+    target_triple: "xtensa-esp32-espidf",
+    target_arch: Arch::Xtensa,
+    target_os: OS::Espidf,
+    target_env: Env::Newlib,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// Xtensa ESP32
+pub(crate) const XTENSA_ESP32_NONE_ELF: Platform = Platform {
+    target_triple: "xtensa-esp32-none-elf",
+    target_arch: Arch::Xtensa,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// Xtensa ESP32-S2
+pub(crate) const XTENSA_ESP32S2_ESPIDF: Platform = Platform {
+    target_triple: "xtensa-esp32s2-espidf",
+    target_arch: Arch::Xtensa,
+    target_os: OS::Espidf,
+    target_env: Env::Newlib,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// Xtensa ESP32-S2
+pub(crate) const XTENSA_ESP32S2_NONE_ELF: Platform = Platform {
+    target_triple: "xtensa-esp32s2-none-elf",
+    target_arch: Arch::Xtensa,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// Xtensa ESP32-S3
+pub(crate) const XTENSA_ESP32S3_ESPIDF: Platform = Platform {
+    target_triple: "xtensa-esp32s3-espidf",
+    target_arch: Arch::Xtensa,
+    target_os: OS::Espidf,
+    target_env: Env::Newlib,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// Xtensa ESP32-S3
+pub(crate) const XTENSA_ESP32S3_NONE_ELF: Platform = Platform {
+    target_triple: "xtensa-esp32s3-none-elf",
+    target_arch: Arch::Xtensa,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
     tier: Tier::Three,
 };

--- a/platforms/src/target/arch.rs
+++ b/platforms/src/target/arch.rs
@@ -87,6 +87,9 @@ pub enum Arch {
 
     /// `x86_64`: 'AMD64' CPU architecture
     X86_64,
+
+    /// `xtensa`
+    Xtensa,
 }
 
 impl Arch {
@@ -119,6 +122,7 @@ impl Arch {
             Arch::Wasm64 => "wasm64",
             Arch::X86 => "x86",
             Arch::X86_64 => "x86_64",
+            Arch::Xtensa => "xtensa",
         }
     }
 }
@@ -155,6 +159,7 @@ impl FromStr for Arch {
             "wasm64" => Arch::Wasm64,
             "x86" => Arch::X86,
             "x86_64" => Arch::X86_64,
+            "xtensa" => Arch::Xtensa,
             _ => return Err(Error),
         };
 

--- a/platforms/src/target/env.rs
+++ b/platforms/src/target/env.rs
@@ -38,6 +38,9 @@ pub enum Env {
     /// `ohos`
     OhOS,
 
+    /// `p1`
+    P1,
+
     /// `p2`
     P2,
 
@@ -66,6 +69,7 @@ impl Env {
             Env::Nto70 => "nto70",
             Env::Nto71 => "nto71",
             Env::OhOS => "ohos",
+            Env::P1 => "p1",
             Env::P2 => "p2",
             Env::Psx => "psx",
             Env::Relibc => "relibc",
@@ -89,6 +93,7 @@ impl FromStr for Env {
             "nto70" => Env::Nto70,
             "nto71" => Env::Nto71,
             "ohos" => Env::OhOS,
+            "p1" => Env::P1,
             "p2" => Env::P2,
             "psx" => Env::Psx,
             "relibc" => Env::Relibc,

--- a/platforms/src/target/os.rs
+++ b/platforms/src/target/os.rs
@@ -101,6 +101,9 @@ pub enum OS {
     /// `unknown`
     Unknown,
 
+    /// `visionos`
+    VisionOS,
+
     /// `vita`
     Vita,
 
@@ -156,6 +159,7 @@ impl OS {
             OS::TvOS => "tvos",
             OS::Uefi => "uefi",
             OS::Unknown => "unknown",
+            OS::VisionOS => "visionos",
             OS::Vita => "vita",
             OS::VxWorks => "vxworks",
             OS::Wasi => "wasi",
@@ -202,6 +206,7 @@ impl FromStr for OS {
             "tvos" => OS::TvOS,
             "uefi" => OS::Uefi,
             "unknown" => OS::Unknown,
+            "visionos" => OS::VisionOS,
             "vita" => OS::Vita,
             "vxworks" => OS::VxWorks,
             "wasi" => OS::Wasi,


### PR DESCRIPTION
Ran `regenerate-platforms-crate.sh` for new Rust toolchain changes. Would be great if we can release a new version.