### PR TITLE
Bump `auditable-info` => 0.8; `auditable-serde` => v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "auditable-info"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0d13c05dccf8623bdd1a86359100b35738575c30e4401a503d2b7e6c1ccc70"
+checksum = "9869e704667d719c8eb359a86d9ec51791185c04017d7139f7d393e7126270cd"
 dependencies = [
  "auditable-extract",
  "auditable-serde",
@@ -259,10 +259,10 @@ dependencies = [
 
 [[package]]
 name = "auditable-serde"
-version = "0.6.1"
-source = "git+https://github.com/tarcieri/cargo-auditable?branch=cargo-lock/v10.0.0-pre.0#f19d2e84cc235d178f1617f9b84511f1752ad27f"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7e600cac76c55b2d2893e3d4717fe8484d51af2622d52ab3fb9b7bb5ca1663"
 dependencies = [
- "cargo-lock",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [
 abscissa_core = "0.7"
 askama = "0.12"
 atom_syndication = "0.12"
-auditable-info = "0.7.2"
-auditable-serde = "0.6"
+auditable-info = "0.8"
+auditable-serde = "0.7"
 binfarce = "0.2"
 cargo-lock = { version = "=10.0.0-pre.0", path = "./cargo-lock" }
 chrono = { version = "0.4", default-features = false }
@@ -49,7 +49,6 @@ url = "2"
 xml-rs = "0.8"
 
 [patch.crates-io]
-auditable-serde = { git = "https://github.com/tarcieri/cargo-auditable", branch = "cargo-lock/v10.0.0-pre.0" }
 cargo-lock = { path = "./cargo-lock" }
 cvss = { path = "./cvss" }
 platforms = { path = "./platforms" }

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = { workspace = true }
 # for scanning binary files
 auditable-info = { workspace = true, features = ["wasm"], optional = true }
 cargo-lock = { workspace = true, optional = true }
-auditable-serde = { workspace = true, features = ["toml"], optional = true }
+auditable-serde = { workspace = true, optional = true }
 quitters = { workspace = true, optional = true }
 once_cell = { workspace = true, optional = true }
 binfarce = { workspace = true, optional = true }


### PR DESCRIPTION
These drop the dependency on `cargo-lock`.

Vendors the code removed in rust-secure-code/cargo-auditable#160 into `binary_deps.rs`