### PR TITLE
cargo-lock v10.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "10.0.0"
+version = "10.0.1"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/cargo-lock/CHANGELOG.md
+++ b/cargo-lock/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 10.0.1 (2024-10-25)
+### Fixed
+- Remove `precise` from source IDs during normalization ([#1270])
+
+[#1270]: https://github.com/RustSec/rustsec/pull/1270
+
 ## 10.0.0 (2024-10-15)
 ### Added
 - V4 lockfile support ([#1206])

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "10.0.0"
+version      = "10.0.1"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"


### PR DESCRIPTION
### Fixed
- Remove `precise` from source IDs during normalization ([#1270])

[#1270]: https://github.com/RustSec/rustsec/pull/1270