### PR TITLE
chore: regenerate platform support and bump to platforms@3.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,7 +2246,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "platforms"
-version = "3.4.1"
+version = "3.4.2"
 dependencies = [
  "serde",
 ]

--- a/platforms/Cargo.toml
+++ b/platforms/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from the Rust compiler.
 """
-version    = "3.4.1"
+version    = "3.4.2"
 authors    = ["Tony Arcieri <bascule@gmail.com>", "Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://rustsec.org"

--- a/platforms/README.md
+++ b/platforms/README.md
@@ -64,6 +64,7 @@ If we remove platforms, we will bump the minor version of this crate.
 
 | target triple                          | target_arch | target_os  | target_env |
 |----------------------------------------|-------------|------------|------------|
+| [aarch64-apple-darwin]                 | aarch64     | macos      |            |
 | [aarch64-unknown-linux-gnu]            | aarch64     | linux      | gnu        |
 | [i686-pc-windows-gnu]                  | x86         | windows    | gnu        |
 | [i686-pc-windows-msvc]                 | x86         | windows    | msvc       |
@@ -77,10 +78,9 @@ If we remove platforms, we will bump the minor version of this crate.
 
 | target triple                          | target_arch | target_os  | target_env |
 |----------------------------------------|-------------|------------|------------|
-| [aarch64-apple-darwin]                 | aarch64     | macos      |            |
 | [aarch64-apple-ios]                    | aarch64     | ios        |            |
+| [aarch64-apple-ios-macabi]             | aarch64     | ios        |            |
 | [aarch64-apple-ios-sim]                | aarch64     | ios        |            |
-| [aarch64-fuchsia]                      | aarch64     | fuchsia    |            |
 | [aarch64-linux-android]                | aarch64     | android    |            |
 | [aarch64-pc-windows-gnullvm]           | aarch64     | windows    | gnu        |
 | [aarch64-pc-windows-msvc]              | aarch64     | windows    | msvc       |
@@ -131,6 +131,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [riscv32imafc-unknown-none-elf]        | riscv32     | none       |            |
 | [riscv32imc-unknown-none-elf]          | riscv32     | none       |            |
 | [riscv64gc-unknown-linux-gnu]          | riscv64     | linux      | gnu        |
+| [riscv64gc-unknown-linux-musl]         | riscv64     | linux      | musl       |
 | [riscv64gc-unknown-none-elf]           | riscv64     | none       |            |
 | [riscv64imac-unknown-none-elf]         | riscv64     | none       |            |
 | [s390x-unknown-linux-gnu]              | s390x       | linux      | gnu        |
@@ -150,9 +151,10 @@ If we remove platforms, we will bump the minor version of this crate.
 | [wasm32-wasi]                          | wasm32      | wasi       | p1         |
 | [wasm32-wasip1]                        | wasm32      | wasi       | p1         |
 | [wasm32-wasip1-threads]                | wasm32      | wasi       | p1         |
+| [wasm32v1-none]                        | wasm32      | none       |            |
 | [x86_64-apple-ios]                     | x86_64      | ios        |            |
+| [x86_64-apple-ios-macabi]              | x86_64      | ios        |            |
 | [x86_64-fortanix-unknown-sgx]          | x86_64      | unknown    | sgx        |
-| [x86_64-fuchsia]                       | x86_64      | fuchsia    |            |
 | [x86_64-linux-android]                 | x86_64      | android    |            |
 | [x86_64-pc-solaris]                    | x86_64      | solaris    |            |
 | [x86_64-pc-windows-gnullvm]            | x86_64      | windows    | gnu        |
@@ -171,7 +173,6 @@ If we remove platforms, we will bump the minor version of this crate.
 
 | target triple                          | target_arch | target_os  | target_env |
 |----------------------------------------|-------------|------------|------------|
-| [aarch64-apple-ios-macabi]             | aarch64     | ios        |            |
 | [aarch64-apple-tvos]                   | aarch64     | tvos       |            |
 | [aarch64-apple-tvos-sim]               | aarch64     | tvos       |            |
 | [aarch64-apple-visionos]               | aarch64     | visionos   |            |
@@ -185,10 +186,12 @@ If we remove platforms, we will bump the minor version of this crate.
 | [aarch64-unknown-illumos]              | aarch64     | illumos    |            |
 | [aarch64-unknown-linux-gnu_ilp32]      | aarch64     | linux      | gnu        |
 | [aarch64-unknown-netbsd]               | aarch64     | netbsd     |            |
+| [aarch64-unknown-nto-qnx700]           | aarch64     | nto        | nto70      |
 | [aarch64-unknown-nto-qnx710]           | aarch64     | nto        | nto71      |
 | [aarch64-unknown-openbsd]              | aarch64     | openbsd    |            |
 | [aarch64-unknown-redox]                | aarch64     | redox      | relibc     |
 | [aarch64-unknown-teeos]                | aarch64     | teeos      |            |
+| [aarch64-unknown-trusty]               | aarch64     | trusty     |            |
 | [aarch64-uwp-windows-msvc]             | aarch64     | windows    | msvc       |
 | [aarch64-wrs-vxworks]                  | aarch64     | vxworks    | gnu        |
 | [aarch64_be-unknown-linux-gnu]         | aarch64     | linux      | gnu        |
@@ -197,6 +200,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [arm64_32-apple-watchos]               | aarch64     | watchos    |            |
 | [arm64e-apple-darwin]                  | aarch64     | macos      |            |
 | [arm64e-apple-ios]                     | aarch64     | ios        |            |
+| [arm64e-apple-tvos]                    | aarch64     | tvos       |            |
 | [armeb-unknown-linux-gnueabi]          | arm         | linux      | gnu        |
 | [armv4t-none-eabi]                     | arm         | none       |            |
 | [armv4t-unknown-linux-gnueabi]         | arm         | linux      | gnu        |
@@ -205,11 +209,13 @@ If we remove platforms, we will bump the minor version of this crate.
 | [armv6-unknown-freebsd]                | arm         | freebsd    | gnu        |
 | [armv6-unknown-netbsd-eabihf]          | arm         | netbsd     |            |
 | [armv6k-nintendo-3ds]                  | arm         | horizon    | newlib     |
+| [armv7-rtems-eabihf]                   | arm         | rtems      | newlib     |
 | [armv7-sony-vita-newlibeabihf]         | arm         | vita       | newlib     |
 | [armv7-unknown-freebsd]                | arm         | freebsd    | gnu        |
 | [armv7-unknown-linux-uclibceabi]       | arm         | linux      | uclibc     |
 | [armv7-unknown-linux-uclibceabihf]     | arm         | linux      | uclibc     |
 | [armv7-unknown-netbsd-eabihf]          | arm         | netbsd     |            |
+| [armv7-unknown-trusty]                 | arm         | trusty     |            |
 | [armv7-wrs-vxworks-eabihf]             | arm         | vxworks    | gnu        |
 | [armv7a-kmc-solid_asp3-eabi]           | arm         | solid_asp3 |            |
 | [armv7a-kmc-solid_asp3-eabihf]         | arm         | solid_asp3 |            |
@@ -217,7 +223,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [armv7k-apple-watchos]                 | arm         | watchos    |            |
 | [armv7s-apple-ios]                     | arm         | ios        |            |
 | [armv8r-none-eabihf]                   | arm         | none       |            |
-| [avr-unknown-gnu-atmega328]            | avr         | none       |            |
+| [avr-unknown-gnu-atmega328]            | avr         | none       | gnu        |
 | [bpfeb-unknown-none]                   | bpf         | none       |            |
 | [bpfel-unknown-none]                   | bpf         | none       |            |
 | [csky-unknown-linux-gnuabiv2]          | csky        | linux      | gnu        |
@@ -237,6 +243,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [i686-uwp-windows-msvc]                | x86         | windows    | msvc       |
 | [i686-win7-windows-msvc]               | x86         | windows    | msvc       |
 | [i686-wrs-vxworks]                     | x86         | vxworks    | gnu        |
+| [loongarch64-unknown-linux-ohos]       | loongarch64 | linux      | ohos       |
 | [m68k-unknown-linux-gnu]               | m68k        | linux      | gnu        |
 | [mips-unknown-linux-gnu]               | mips        | linux      | gnu        |
 | [mips-unknown-linux-musl]              | mips        | linux      | musl       |
@@ -261,6 +268,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [powerpc-unknown-freebsd]              | powerpc     | freebsd    |            |
 | [powerpc-unknown-linux-gnuspe]         | powerpc     | linux      | gnu        |
 | [powerpc-unknown-linux-musl]           | powerpc     | linux      | musl       |
+| [powerpc-unknown-linux-muslspe]        | powerpc     | linux      | musl       |
 | [powerpc-unknown-netbsd]               | powerpc     | netbsd     |            |
 | [powerpc-unknown-openbsd]              | powerpc     | openbsd    |            |
 | [powerpc-wrs-vxworks]                  | powerpc     | vxworks    | gnu        |
@@ -272,21 +280,30 @@ If we remove platforms, we will bump the minor version of this crate.
 | [powerpc64-wrs-vxworks]                | powerpc64   | vxworks    | gnu        |
 | [powerpc64le-unknown-freebsd]          | powerpc64   | freebsd    |            |
 | [powerpc64le-unknown-linux-musl]       | powerpc64   | linux      | musl       |
+| [riscv32-wrs-vxworks]                  | riscv32     | vxworks    | gnu        |
+| [riscv32e-unknown-none-elf]            | riscv32     | none       |            |
+| [riscv32em-unknown-none-elf]           | riscv32     | none       |            |
+| [riscv32emc-unknown-none-elf]          | riscv32     | none       |            |
 | [riscv32gc-unknown-linux-gnu]          | riscv32     | linux      | gnu        |
 | [riscv32gc-unknown-linux-musl]         | riscv32     | linux      | musl       |
 | [riscv32im-risc0-zkvm-elf]             | riscv32     | zkvm       |            |
 | [riscv32ima-unknown-none-elf]          | riscv32     | none       |            |
 | [riscv32imac-esp-espidf]               | riscv32     | espidf     | newlib     |
+| [riscv32imac-unknown-nuttx-elf]        | riscv32     | nuttx      |            |
 | [riscv32imac-unknown-xous-elf]         | riscv32     | xous       |            |
 | [riscv32imafc-esp-espidf]              | riscv32     | espidf     | newlib     |
+| [riscv32imafc-unknown-nuttx-elf]       | riscv32     | nuttx      |            |
 | [riscv32imc-esp-espidf]                | riscv32     | espidf     | newlib     |
+| [riscv32imc-unknown-nuttx-elf]         | riscv32     | nuttx      |            |
 | [riscv64-linux-android]                | riscv64     | android    |            |
+| [riscv64-wrs-vxworks]                  | riscv64     | vxworks    | gnu        |
 | [riscv64gc-unknown-freebsd]            | riscv64     | freebsd    |            |
 | [riscv64gc-unknown-fuchsia]            | riscv64     | fuchsia    |            |
 | [riscv64gc-unknown-hermit]             | riscv64     | hermit     |            |
-| [riscv64gc-unknown-linux-musl]         | riscv64     | linux      | musl       |
 | [riscv64gc-unknown-netbsd]             | riscv64     | netbsd     |            |
+| [riscv64gc-unknown-nuttx-elf]          | riscv64     | nuttx      |            |
 | [riscv64gc-unknown-openbsd]            | riscv64     | openbsd    |            |
+| [riscv64imac-unknown-nuttx-elf]        | riscv64     | nuttx      |            |
 | [s390x-unknown-linux-musl]             | s390x       | linux      | musl       |
 | [sparc-unknown-linux-gnu]              | sparc       | linux      | gnu        |
 | [sparc-unknown-none-elf]               | sparc       | none       |            |
@@ -294,12 +311,18 @@ If we remove platforms, we will bump the minor version of this crate.
 | [sparc64-unknown-openbsd]              | sparc64     | openbsd    |            |
 | [thumbv4t-none-eabi]                   | arm         | none       |            |
 | [thumbv5te-none-eabi]                  | arm         | none       |            |
+| [thumbv6m-nuttx-eabi]                  | arm         | nuttx      |            |
 | [thumbv7a-pc-windows-msvc]             | arm         | windows    | msvc       |
 | [thumbv7a-uwp-windows-msvc]            | arm         | windows    | msvc       |
+| [thumbv7em-nuttx-eabi]                 | arm         | nuttx      |            |
+| [thumbv7em-nuttx-eabihf]               | arm         | nuttx      |            |
+| [thumbv7m-nuttx-eabi]                  | arm         | nuttx      |            |
 | [thumbv7neon-unknown-linux-musleabihf] | arm         | linux      | musl       |
+| [thumbv8m.base-nuttx-eabi]             | arm         | nuttx      |            |
+| [thumbv8m.main-nuttx-eabi]             | arm         | nuttx      |            |
+| [thumbv8m.main-nuttx-eabihf]           | arm         | nuttx      |            |
 | [wasm32-wasip2]                        | wasm32      | wasi       | p2         |
 | [wasm64-unknown-unknown]               | wasm64      | unknown    |            |
-| [x86_64-apple-ios-macabi]              | x86_64      | ios        |            |
 | [x86_64-apple-tvos]                    | x86_64      | tvos       |            |
 | [x86_64-apple-watchos-sim]             | x86_64      | watchos    |            |
 | [x86_64-pc-nto-qnx710]                 | x86_64      | nto        | nto71      |
@@ -307,9 +330,11 @@ If we remove platforms, we will bump the minor version of this crate.
 | [x86_64-unknown-dragonfly]             | x86_64      | dragonfly  |            |
 | [x86_64-unknown-haiku]                 | x86_64      | haiku      |            |
 | [x86_64-unknown-hermit]                | x86_64      | hermit     |            |
+| [x86_64-unknown-hurd-gnu]              | x86_64      | hurd       | gnu        |
 | [x86_64-unknown-l4re-uclibc]           | x86_64      | l4re       | uclibc     |
 | [x86_64-unknown-linux-none]            | x86_64      | linux      |            |
 | [x86_64-unknown-openbsd]               | x86_64      | openbsd    |            |
+| [x86_64-unknown-trusty]                | x86_64      | trusty     |            |
 | [x86_64-uwp-windows-gnu]               | x86_64      | windows    | gnu        |
 | [x86_64-uwp-windows-msvc]              | x86_64      | windows    | msvc       |
 | [x86_64-win7-windows-msvc]             | x86_64      | windows    | msvc       |
@@ -332,7 +357,6 @@ If we remove platforms, we will bump the minor version of this crate.
 [aarch64-apple-visionos-sim]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_VISIONOS_SIM.html
 [aarch64-apple-watchos]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_WATCHOS.html
 [aarch64-apple-watchos-sim]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_APPLE_WATCHOS_SIM.html
-[aarch64-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_FUCHSIA.html
 [aarch64-kmc-solid_asp3]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_KMC_SOLID_ASP3.html
 [aarch64-linux-android]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_LINUX_ANDROID.html
 [aarch64-nintendo-switch-freestanding]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_NINTENDO_SWITCH_FREESTANDING.html
@@ -349,10 +373,12 @@ If we remove platforms, we will bump the minor version of this crate.
 [aarch64-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_NETBSD.html
 [aarch64-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_NONE.html
 [aarch64-unknown-none-softfloat]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_NONE_SOFTFLOAT.html
+[aarch64-unknown-nto-qnx700]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_NTO_QNX700.html
 [aarch64-unknown-nto-qnx710]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_NTO_QNX710.html
 [aarch64-unknown-openbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_OPENBSD.html
 [aarch64-unknown-redox]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_REDOX.html
 [aarch64-unknown-teeos]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_TEEOS.html
+[aarch64-unknown-trusty]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_TRUSTY.html
 [aarch64-unknown-uefi]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_UEFI.html
 [aarch64-uwp-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UWP_WINDOWS_MSVC.html
 [aarch64-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_WRS_VXWORKS.html
@@ -367,6 +393,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [arm64_32-apple-watchos]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64_32_APPLE_WATCHOS.html
 [arm64e-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64E_APPLE_DARWIN.html
 [arm64e-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64E_APPLE_IOS.html
+[arm64e-apple-tvos]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64E_APPLE_TVOS.html
 [arm64ec-pc-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM64EC_PC_WINDOWS_MSVC.html
 [armeb-unknown-linux-gnueabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMEB_UNKNOWN_LINUX_GNUEABI.html
 [armebv7r-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMEBV7R_NONE_EABI.html
@@ -381,6 +408,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [armv6-unknown-netbsd-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV6_UNKNOWN_NETBSD_EABIHF.html
 [armv6k-nintendo-3ds]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV6K_NINTENDO_3DS.html
 [armv7-linux-androideabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_LINUX_ANDROIDEABI.html
+[armv7-rtems-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_RTEMS_EABIHF.html
 [armv7-sony-vita-newlibeabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_SONY_VITA_NEWLIBEABIHF.html
 [armv7-unknown-freebsd]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_UNKNOWN_FREEBSD.html
 [armv7-unknown-linux-gnueabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_UNKNOWN_LINUX_GNUEABI.html
@@ -391,6 +419,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [armv7-unknown-linux-uclibceabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_UNKNOWN_LINUX_UCLIBCEABI.html
 [armv7-unknown-linux-uclibceabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_UNKNOWN_LINUX_UCLIBCEABIHF.html
 [armv7-unknown-netbsd-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_UNKNOWN_NETBSD_EABIHF.html
+[armv7-unknown-trusty]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_UNKNOWN_TRUSTY.html
 [armv7-wrs-vxworks-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7_WRS_VXWORKS_EABIHF.html
 [armv7a-kmc-solid_asp3-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7A_KMC_SOLID_ASP3_EABI.html
 [armv7a-kmc-solid_asp3-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7A_KMC_SOLID_ASP3_EABIHF.html
@@ -434,6 +463,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [i686-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_WRS_VXWORKS.html
 [loongarch64-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_LINUX_GNU.html
 [loongarch64-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_LINUX_MUSL.html
+[loongarch64-unknown-linux-ohos]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_LINUX_OHOS.html
 [loongarch64-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_NONE.html
 [loongarch64-unknown-none-softfloat]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_NONE_SOFTFLOAT.html
 [m68k-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.M68K_UNKNOWN_LINUX_GNU.html
@@ -462,6 +492,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [powerpc-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC_UNKNOWN_LINUX_GNU.html
 [powerpc-unknown-linux-gnuspe]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC_UNKNOWN_LINUX_GNUSPE.html
 [powerpc-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC_UNKNOWN_LINUX_MUSL.html
+[powerpc-unknown-linux-muslspe]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC_UNKNOWN_LINUX_MUSLSPE.html
 [powerpc-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC_UNKNOWN_NETBSD.html
 [powerpc-unknown-openbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC_UNKNOWN_OPENBSD.html
 [powerpc-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC_WRS_VXWORKS.html
@@ -475,6 +506,10 @@ If we remove platforms, we will bump the minor version of this crate.
 [powerpc64le-unknown-freebsd]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC64LE_UNKNOWN_FREEBSD.html
 [powerpc64le-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC64LE_UNKNOWN_LINUX_GNU.html
 [powerpc64le-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.POWERPC64LE_UNKNOWN_LINUX_MUSL.html
+[riscv32-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32_WRS_VXWORKS.html
+[riscv32e-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32E_UNKNOWN_NONE_ELF.html
+[riscv32em-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32EM_UNKNOWN_NONE_ELF.html
+[riscv32emc-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32EMC_UNKNOWN_NONE_ELF.html
 [riscv32gc-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32GC_UNKNOWN_LINUX_GNU.html
 [riscv32gc-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32GC_UNKNOWN_LINUX_MUSL.html
 [riscv32i-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32I_UNKNOWN_NONE_ELF.html
@@ -483,12 +518,16 @@ If we remove platforms, we will bump the minor version of this crate.
 [riscv32ima-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMA_UNKNOWN_NONE_ELF.html
 [riscv32imac-esp-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAC_ESP_ESPIDF.html
 [riscv32imac-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAC_UNKNOWN_NONE_ELF.html
+[riscv32imac-unknown-nuttx-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAC_UNKNOWN_NUTTX_ELF.html
 [riscv32imac-unknown-xous-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAC_UNKNOWN_XOUS_ELF.html
 [riscv32imafc-esp-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAFC_ESP_ESPIDF.html
 [riscv32imafc-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAFC_UNKNOWN_NONE_ELF.html
+[riscv32imafc-unknown-nuttx-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMAFC_UNKNOWN_NUTTX_ELF.html
 [riscv32imc-esp-espidf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMC_ESP_ESPIDF.html
 [riscv32imc-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMC_UNKNOWN_NONE_ELF.html
+[riscv32imc-unknown-nuttx-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMC_UNKNOWN_NUTTX_ELF.html
 [riscv64-linux-android]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64_LINUX_ANDROID.html
+[riscv64-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64_WRS_VXWORKS.html
 [riscv64gc-unknown-freebsd]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_FREEBSD.html
 [riscv64gc-unknown-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_FUCHSIA.html
 [riscv64gc-unknown-hermit]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_HERMIT.html
@@ -496,8 +535,10 @@ If we remove platforms, we will bump the minor version of this crate.
 [riscv64gc-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_LINUX_MUSL.html
 [riscv64gc-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_NETBSD.html
 [riscv64gc-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_NONE_ELF.html
+[riscv64gc-unknown-nuttx-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_NUTTX_ELF.html
 [riscv64gc-unknown-openbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_OPENBSD.html
 [riscv64imac-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64IMAC_UNKNOWN_NONE_ELF.html
+[riscv64imac-unknown-nuttx-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64IMAC_UNKNOWN_NUTTX_ELF.html
 [s390x-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.S390X_UNKNOWN_LINUX_GNU.html
 [s390x-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.S390X_UNKNOWN_LINUX_MUSL.html
 [sparc-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.SPARC_UNKNOWN_LINUX_GNU.html
@@ -509,23 +550,31 @@ If we remove platforms, we will bump the minor version of this crate.
 [thumbv4t-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV4T_NONE_EABI.html
 [thumbv5te-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV5TE_NONE_EABI.html
 [thumbv6m-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV6M_NONE_EABI.html
+[thumbv6m-nuttx-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV6M_NUTTX_EABI.html
 [thumbv7a-pc-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7A_PC_WINDOWS_MSVC.html
 [thumbv7a-uwp-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7A_UWP_WINDOWS_MSVC.html
 [thumbv7em-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7EM_NONE_EABI.html
 [thumbv7em-none-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7EM_NONE_EABIHF.html
+[thumbv7em-nuttx-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7EM_NUTTX_EABI.html
+[thumbv7em-nuttx-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7EM_NUTTX_EABIHF.html
 [thumbv7m-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7M_NONE_EABI.html
+[thumbv7m-nuttx-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7M_NUTTX_EABI.html
 [thumbv7neon-linux-androideabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7NEON_LINUX_ANDROIDEABI.html
 [thumbv7neon-unknown-linux-gnueabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF.html
 [thumbv7neon-unknown-linux-musleabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV7NEON_UNKNOWN_LINUX_MUSLEABIHF.html
 [thumbv8m.base-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV8M.BASE_NONE_EABI.html
+[thumbv8m.base-nuttx-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV8M.BASE_NUTTX_EABI.html
 [thumbv8m.main-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV8M.MAIN_NONE_EABI.html
 [thumbv8m.main-none-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV8M.MAIN_NONE_EABIHF.html
+[thumbv8m.main-nuttx-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV8M.MAIN_NUTTX_EABI.html
+[thumbv8m.main-nuttx-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.THUMBV8M.MAIN_NUTTX_EABIHF.html
 [wasm32-unknown-emscripten]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_UNKNOWN_EMSCRIPTEN.html
 [wasm32-unknown-unknown]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_UNKNOWN_UNKNOWN.html
 [wasm32-wasi]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASI.html
 [wasm32-wasip1]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP1.html
 [wasm32-wasip1-threads]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP1_THREADS.html
 [wasm32-wasip2]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP2.html
+[wasm32v1-none]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32V1_NONE.html
 [wasm64-unknown-unknown]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM64_UNKNOWN_UNKNOWN.html
 [x86_64-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_APPLE_DARWIN.html
 [x86_64-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_APPLE_IOS.html
@@ -533,7 +582,6 @@ If we remove platforms, we will bump the minor version of this crate.
 [x86_64-apple-tvos]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_APPLE_TVOS.html
 [x86_64-apple-watchos-sim]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_APPLE_WATCHOS_SIM.html
 [x86_64-fortanix-unknown-sgx]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_FORTANIX_UNKNOWN_SGX.html
-[x86_64-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_FUCHSIA.html
 [x86_64-linux-android]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_LINUX_ANDROID.html
 [x86_64-pc-nto-qnx710]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_PC_NTO_QNX710.html
 [x86_64-pc-solaris]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_PC_SOLARIS.html
@@ -546,6 +594,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [x86_64-unknown-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_FUCHSIA.html
 [x86_64-unknown-haiku]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_HAIKU.html
 [x86_64-unknown-hermit]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_HERMIT.html
+[x86_64-unknown-hurd-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_HURD_GNU.html
 [x86_64-unknown-illumos]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_ILLUMOS.html
 [x86_64-unknown-l4re-uclibc]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_L4RE_UCLIBC.html
 [x86_64-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_GNU.html
@@ -557,6 +606,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [x86_64-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_NONE.html
 [x86_64-unknown-openbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_OPENBSD.html
 [x86_64-unknown-redox]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_REDOX.html
+[x86_64-unknown-trusty]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_TRUSTY.html
 [x86_64-unknown-uefi]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_UEFI.html
 [x86_64-uwp-windows-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UWP_WINDOWS_GNU.html
 [x86_64-uwp-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UWP_WINDOWS_MSVC.html

--- a/platforms/src/platform/platforms.rs
+++ b/platforms/src/platform/platforms.rs
@@ -25,7 +25,6 @@ pub(crate) const ALL: &[Platform] = &[
     AARCH64_APPLE_VISIONOS_SIM,
     AARCH64_APPLE_WATCHOS,
     AARCH64_APPLE_WATCHOS_SIM,
-    AARCH64_FUCHSIA,
     AARCH64_KMC_SOLID_ASP3,
     AARCH64_LINUX_ANDROID,
     AARCH64_NINTENDO_SWITCH_FREESTANDING,
@@ -42,10 +41,12 @@ pub(crate) const ALL: &[Platform] = &[
     AARCH64_UNKNOWN_NETBSD,
     AARCH64_UNKNOWN_NONE,
     AARCH64_UNKNOWN_NONE_SOFTFLOAT,
+    AARCH64_UNKNOWN_NTO_QNX700,
     AARCH64_UNKNOWN_NTO_QNX710,
     AARCH64_UNKNOWN_OPENBSD,
     AARCH64_UNKNOWN_REDOX,
     AARCH64_UNKNOWN_TEEOS,
+    AARCH64_UNKNOWN_TRUSTY,
     AARCH64_UNKNOWN_UEFI,
     AARCH64_UWP_WINDOWS_MSVC,
     AARCH64_WRS_VXWORKS,
@@ -60,6 +61,7 @@ pub(crate) const ALL: &[Platform] = &[
     ARM64_32_APPLE_WATCHOS,
     ARM64E_APPLE_DARWIN,
     ARM64E_APPLE_IOS,
+    ARM64E_APPLE_TVOS,
     ARM64EC_PC_WINDOWS_MSVC,
     ARMEB_UNKNOWN_LINUX_GNUEABI,
     ARMEBV7R_NONE_EABI,
@@ -74,6 +76,7 @@ pub(crate) const ALL: &[Platform] = &[
     ARMV6_UNKNOWN_NETBSD_EABIHF,
     ARMV6K_NINTENDO_3DS,
     ARMV7_LINUX_ANDROIDEABI,
+    ARMV7_RTEMS_EABIHF,
     ARMV7_SONY_VITA_NEWLIBEABIHF,
     ARMV7_UNKNOWN_FREEBSD,
     ARMV7_UNKNOWN_LINUX_GNUEABI,
@@ -84,6 +87,7 @@ pub(crate) const ALL: &[Platform] = &[
     ARMV7_UNKNOWN_LINUX_UCLIBCEABI,
     ARMV7_UNKNOWN_LINUX_UCLIBCEABIHF,
     ARMV7_UNKNOWN_NETBSD_EABIHF,
+    ARMV7_UNKNOWN_TRUSTY,
     ARMV7_WRS_VXWORKS_EABIHF,
     ARMV7A_KMC_SOLID_ASP3_EABI,
     ARMV7A_KMC_SOLID_ASP3_EABIHF,
@@ -127,6 +131,7 @@ pub(crate) const ALL: &[Platform] = &[
     I686_WRS_VXWORKS,
     LOONGARCH64_UNKNOWN_LINUX_GNU,
     LOONGARCH64_UNKNOWN_LINUX_MUSL,
+    LOONGARCH64_UNKNOWN_LINUX_OHOS,
     LOONGARCH64_UNKNOWN_NONE,
     LOONGARCH64_UNKNOWN_NONE_SOFTFLOAT,
     M68K_UNKNOWN_LINUX_GNU,
@@ -155,6 +160,7 @@ pub(crate) const ALL: &[Platform] = &[
     POWERPC_UNKNOWN_LINUX_GNU,
     POWERPC_UNKNOWN_LINUX_GNUSPE,
     POWERPC_UNKNOWN_LINUX_MUSL,
+    POWERPC_UNKNOWN_LINUX_MUSLSPE,
     POWERPC_UNKNOWN_NETBSD,
     POWERPC_UNKNOWN_OPENBSD,
     POWERPC_WRS_VXWORKS,
@@ -168,6 +174,10 @@ pub(crate) const ALL: &[Platform] = &[
     POWERPC64LE_UNKNOWN_FREEBSD,
     POWERPC64LE_UNKNOWN_LINUX_GNU,
     POWERPC64LE_UNKNOWN_LINUX_MUSL,
+    RISCV32_WRS_VXWORKS,
+    RISCV32E_UNKNOWN_NONE_ELF,
+    RISCV32EM_UNKNOWN_NONE_ELF,
+    RISCV32EMC_UNKNOWN_NONE_ELF,
     RISCV32GC_UNKNOWN_LINUX_GNU,
     RISCV32GC_UNKNOWN_LINUX_MUSL,
     RISCV32I_UNKNOWN_NONE_ELF,
@@ -176,12 +186,16 @@ pub(crate) const ALL: &[Platform] = &[
     RISCV32IMA_UNKNOWN_NONE_ELF,
     RISCV32IMAC_ESP_ESPIDF,
     RISCV32IMAC_UNKNOWN_NONE_ELF,
+    RISCV32IMAC_UNKNOWN_NUTTX_ELF,
     RISCV32IMAC_UNKNOWN_XOUS_ELF,
     RISCV32IMAFC_ESP_ESPIDF,
     RISCV32IMAFC_UNKNOWN_NONE_ELF,
+    RISCV32IMAFC_UNKNOWN_NUTTX_ELF,
     RISCV32IMC_ESP_ESPIDF,
     RISCV32IMC_UNKNOWN_NONE_ELF,
+    RISCV32IMC_UNKNOWN_NUTTX_ELF,
     RISCV64_LINUX_ANDROID,
+    RISCV64_WRS_VXWORKS,
     RISCV64GC_UNKNOWN_FREEBSD,
     RISCV64GC_UNKNOWN_FUCHSIA,
     RISCV64GC_UNKNOWN_HERMIT,
@@ -189,8 +203,10 @@ pub(crate) const ALL: &[Platform] = &[
     RISCV64GC_UNKNOWN_LINUX_MUSL,
     RISCV64GC_UNKNOWN_NETBSD,
     RISCV64GC_UNKNOWN_NONE_ELF,
+    RISCV64GC_UNKNOWN_NUTTX_ELF,
     RISCV64GC_UNKNOWN_OPENBSD,
     RISCV64IMAC_UNKNOWN_NONE_ELF,
+    RISCV64IMAC_UNKNOWN_NUTTX_ELF,
     S390X_UNKNOWN_LINUX_GNU,
     S390X_UNKNOWN_LINUX_MUSL,
     SPARC_UNKNOWN_LINUX_GNU,
@@ -202,23 +218,31 @@ pub(crate) const ALL: &[Platform] = &[
     THUMBV4T_NONE_EABI,
     THUMBV5TE_NONE_EABI,
     THUMBV6M_NONE_EABI,
+    THUMBV6M_NUTTX_EABI,
     THUMBV7A_PC_WINDOWS_MSVC,
     THUMBV7A_UWP_WINDOWS_MSVC,
     THUMBV7EM_NONE_EABI,
     THUMBV7EM_NONE_EABIHF,
+    THUMBV7EM_NUTTX_EABI,
+    THUMBV7EM_NUTTX_EABIHF,
     THUMBV7M_NONE_EABI,
+    THUMBV7M_NUTTX_EABI,
     THUMBV7NEON_LINUX_ANDROIDEABI,
     THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF,
     THUMBV7NEON_UNKNOWN_LINUX_MUSLEABIHF,
     THUMBV8M_BASE_NONE_EABI,
+    THUMBV8M_BASE_NUTTX_EABI,
     THUMBV8M_MAIN_NONE_EABI,
     THUMBV8M_MAIN_NONE_EABIHF,
+    THUMBV8M_MAIN_NUTTX_EABI,
+    THUMBV8M_MAIN_NUTTX_EABIHF,
     WASM32_UNKNOWN_EMSCRIPTEN,
     WASM32_UNKNOWN_UNKNOWN,
     WASM32_WASI,
     WASM32_WASIP1,
     WASM32_WASIP1_THREADS,
     WASM32_WASIP2,
+    WASM32V1_NONE,
     WASM64_UNKNOWN_UNKNOWN,
     X86_64_APPLE_DARWIN,
     X86_64_APPLE_IOS,
@@ -226,7 +250,6 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_APPLE_TVOS,
     X86_64_APPLE_WATCHOS_SIM,
     X86_64_FORTANIX_UNKNOWN_SGX,
-    X86_64_FUCHSIA,
     X86_64_LINUX_ANDROID,
     X86_64_PC_NTO_QNX710,
     X86_64_PC_SOLARIS,
@@ -239,6 +262,7 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_UNKNOWN_FUCHSIA,
     X86_64_UNKNOWN_HAIKU,
     X86_64_UNKNOWN_HERMIT,
+    X86_64_UNKNOWN_HURD_GNU,
     X86_64_UNKNOWN_ILLUMOS,
     X86_64_UNKNOWN_L4RE_UCLIBC,
     X86_64_UNKNOWN_LINUX_GNU,
@@ -250,6 +274,7 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_UNKNOWN_NONE,
     X86_64_UNKNOWN_OPENBSD,
     X86_64_UNKNOWN_REDOX,
+    X86_64_UNKNOWN_TRUSTY,
     X86_64_UNKNOWN_UEFI,
     X86_64_UWP_WINDOWS_GNU,
     X86_64_UWP_WINDOWS_MSVC,
@@ -272,7 +297,7 @@ pub(crate) const AARCH64_APPLE_DARWIN: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Two,
+    tier: Tier::One,
 };
 
 /// ARM64 iOS
@@ -286,7 +311,7 @@ pub(crate) const AARCH64_APPLE_IOS: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Apple Catalyst on ARM64
+/// Mac Catalyst on ARM64
 pub(crate) const AARCH64_APPLE_IOS_MACABI: Platform = Platform {
     target_triple: "aarch64-apple-ios-macabi",
     target_arch: Arch::AArch64,
@@ -294,7 +319,7 @@ pub(crate) const AARCH64_APPLE_IOS_MACABI: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// Apple iOS Simulator on ARM64
@@ -372,17 +397,6 @@ pub(crate) const AARCH64_APPLE_WATCHOS_SIM: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
-};
-
-/// Alias for `aarch64-unknown-fuchsia`
-pub(crate) const AARCH64_FUCHSIA: Platform = Platform {
-    target_triple: "aarch64-fuchsia",
-    target_arch: Arch::AArch64,
-    target_os: OS::Fuchsia,
-    target_env: Env::None,
-    target_endian: Endian::Little,
-    target_pointer_width: PointerWidth::U64,
-    tier: Tier::Two,
 };
 
 /// ARM64 SOLID with TOPPERS/ASP3
@@ -561,6 +575,16 @@ pub(crate) const AARCH64_UNKNOWN_NONE_SOFTFLOAT: Platform = Platform {
     tier: Tier::Two,
 };
 
+pub(crate) const AARCH64_UNKNOWN_NTO_QNX700: Platform = Platform {
+    target_triple: "aarch64-unknown-nto-qnx700",
+    target_arch: Arch::AArch64,
+    target_os: OS::Nto,
+    target_env: Env::Nto70,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 pub(crate) const AARCH64_UNKNOWN_NTO_QNX710: Platform = Platform {
     target_triple: "aarch64-unknown-nto-qnx710",
     target_arch: Arch::AArch64,
@@ -603,6 +627,16 @@ pub(crate) const AARCH64_UNKNOWN_TEEOS: Platform = Platform {
     tier: Tier::Three,
 };
 
+pub(crate) const AARCH64_UNKNOWN_TRUSTY: Platform = Platform {
+    target_triple: "aarch64-unknown-trusty",
+    target_arch: Arch::AArch64,
+    target_os: OS::Trusty,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// ARM64 UEFI
 pub(crate) const AARCH64_UNKNOWN_UEFI: Platform = Platform {
     target_triple: "aarch64-unknown-uefi",
@@ -624,6 +658,7 @@ pub(crate) const AARCH64_UWP_WINDOWS_MSVC: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// ARM64 VxWorks OS
 pub(crate) const AARCH64_WRS_VXWORKS: Platform = Platform {
     target_triple: "aarch64-wrs-vxworks",
     target_arch: Arch::AArch64,
@@ -749,6 +784,17 @@ pub(crate) const ARM64E_APPLE_IOS: Platform = Platform {
     target_triple: "arm64e-apple-ios",
     target_arch: Arch::AArch64,
     target_os: OS::iOS,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
+/// ARM64e Apple tvOS
+pub(crate) const ARM64E_APPLE_TVOS: Platform = Platform {
+    target_triple: "arm64e-apple-tvos",
+    target_arch: Arch::AArch64,
+    target_os: OS::TvOS,
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
@@ -909,6 +955,17 @@ pub(crate) const ARMV7_LINUX_ANDROIDEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// RTEMS OS for ARM BSPs
+pub(crate) const ARMV7_RTEMS_EABIHF: Platform = Platform {
+    target_triple: "armv7-rtems-eabihf",
+    target_arch: Arch::Arm,
+    target_os: OS::Rtems,
+    target_env: Env::Newlib,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// Armv7-A Cortex-A9 Sony PlayStation Vita (requires VITASDK toolchain)
 pub(crate) const ARMV7_SONY_VITA_NEWLIBEABIHF: Platform = Platform {
     target_triple: "armv7-sony-vita-newlibeabihf",
@@ -1013,6 +1070,16 @@ pub(crate) const ARMV7_UNKNOWN_NETBSD_EABIHF: Platform = Platform {
     target_triple: "armv7-unknown-netbsd-eabihf",
     target_arch: Arch::Arm,
     target_os: OS::NetBSD,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+pub(crate) const ARMV7_UNKNOWN_TRUSTY: Platform = Platform {
+    target_triple: "armv7-unknown-trusty",
+    target_arch: Arch::Arm,
+    target_os: OS::Trusty,
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
@@ -1134,7 +1201,7 @@ pub(crate) const AVR_UNKNOWN_GNU_ATMEGA328: Platform = Platform {
     target_triple: "avr-unknown-gnu-atmega328",
     target_arch: Arch::Avr,
     target_os: OS::None,
-    target_env: Env::None,
+    target_env: Env::Gnu,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U16,
     tier: Tier::Three,
@@ -1492,6 +1559,17 @@ pub(crate) const LOONGARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// LoongArch64 OpenHarmony
+pub(crate) const LOONGARCH64_UNKNOWN_LINUX_OHOS: Platform = Platform {
+    target_triple: "loongarch64-unknown-linux-ohos",
+    target_arch: Arch::Loongarch64,
+    target_os: OS::Linux,
+    target_env: Env::OhOS,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// LoongArch64 Bare-metal (LP64D ABI)
 pub(crate) const LOONGARCH64_UNKNOWN_NONE: Platform = Platform {
     target_triple: "loongarch64-unknown-none",
@@ -1800,6 +1878,17 @@ pub(crate) const POWERPC_UNKNOWN_LINUX_MUSL: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// PowerPC SPE Linux
+pub(crate) const POWERPC_UNKNOWN_LINUX_MUSLSPE: Platform = Platform {
+    target_triple: "powerpc-unknown-linux-muslspe",
+    target_arch: Arch::PowerPc,
+    target_os: OS::Linux,
+    target_env: Env::Musl,
+    target_endian: Endian::Big,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// NetBSD 32-bit powerpc systems
 pub(crate) const POWERPC_UNKNOWN_NETBSD: Platform = Platform {
     target_triple: "powerpc-unknown-netbsd",
@@ -1939,6 +2028,49 @@ pub(crate) const POWERPC64LE_UNKNOWN_LINUX_MUSL: Platform = Platform {
     tier: Tier::Three,
 };
 
+pub(crate) const RISCV32_WRS_VXWORKS: Platform = Platform {
+    target_triple: "riscv32-wrs-vxworks",
+    target_arch: Arch::Riscv32,
+    target_os: OS::VxWorks,
+    target_env: Env::Gnu,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// Bare RISC-V (RV32E ISA)
+pub(crate) const RISCV32E_UNKNOWN_NONE_ELF: Platform = Platform {
+    target_triple: "riscv32e-unknown-none-elf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// Bare RISC-V (RV32EM ISA)
+pub(crate) const RISCV32EM_UNKNOWN_NONE_ELF: Platform = Platform {
+    target_triple: "riscv32em-unknown-none-elf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// Bare RISC-V (RV32EMC ISA)
+pub(crate) const RISCV32EMC_UNKNOWN_NONE_ELF: Platform = Platform {
+    target_triple: "riscv32emc-unknown-none-elf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// RISC-V Linux (kernel 5.4, glibc 2.33)
 pub(crate) const RISCV32GC_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "riscv32gc-unknown-linux-gnu",
@@ -2027,6 +2159,17 @@ pub(crate) const RISCV32IMAC_UNKNOWN_NONE_ELF: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// RISC-V 32bit with NuttX
+pub(crate) const RISCV32IMAC_UNKNOWN_NUTTX_ELF: Platform = Platform {
+    target_triple: "riscv32imac-unknown-nuttx-elf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// RISC-V Xous (RV32IMAC ISA)
 pub(crate) const RISCV32IMAC_UNKNOWN_XOUS_ELF: Platform = Platform {
     target_triple: "riscv32imac-unknown-xous-elf",
@@ -2060,6 +2203,17 @@ pub(crate) const RISCV32IMAFC_UNKNOWN_NONE_ELF: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// RISC-V 32bit with NuttX
+pub(crate) const RISCV32IMAFC_UNKNOWN_NUTTX_ELF: Platform = Platform {
+    target_triple: "riscv32imafc-unknown-nuttx-elf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// RISC-V ESP-IDF
 pub(crate) const RISCV32IMC_ESP_ESPIDF: Platform = Platform {
     target_triple: "riscv32imc-esp-espidf",
@@ -2082,12 +2236,33 @@ pub(crate) const RISCV32IMC_UNKNOWN_NONE_ELF: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// RISC-V 32bit with NuttX
+pub(crate) const RISCV32IMC_UNKNOWN_NUTTX_ELF: Platform = Platform {
+    target_triple: "riscv32imc-unknown-nuttx-elf",
+    target_arch: Arch::Riscv32,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// RISC-V 64-bit Android
 pub(crate) const RISCV64_LINUX_ANDROID: Platform = Platform {
     target_triple: "riscv64-linux-android",
     target_arch: Arch::Riscv64,
     target_os: OS::Android,
     target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
+pub(crate) const RISCV64_WRS_VXWORKS: Platform = Platform {
+    target_triple: "riscv64-wrs-vxworks",
+    target_arch: Arch::Riscv64,
+    target_os: OS::VxWorks,
+    target_env: Env::Gnu,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
@@ -2145,7 +2320,7 @@ pub(crate) const RISCV64GC_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_env: Env::Musl,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// RISC-V NetBSD
@@ -2170,6 +2345,17 @@ pub(crate) const RISCV64GC_UNKNOWN_NONE_ELF: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// RISC-V 64bit with NuttX
+pub(crate) const RISCV64GC_UNKNOWN_NUTTX_ELF: Platform = Platform {
+    target_triple: "riscv64gc-unknown-nuttx-elf",
+    target_arch: Arch::Riscv64,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// OpenBSD/riscv64
 pub(crate) const RISCV64GC_UNKNOWN_OPENBSD: Platform = Platform {
     target_triple: "riscv64gc-unknown-openbsd",
@@ -2190,6 +2376,17 @@ pub(crate) const RISCV64IMAC_UNKNOWN_NONE_ELF: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
+};
+
+/// RISC-V 64bit with NuttX
+pub(crate) const RISCV64IMAC_UNKNOWN_NUTTX_ELF: Platform = Platform {
+    target_triple: "riscv64imac-unknown-nuttx-elf",
+    target_arch: Arch::Riscv64,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
 };
 
 /// S390x Linux (kernel 3.2, glibc 2.17)
@@ -2313,6 +2510,17 @@ pub(crate) const THUMBV6M_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// ARMv6M with NuttX
+pub(crate) const THUMBV6M_NUTTX_EABI: Platform = Platform {
+    target_triple: "thumbv6m-nuttx-eabi",
+    target_arch: Arch::Arm,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 pub(crate) const THUMBV7A_PC_WINDOWS_MSVC: Platform = Platform {
     target_triple: "thumbv7a-pc-windows-msvc",
     target_arch: Arch::Arm,
@@ -2355,6 +2563,28 @@ pub(crate) const THUMBV7EM_NONE_EABIHF: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// ARMv7EM with NuttX
+pub(crate) const THUMBV7EM_NUTTX_EABI: Platform = Platform {
+    target_triple: "thumbv7em-nuttx-eabi",
+    target_arch: Arch::Arm,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// ARMv7EM with NuttX, hardfloat
+pub(crate) const THUMBV7EM_NUTTX_EABIHF: Platform = Platform {
+    target_triple: "thumbv7em-nuttx-eabihf",
+    target_arch: Arch::Arm,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// Bare Armv7-M
 pub(crate) const THUMBV7M_NONE_EABI: Platform = Platform {
     target_triple: "thumbv7m-none-eabi",
@@ -2364,6 +2594,17 @@ pub(crate) const THUMBV7M_NONE_EABI: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Two,
+};
+
+/// ARMv7M with NuttX
+pub(crate) const THUMBV7M_NUTTX_EABI: Platform = Platform {
+    target_triple: "thumbv7m-nuttx-eabi",
+    target_arch: Arch::Arm,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
 };
 
 /// Thumb2-mode Armv7-A Android with NEON
@@ -2410,6 +2651,17 @@ pub(crate) const THUMBV8M_BASE_NONE_EABI: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// ARMv8M Baseline with NuttX
+pub(crate) const THUMBV8M_BASE_NUTTX_EABI: Platform = Platform {
+    target_triple: "thumbv8m.base-nuttx-eabi",
+    target_arch: Arch::Arm,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// Bare Armv8-M Mainline
 pub(crate) const THUMBV8M_MAIN_NONE_EABI: Platform = Platform {
     target_triple: "thumbv8m.main-none-eabi",
@@ -2430,6 +2682,28 @@ pub(crate) const THUMBV8M_MAIN_NONE_EABIHF: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Two,
+};
+
+/// ARMv8M Mainline with NuttX
+pub(crate) const THUMBV8M_MAIN_NUTTX_EABI: Platform = Platform {
+    target_triple: "thumbv8m.main-nuttx-eabi",
+    target_arch: Arch::Arm,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// ARMv8M Mainline with NuttX, hardfloat
+pub(crate) const THUMBV8M_MAIN_NUTTX_EABIHF: Platform = Platform {
+    target_triple: "thumbv8m.main-nuttx-eabihf",
+    target_arch: Arch::Arm,
+    target_os: OS::Nuttx,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
 };
 
 /// WebAssembly via Emscripten
@@ -2498,6 +2772,17 @@ pub(crate) const WASM32_WASIP2: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// WebAssembly limited to 1.0 features and no imports
+pub(crate) const WASM32V1_NONE: Platform = Platform {
+    target_triple: "wasm32v1-none",
+    target_arch: Arch::Wasm32,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Two,
+};
+
 /// WebAssembly
 pub(crate) const WASM64_UNKNOWN_UNKNOWN: Platform = Platform {
     target_triple: "wasm64-unknown-unknown",
@@ -2531,7 +2816,7 @@ pub(crate) const X86_64_APPLE_IOS: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Apple Catalyst on x86_64
+/// Mac Catalyst on x86_64
 pub(crate) const X86_64_APPLE_IOS_MACABI: Platform = Platform {
     target_triple: "x86_64-apple-ios-macabi",
     target_arch: Arch::X86_64,
@@ -2539,7 +2824,7 @@ pub(crate) const X86_64_APPLE_IOS_MACABI: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Three,
+    tier: Tier::Two,
 };
 
 /// x86 64-bit tvOS
@@ -2570,17 +2855,6 @@ pub(crate) const X86_64_FORTANIX_UNKNOWN_SGX: Platform = Platform {
     target_arch: Arch::X86_64,
     target_os: OS::Unknown,
     target_env: Env::Sgx,
-    target_endian: Endian::Little,
-    target_pointer_width: PointerWidth::U64,
-    tier: Tier::Two,
-};
-
-/// Alias for `x86_64-unknown-fuchsia`
-pub(crate) const X86_64_FUCHSIA: Platform = Platform {
-    target_triple: "x86_64-fuchsia",
-    target_arch: Arch::X86_64,
-    target_os: OS::Fuchsia,
-    target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
@@ -2717,6 +2991,17 @@ pub(crate) const X86_64_UNKNOWN_HERMIT: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// 64-bit GNU/Hurd
+pub(crate) const X86_64_UNKNOWN_HURD_GNU: Platform = Platform {
+    target_triple: "x86_64-unknown-hurd-gnu",
+    target_arch: Arch::X86_64,
+    target_os: OS::Hurd,
+    target_env: Env::Gnu,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// illumos
 pub(crate) const X86_64_UNKNOWN_ILLUMOS: Platform = Platform {
     target_triple: "x86_64-unknown-illumos",
@@ -2835,6 +3120,16 @@ pub(crate) const X86_64_UNKNOWN_REDOX: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
+};
+
+pub(crate) const X86_64_UNKNOWN_TRUSTY: Platform = Platform {
+    target_triple: "x86_64-unknown-trusty",
+    target_arch: Arch::X86_64,
+    target_os: OS::Trusty,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
 };
 
 /// 64-bit UEFI

--- a/platforms/src/target/os.rs
+++ b/platforms/src/target/os.rs
@@ -74,6 +74,9 @@ pub enum OS {
     /// `nto`
     Nto,
 
+    /// `nuttx`
+    Nuttx,
+
     /// `openbsd`: The OpenBSD operating system
     OpenBSD,
 
@@ -83,6 +86,9 @@ pub enum OS {
     /// `redox`: Redox, a Unix-like OS written in Rust
     Redox,
 
+    /// `rtems`
+    Rtems,
+
     /// `solaris`: Oracle's (formerly Sun) Solaris operating system
     Solaris,
 
@@ -91,6 +97,9 @@ pub enum OS {
 
     /// `teeos`
     TeeOS,
+
+    /// `trusty`
+    Trusty,
 
     /// `tvos`
     TvOS,
@@ -150,12 +159,15 @@ impl OS {
             OS::NetBSD => "netbsd",
             OS::None => "none",
             OS::Nto => "nto",
+            OS::Nuttx => "nuttx",
             OS::OpenBSD => "openbsd",
             OS::Psp => "psp",
             OS::Redox => "redox",
+            OS::Rtems => "rtems",
             OS::Solaris => "solaris",
             OS::SolidAsp3 => "solid_asp3",
             OS::TeeOS => "teeos",
+            OS::Trusty => "trusty",
             OS::TvOS => "tvos",
             OS::Uefi => "uefi",
             OS::Unknown => "unknown",
@@ -197,12 +209,15 @@ impl FromStr for OS {
             "netbsd" => OS::NetBSD,
             "none" => OS::None,
             "nto" => OS::Nto,
+            "nuttx" => OS::Nuttx,
             "openbsd" => OS::OpenBSD,
             "psp" => OS::Psp,
             "redox" => OS::Redox,
+            "rtems" => OS::Rtems,
             "solaris" => OS::Solaris,
             "solid_asp3" => OS::SolidAsp3,
             "teeos" => OS::TeeOS,
+            "trusty" => OS::Trusty,
             "tvos" => OS::TvOS,
             "uefi" => OS::Uefi,
             "unknown" => OS::Unknown,


### PR DESCRIPTION
Ran `regenerate-platforms-crate.sh` for new Rust toolchain changes. Would be great if we can release a new version.