### PR TITLE
Do not assert in tests that there are no vulnerabilities in our own Cargo.lock

### DIFF
--- a/rustsec/tests/integration.rs
+++ b/rustsec/tests/integration.rs
@@ -52,17 +52,7 @@ fn verify_rustsec_2017_0001(db: &Database) {
     assert_eq!(example_advisory, crate_advisories[0]);
 
     let lockfile = Lockfile::load("../Cargo.lock").unwrap();
-    let vulns = db.vulnerabilities(&lockfile);
-
-    // TODO(tarcieri): find, file, and fix the version matching bug causing this
-    assert_eq!(
-        vulns
-            .iter()
-            .find(|v| !["RUSTSEC-2021-0055", "RUSTSEC-2021-0056"]
-                .iter()
-                .any(|id| v.advisory.id == id.parse().unwrap())),
-        None
-    );
+    let _vulns = db.vulnerabilities(&lockfile);
 }
 
 /// End-to-end integration test (has online dependency on GitHub) which looks


### PR DESCRIPTION
I found it very confusing that our tests assume that. I thought failing tests means the code is broken, but turns out it wasn't.