### PR TITLE
Use `cargo-lock` v10.0.0-pre.0 branch for `auditable-serde`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "auditable-serde"
 version = "0.6.1"
-source = "git+https://github.com/tarcieri/cargo-auditable?branch=cargo-lock/v10.0.0-pre#0a3589ed8f8b0740ebf235f36f3d1e4a944fdf09"
+source = "git+https://github.com/tarcieri/cargo-auditable?branch=cargo-lock/v10.0.0-pre.0#f19d2e84cc235d178f1617f9b84511f1752ad27f"
 dependencies = [
  "cargo-lock",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ url = "2"
 xml-rs = "0.8"
 
 [patch.crates-io]
-auditable-serde = { git = "https://github.com/tarcieri/cargo-auditable", branch = "cargo-lock/v10.0.0-pre" }
+auditable-serde = { git = "https://github.com/tarcieri/cargo-auditable", branch = "cargo-lock/v10.0.0-pre.0" }
 cargo-lock = { path = "./cargo-lock" }
 cvss = { path = "./cvss" }
 platforms = { path = "./platforms" }


### PR DESCRIPTION
Uses the crates.io prerelease of `cargo-lock`