### PR TITLE
Do not serialize schema version as 'null' if not set

### DIFF
--- a/rustsec/src/osv/advisory.rs
+++ b/rustsec/src/osv/advisory.rs
@@ -22,6 +22,7 @@ const ECOSYSTEM: &str = "crates.io";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(docsrs, doc(cfg(feature = "osv-export")))]
 pub struct OsvAdvisory {
+    #[serde(skip_serializing_if = "Option::is_none")]
     schema_version: Option<semver::Version>,
     id: Id,
     modified: String,  // maybe add an rfc3339 newtype?


### PR DESCRIPTION
to fix OSV JSON schema compliance https://github.com/rustsec/advisory-db/issues/2135