### PR TITLE
Fix links to CVSS calculator

### DIFF
--- a/admin/src/web/templates/advisory-content.html
+++ b/admin/src/web/templates/advisory-content.html
@@ -211,7 +211,14 @@
       </dd>
 
       <dt id="cvss">CVSS Vector</dt>
-      <dd><a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector={{ cvss }}">{{ cvss }}</a></dd>
+
+      {% if cvss.to_string().starts_with("CVSS:3.1/") %}
+      <dd><a href="https://www.first.org/cvss/calculator/3.1#{{ cvss }}">{{ cvss }}</a></dd>
+      {% else if cvss.to_string().starts_with("CVSS:3.0/") %}
+      <dd><a href="https://www.first.org/cvss/calculator/3.0#{{ cvss }}">{{ cvss }}</a></dd>
+      {% else %}
+      <dd>{{ cvss }}</dd>
+      {% endif %}
 
       {% when None %}
       {% endmatch %}


### PR DESCRIPTION
Use the calculator at first.org (which manages the CVSS specification). It expects the full vector without modification, and is also more neutral than a US government site.

Fixes #1177.