### PR TITLE
Bump versions to prepare for breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,8 +260,7 @@ dependencies = [
 [[package]]
 name = "auditable-serde"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551661dec59a0d8f0c2245ca7c18b8fba3a017d66fa2bdb5c6e1bfd340639247"
+source = "git+https://github.com/tarcieri/cargo-auditable?branch=cargo-lock/v10.0.0-pre#127454758f17a394e4bfeb0380ebeb6dc4979aec"
 dependencies = [
  "cargo-lock",
  "semver",
@@ -370,7 +369,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.20.0"
+version = "0.21.0-pre"
 dependencies = [
  "abscissa_core",
  "auditable-info",
@@ -392,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "9.0.0"
+version = "10.0.0-pre"
 dependencies = [
  "gumdrop",
  "petgraph",
@@ -2645,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.29.2"
+version = "0.30.0-pre"
 dependencies = [
  "cargo-lock",
  "cvss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ atom_syndication = "0.12"
 auditable-info = "0.7.2"
 auditable-serde = "0.6"
 binfarce = "0.2"
-cargo-lock = { version = "9.0.0", path = "./cargo-lock" }
+cargo-lock = { version = "=10.0.0-pre", path = "./cargo-lock" }
 chrono = { version = "0.4", default-features = false }
 clap = "4"
 comrak = { version = "0.24", default-features = false }
@@ -34,7 +34,7 @@ platforms = { version = "3", path = "./platforms" }
 quitters = { version = "0.1.0", path = "./quitters" }
 regex = { version = "1.10.5", default-features = false }
 rust-embed = "8.5.0"
-rustsec = { version = "0.29.2", path = "./rustsec" }
+rustsec = { version = "=0.30.0-pre", path = "./rustsec" }
 semver = "1.0.23"
 serde = "1"
 serde_json = "1"
@@ -49,6 +49,7 @@ url = "2"
 xml-rs = "0.8"
 
 [patch.crates-io]
+auditable-serde = { git = "https://github.com/tarcieri/cargo-auditable", branch = "cargo-lock/v10.0.0-pre" }
 cargo-lock = { path = "./cargo-lock" }
 cvss = { path = "./cvss" }
 platforms = { path = "./platforms" }

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-audit"
 description  = "Audit Cargo.lock for crates with security vulnerabilities"
-version      = "0.20.0"
+version      = "0.21.0-pre"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "9.0.0"
+version      = "10.0.0-pre"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "rustsec"
 description  = "Client library for the RustSec security advisory database"
-version      = "0.29.2"
+version      = "0.30.0-pre"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"


### PR DESCRIPTION
Bumps the following to prerelease versions (which are not yet intended to have an associated crates.io release):

- `cargo-audit` v0.21.0-pre
- `cargo-lock` v10.0.0-pre
- `rustsec` v0.30.0-pre