### PR TITLE
cargo-lock v10.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "10.0.0-rc.0"
+version = "10.0.0"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ atom_syndication = "0.12"
 auditable-info = "0.8"
 auditable-serde = "0.7"
 binfarce = "0.2"
-cargo-lock = { version = "10.0.0-rc.0", path = "./cargo-lock" }
+cargo-lock = { version = "10", path = "./cargo-lock" }
 chrono = { version = "0.4", default-features = false }
 clap = "4"
 comrak = { version = "0.24", default-features = false }

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 10.0.0 (2024-10-15)
+### Added
+- V4 lockfile support ([#1206])
+
+### Changed
+- MSRV 1.70 ([#1092])
+
+### Removed
+- `toml` dependency from public API ([#1226])
+
+[#1092]: https://github.com/RustSec/rustsec/pull/1092
+[#1206]: https://github.com/RustSec/rustsec/pull/1206
+[#1226]: https://github.com/RustSec/rustsec/pull/1226
+
 ## 9.0.0 (2023-04-24)
 ### Added
 - Implement `From<Name>` for `String` ([#776])

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "10.0.0-rc.0"
+version      = "10.0.0"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"

--- a/cargo-lock/README.md
+++ b/cargo-lock/README.md
@@ -9,8 +9,8 @@
 [![Project Chat][zulip-image]][zulip-link]
 
 Self-contained [serde]-powered `Cargo.lock` parser/serializer with support
-for the V1, V2 (merge-friendly), V3, and V4 formats, as well as optional
-dependency tree analysis features. Used by [RustSec].
+for the V1/V2/V3/V4 formats, as well as optional dependency tree analysis features.
+Used by [RustSec].
 
 When the `dependency-tree` feature of this crate is enabled, it supports
 computing a directed graph of the dependency tree, modeled using the
@@ -69,14 +69,14 @@ additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]:  https://buildstats.info/crate/cargo-lock
+[crate-image]: https://img.shields.io/crates/v/cargo-lock?logo=rust
 [crate-link]: https://crates.io/crates/cargo-lock
 [docs-image]: https://docs.rs/cargo-lock/badge.svg
 [docs-link]: https://docs.rs/cargo-lock/
 [build-image]: https://github.com/RustSec/rustsec/actions/workflows/cargo-lock.yml/badge.svg
 [build-link]: https://github.com/RustSec/rustsec/actions/workflows/cargo-lock.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.70+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [zulip-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg


### PR DESCRIPTION
### Added
- V4 lockfile support ([#1206])

### Changed
- MSRV 1.70 ([#1092])

### Removed
- `toml` dependency from public API ([#1226])

[#1092]: https://github.com/RustSec/rustsec/pull/1092
[#1206]: https://github.com/RustSec/rustsec/pull/1206
[#1226]: https://github.com/RustSec/rustsec/pull/1226