### PR TITLE
rustsec v0.30.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ platforms = { version = "3", path = "./platforms" }
 quitters = { version = "0.1.0", path = "./quitters" }
 regex = { version = "1.10.6", default-features = false }
 rust-embed = "8.5.0"
-rustsec = { version = "=0.30.0-rc.1", path = "./rustsec" }
+rustsec = { version = "0.30", path = "./rustsec" }
 semver = "1.0.23"
 serde = "1"
 serde_json = "1"

--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.30.0 (2024-10-29)
+
+### Changed
+- MSRV 1.73 ([#1222])
+- Bump `cargo-lock` to v0.10; adds V4 lockfile support ([#1224], [#1264])
+- Bump `gix` to 0.66 ([#1251])
+- Bump `tame-index` to v0.14 ([#1251])
+
+[#1222]: https://github.com/rustsec/rustsec/pull/1222
+[#1224]: https://github.com/rustsec/rustsec/pull/1224
+[#1251]: https://github.com/rustsec/rustsec/pull/1251
+[#1264]: https://github.com/rustsec/rustsec/pull/1264
+
 ## 0.29.2 (2024-05-01)
 
 ### Changed

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "rustsec"
 description  = "Client library for the RustSec security advisory database"
-version      = "0.30.0-rc.1"
+version      = "0.30.0"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"
@@ -10,7 +10,7 @@ readme       = "README.md"
 categories   = ["api-bindings", "development-tools"]
 keywords     = ["audit", "rustsec", "security", "advisory", "vulnerability"]
 edition      = "2021"
-rust-version = "1.73.0"
+rust-version = "1.73"
 
 [dependencies]
 cargo-lock = { workspace = true }


### PR DESCRIPTION
### Changed
- MSRV 1.73 ([#1222])
- Bump `cargo-lock` to v0.10; adds V4 lockfile support ([#1224], [#1264])
- Bump `gix` to 0.66 ([#1251])
- Bump `tame-index` to v0.14 ([#1251])

[#1222]: https://github.com/rustsec/rustsec/pull/1222
[#1224]: https://github.com/rustsec/rustsec/pull/1224
[#1251]: https://github.com/rustsec/rustsec/pull/1251
[#1264]: https://github.com/rustsec/rustsec/pull/1264