### PR TITLE
Cargo.toml: bump `cargo-lock` to v10.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ atom_syndication = "0.12"
 auditable-info = "0.8"
 auditable-serde = "0.7"
 binfarce = "0.2"
-cargo-lock = { version = "10", path = "./cargo-lock" }
+cargo-lock = { version = "10.0.1", path = "./cargo-lock" }
 chrono = { version = "0.4", default-features = false }
 clap = "4"
 comrak = { version = "0.24", default-features = false }


### PR DESCRIPTION
This ensures we always get the bugfix in #1270