### PR TITLE
Update petgraph to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2366,9 +2366,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ gix = { version = "0.66", default-features = false }
 gumdrop = "0.8"
 home = "0.5"
 once_cell = "1.15.0"
-petgraph = "0.6"
+petgraph = "0.7"
 platforms = { version = "3", path = "./platforms" }
 quitters = { version = "0.1.0", path = "./quitters" }
 regex = { version = "1.10.6", default-features = false }


### PR DESCRIPTION
See https://github.com/petgraph/petgraph/blob/petgraph%40v0.7.1/RELEASES.rst. This is a SemVer-incompatible update only because petgraph’s exposed dependency fixedbitset was updated SemVer-incompatibly, but rustsec’s use of the petgraph APIs is straightforward, and no code changes appear to be necessary:

```
$ rg petgraph::
cargo-lock/src/dependency/tree.rs
185:        use petgraph::visit::EdgeRef;

cargo-lock/src/dependency/graph.rs
3:pub use petgraph::{graph::NodeIndex, EdgeDirection};
8:pub type Graph = petgraph::graph::Graph<Package, Dependency>;

cargo-lock/src/bin/cargo-lock/main.rs
13:use petgraph::graph::NodeIndex;
```

Tested with `cargo test --workspace -- --skip lint_advisory_db`.