### PR TITLE
cargo-audit: make `cargo-lock` a hard dependency

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -50,6 +50,8 @@ jobs:
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v2
+      - run: cargo test --no-default-features
+      - run: cargo test
       - run: cargo test --all-features
 
   doc:

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -18,6 +18,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 abscissa_core = { workspace = true }
+cargo-lock = { workspace = true }
 clap = { workspace = true }
 home = { workspace = true }
 rustsec = { workspace = true, features = ["dependency-tree"] }
@@ -27,7 +28,6 @@ thiserror = { workspace = true }
 
 # for scanning binary files
 auditable-info = { workspace = true, features = ["wasm"], optional = true }
-cargo-lock = { workspace = true, optional = true }
 auditable-serde = { workspace = true, optional = true }
 quitters = { workspace = true, optional = true }
 once_cell = { workspace = true, optional = true }
@@ -43,4 +43,4 @@ toml = { workspace = true }
 [features]
 default = ["binary-scanning"]
 fix = []
-binary-scanning = ["dep:auditable-info", "dep:cargo-lock", "dep:auditable-serde", "dep:binfarce", "dep:quitters", "dep:once_cell"]
+binary-scanning = ["dep:auditable-info", "dep:auditable-serde", "dep:binfarce", "dep:quitters", "dep:once_cell"]

--- a/cargo-audit/src/binary_format.rs
+++ b/cargo-audit/src/binary_format.rs
@@ -1,5 +1,6 @@
 /// A shim around `binfarce::Format` so that `binfarce` crate could be an optional dependency
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)] // May be unused when the "binary-scanning" feature is disabled
 pub enum BinaryFormat {
     Elf32,
     Elf64,


### PR DESCRIPTION
It was previously marked as optional, however it's already a hard transitive dependency by way of the `rustsec` crate.

It could potentially be removed as a direct dependency since it's re-exported as `rustsec::cargo_lock` anyway, but this PR aims to immediately resolve #1238