### PR TITLE
feat(cli): Honor CARGO_TERM_COLOR for cargo-audit

### DIFF
--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -72,7 +72,7 @@ pub struct AuditCommand {
     #[arg(
         short = 'c',
         long = "color",
-        help = "color configuration",
+        help = "color configuration (default: auto)",
     )]
     color: Option<Color>,
 

--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -73,9 +73,8 @@ pub struct AuditCommand {
         short = 'c',
         long = "color",
         help = "color configuration",
-        default_value_t
     )]
-    color: Color,
+    color: Option<Color>,
 
     /// Filesystem path to the advisory database git repository
     #[arg(
@@ -183,7 +182,16 @@ If not, recovers a part of the dependency list from panic messages."
 impl AuditCommand {
     /// Get the color configuration
     pub fn term_colors(&self) -> ColorChoice {
-        self.color.into()
+        if let Some(color) = self.color {
+            color.into()
+        } else {
+            match std::env::var("CARGO_TERM_COLOR") {
+                Ok(e) if e == "always" => ColorChoice::Always,
+                Ok(e) if e == "never" => ColorChoice::Never,
+                Ok(e) if e == "auto" => ColorChoice::Auto,
+                _ => ColorChoice::default()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adds more 'just works' like any normal cargo command to cargo-audit.
Any explicit command line flag will take priority over `CARGO_TERM_COLOR`.

Fixes #865