### PR TITLE
cargo-lock: use `doc_auto_cfg`

### DIFF
--- a/cargo-lock/src/dependency.rs
+++ b/cargo-lock/src/dependency.rs
@@ -1,10 +1,8 @@
 //! Package dependencies
 
 #[cfg(feature = "dependency-tree")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dependency-tree")))]
 pub mod graph;
 #[cfg(feature = "dependency-tree")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dependency-tree")))]
 pub mod tree;
 
 #[cfg(feature = "dependency-tree")]

--- a/cargo-lock/src/lib.rs
+++ b/cargo-lock/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png")]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
Replaces the need for manual annotations