### PR TITLE
cargo-lock: remove `toml` from the public API

### DIFF
--- a/cargo-lock/src/error.rs
+++ b/cargo-lock/src/error.rs
@@ -51,10 +51,4 @@ impl From<std::num::ParseIntError> for Error {
     }
 }
 
-impl From<toml::de::Error> for Error {
-    fn from(err: toml::de::Error) -> Self {
-        Error::Parse(err.to_string())
-    }
-}
-
 impl std::error::Error for Error {}

--- a/cargo-lock/src/lockfile.rs
+++ b/cargo-lock/src/lockfile.rs
@@ -56,7 +56,7 @@ impl FromStr for Lockfile {
     type Err = Error;
 
     fn from_str(toml_string: &str) -> Result<Self> {
-        Ok(toml::from_str(toml_string)?)
+        toml::from_str(toml_string).map_err(|e| Error::Parse(e.to_string()))
     }
 }
 


### PR DESCRIPTION
Removes an `impl From<toml::de::Error>` for `cargo_lock::Error`, which in theory is the only place `toml` was present in `cargo-lock`'s public API.

Removing this impl should theoretically allow non-breaking upgrades to the `toml` crate in the future.