### PR TITLE
cargo-audit v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.21.0-rc.0"
+version = "0.21.0"
 dependencies = [
  "abscissa_core",
  "auditable-info",

--- a/cargo-audit/CHANGELOG.md
+++ b/cargo-audit/CHANGELOG.md
@@ -4,7 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.0 (2024-10-29)
+
+### Added
+- V4 lockfile support ([#1275])
+
+### Changed
+- Bump `auditable-info` => 0.8; `auditable-serde` => v0.7 ([#1229])
+- Bump `abscissa` to v0.8 ([#1262])
+- Bump `rustsec` to v0.30; adds V4 lockfile support ([#1275])
+
+[#1229]: https://github.com/rustsec/rustsec/pull/1229
+[#1262]: https://github.com/rustsec/rustsec/pull/1262
+[#1275]: https://github.com/rustsec/rustsec/pull/1275
+
+## 0.20.1 (2024-08-16)
+
+TODO
+
 ## 0.20.0 (2024-02-16)
+
+### Changed
 
  - Completely rewritten `cargo audit fix` subcommand ([#1113])
    - Now it edits `Cargo.lock` as opposed to `Cargo.toml`, and performs only semver-compatible upgrades.

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-audit"
 description  = "Audit Cargo.lock for crates with security vulnerabilities"
-version      = "0.21.0-rc.0"
+version      = "0.21.0"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"


### PR DESCRIPTION
### Added
- V4 lockfile support ([#1275])

### Changed
- Bump `auditable-info` => 0.8; `auditable-serde` => v0.7 ([#1229])
- Bump `abscissa` to v0.8 ([#1262])
- Bump `rustsec` to v0.30; adds V4 lockfile support ([#1275])

[#1229]: https://github.com/rustsec/rustsec/pull/1229
[#1262]: https://github.com/rustsec/rustsec/pull/1262
[#1275]: https://github.com/rustsec/rustsec/pull/1275