### PR TITLE
Make rustsec library compatible with gix's curl backend

### DIFF
--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -39,7 +39,7 @@ jobs:
       - run: cargo check
       - run: cargo test --no-default-features
       - run: cargo test
-      - run: cargo test --all-features
+      - run: cargo test --features=dependency-tree,osv-export,binary-scanning
 
   doc:
     runs-on: ubuntu-latest
@@ -51,4 +51,4 @@ jobs:
           override: true
           profile: minimal
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc --all-features
+      - run: cargo doc --features=dependency-tree,osv-export,binary-scanning

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -32,7 +32,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --all-features -- -D warnings
+          args: --workspace --all-features --exclude=rustsec -- -D warnings
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --package=rustsec --features=dependency-tree,osv-export,binary-scanning -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2d5c8f48d9c0c23250e52b55e82a6ab4fdba6650c931f5a0a57a43abda812b"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.82+curl-8.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d63638b5ec65f1a4ae945287b3fd035be4554bbaf211901159c9a2a74fb5be"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cvss"
 version = "2.1.0"
 dependencies = [
@@ -1642,6 +1672,7 @@ checksum = "edfe22ba26d4b65c17879f12b9882eafe65d3c8611c933b272fce2c10f546f59"
 dependencies = [
  "base64",
  "bstr",
+ "curl",
  "gix-command",
  "gix-credentials",
  "gix-features",
@@ -2219,6 +2250,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2415,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2488,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platforms"
@@ -3690,6 +3751,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -57,5 +57,6 @@ osv-export = ["git"]
 binary-scanning = ["dep:auditable-info", "dep:auditable-serde", "dep:binfarce", "dep:quitters", "dep:once_cell"]
 
 [package.metadata.docs.rs]
-all-features = true
+# All features except gix-curl, which is mutually exclusive with gix-reqwest
+features = ["dependency-tree", "osv-export", "binary-scanning"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = { workspace = true, optional = true }
 binfarce = { workspace = true, optional = true }
 
 # optional dependencies
-tame-index = { workspace = true, features = ["git", "sparse", "native-certs"], optional = true }
+tame-index = { workspace = true, features = ["sparse", "native-certs"], optional = true }
 home = { workspace = true, optional = true }
 time = { workspace = true, features = ["formatting", "serde", "parsing"], optional = true }
 gix = { workspace = true, features = ["worktree-mutation", "revision", "max-performance-safe"], optional = true }
@@ -42,13 +42,16 @@ once_cell = { workspace = true }
 serde_json = { workspace = true }
 
 [features]
-default = ["git"]
+default = ["gix-reqwest"]
 git = [
     "dep:tame-index",
     "dep:home",
     "dep:time",
     "dep:gix",
 ]
+# Exactly one of 'gix-reqwest' or 'gix-curl' must be enabled when using the 'git' feature.
+gix-reqwest = ["tame-index/gix-reqwest", "git"]
+gix-curl = ["tame-index/gix-curl", "git"]
 dependency-tree = ["cargo-lock/dependency-tree"]
 osv-export = ["git"]
 binary-scanning = ["dep:auditable-info", "dep:auditable-serde", "dep:binfarce", "dep:quitters", "dep:once_cell"]


### PR DESCRIPTION
Currently, rustsec with git support is unusable in a dependency graph that also enables gix's curl feature. For example something as simple as:

```toml
[dependencies]
cargo = "0.88.0"
rustsec = "0.30.2"
```

causes `gix-transport` to fail to compile because rustsec enables gix's reqwest backend (indirectly through tame-index) and cargo enables gix's curl backend.

- https://github.com/EmbarkStudios/tame-index/blob/0.21.0/Cargo.toml#L14-L17
- https://github.com/rust-lang/cargo/blob/0.88.0/Cargo.toml#L51

```console
error[E0428]: the name `Impl` is defined multiple times
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/gix-transport-0.45.0/src/client/blocking_io/http/mod.rs:220:1
    |
217 | pub type Impl = curl::Curl;
    | --------------------------- previous definition of the type `Impl` here
...
220 | pub type Impl = reqwest::Remote;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Impl` redefined here
    |
    = note: `Impl` must be defined only once in the type namespace of this module

error: Cannot set both 'http-client-reqwest' and 'http-client-curl' features as they are mutually exclusive
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/gix-transport-0.45.0/src/client/blocking_io/http/mod.rs:26:1
   |
26 | compile_error!("Cannot set both 'http-client-reqwest' and 'http-client-curl' features as they are mutually exclusive");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR makes it possible to use rustsec in a project that prefers curl.

```toml
[dependencies]
cargo = "0.88.0"
rustsec = { default-features = false, features = ["gix-curl"] }
```