### PR TITLE
chore(cargo-lock): bump to toml@0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
  "petgraph",
  "semver",
  "serde",
- "toml 0.7.8",
+ "toml 0.8.10",
  "url",
 ]
 
@@ -3067,6 +3067,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.6",
+]
+
+[[package]]
 name = "toml-span"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3116,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.6.1",
 ]

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -21,7 +21,7 @@ gumdrop = { version = "0.8", optional = true }
 petgraph = { version = "0.6", optional = true }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
-toml = "0.7"
+toml = "0.8"
 url = "2"
 
 [features]

--- a/cargo-lock/src/error.rs
+++ b/cargo-lock/src/error.rs
@@ -51,10 +51,4 @@ impl From<std::num::ParseIntError> for Error {
     }
 }
 
-impl From<toml::de::Error> for Error {
-    fn from(err: toml::de::Error) -> Self {
-        Error::Parse(err.to_string())
-    }
-}
-
 impl std::error::Error for Error {}

--- a/cargo-lock/src/lockfile.rs
+++ b/cargo-lock/src/lockfile.rs
@@ -56,7 +56,7 @@ impl FromStr for Lockfile {
     type Err = Error;
 
     fn from_str(toml_string: &str) -> Result<Self> {
-        Ok(toml::from_str(toml_string)?)
+        toml::from_str(toml_string).map_err(|e| Error::Parse(e.to_string()))
     }
 }
 


### PR DESCRIPTION
The only enum having tuple variants is `Error`.
I don't think it is used in serialization/deserialization.

See Changelog:
https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#080---2023-09-13