### PR TITLE
feat(cargo-audit): add SARIF output format support

### DIFF
--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -146,6 +146,14 @@ pub struct AuditCommand {
     )]
     quiet: bool,
 
+    /// Output format
+    #[arg(
+        long = "format",
+        value_name = "FORMAT",
+        help = "Output format: terminal, json, or sarif"
+    )]
+    output_format: Option<OutputFormat>,
+
     /// Output reports as JSON
     #[arg(long = "json", help = "Output report in JSON format")]
     output_json: bool,
@@ -228,8 +236,11 @@ impl Override<AuditConfig> for AuditCommand {
 
         config.output.quiet |= self.quiet;
 
+        // Handle output format (--json flag takes precedence for backward compatibility)
         if self.output_json {
             config.output.format = OutputFormat::Json;
+        } else if let Some(format) = self.output_format {
+            config.output.format = format;
         }
 
         Ok(config)

--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -164,7 +164,7 @@ pub struct OutputConfig {
 impl OutputConfig {
     /// Is quiet mode enabled?
     pub fn is_quiet(&self) -> bool {
-        self.quiet || self.format == OutputFormat::Json
+        self.quiet || self.format == OutputFormat::Json || self.format == OutputFormat::Sarif
     }
 }
 
@@ -231,16 +231,36 @@ impl FromStr for DenyOption {
 }
 
 /// Output format
-#[derive(Default, Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Default, Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, clap::ValueEnum)]
 pub enum OutputFormat {
     /// Display JSON
     #[serde(rename = "json")]
     Json,
 
+    /// Display SARIF (Static Analysis Results Interchange Format)
+    #[serde(rename = "sarif")]
+    Sarif,
+
     /// Display human-readable output to the terminal
     #[serde(rename = "terminal")]
     #[default]
     Terminal,
+}
+
+impl FromStr for OutputFormat {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "json" => Ok(OutputFormat::Json),
+            "sarif" => Ok(OutputFormat::Sarif),
+            "terminal" => Ok(OutputFormat::Terminal),
+            other => Err(Error::new(
+                ErrorKind::Parse,
+                &format!("invalid output format: {other}"),
+            )),
+        }
+    }
 }
 
 /// Helper enum for configuring filter values

--- a/cargo-audit/src/lib.rs
+++ b/cargo-audit/src/lib.rs
@@ -28,6 +28,7 @@ pub mod error;
 pub mod lockfile;
 mod prelude;
 pub mod presenter;
+pub mod sarif;
 
 /// Current version of the `cargo-audit` crate
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -111,7 +111,7 @@ impl Presenter {
                 let cargo_lock_path = path
                     .map(|p| p.to_string_lossy().into_owned())
                     .unwrap_or_else(|| "Cargo.lock".to_string());
-                let sarif_log = crate::sarif::to_sarif(report, &cargo_lock_path);
+                let sarif_log = crate::sarif::SarifLog::from_report(report, &cargo_lock_path);
                 serde_json::to_writer(io::stdout(), &sarif_log).unwrap();
                 io::stdout().flush().unwrap();
                 return;

--- a/cargo-audit/src/sarif.rs
+++ b/cargo-audit/src/sarif.rs
@@ -348,7 +348,9 @@ impl Result {
             }],
             partial_fingerprints: {
                 let mut fingerprints = HashMap::new();
-                fingerprints.insert("primaryLocationLineHash".to_string(), fingerprint);
+                // Use a custom fingerprint key instead of primaryLocationLineHash
+                // to avoid conflicts with GitHub's calculated fingerprints
+                fingerprints.insert("cargo-audit/advisory-fingerprint".to_string(), fingerprint);
                 fingerprints
             },
         }
@@ -404,7 +406,9 @@ impl Result {
             }],
             partial_fingerprints: {
                 let mut fingerprints = HashMap::new();
-                fingerprints.insert("primaryLocationLineHash".to_string(), fingerprint);
+                // Use a custom fingerprint key instead of primaryLocationLineHash
+                // to avoid conflicts with GitHub's calculated fingerprints
+                fingerprints.insert("cargo-audit/advisory-fingerprint".to_string(), fingerprint);
                 fingerprints
             },
         }

--- a/cargo-audit/src/sarif.rs
+++ b/cargo-audit/src/sarif.rs
@@ -1,0 +1,465 @@
+//! SARIF (Static Analysis Results Interchange Format) output support
+//!
+//! This module provides functionality to convert cargo-audit reports to SARIF format,
+//! which can be uploaded to GitHub Security tab and other security analysis platforms.
+//!
+//! SARIF is an OASIS Standard that defines a common format for static analysis tools
+//! to report their findings. This implementation follows SARIF 2.1.0 specification
+//! and is compatible with GitHub's code scanning requirements.
+
+use rustsec::{Report, Vulnerability, Warning, WarningKind, advisory};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// SARIF log root object
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SarifLog {
+    /// URI of the SARIF schema
+    #[serde(rename = "$schema")]
+    pub schema: String,
+    /// SARIF format version
+    pub version: String,
+    /// Array of analysis runs
+    pub runs: Vec<Run>,
+}
+
+/// A run represents a single invocation of an analysis tool
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Run {
+    /// Tool information for this run
+    pub tool: Tool,
+    /// Array of results (findings) from the analysis
+    pub results: Vec<Result>,
+    /// Automation details to distinguish between runs
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub automation_details: Option<RunAutomationDetails>,
+}
+
+/// Tool information
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Tool {
+    /// The analysis tool that was run
+    pub driver: ToolComponent,
+}
+
+/// Tool component (driver) information
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolComponent {
+    /// Name of the tool component
+    pub name: String,
+    /// Tool version string
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Semantic version of the tool
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_version: Option<String>,
+    /// Rules defined by this tool
+    pub rules: Vec<ReportingDescriptor>,
+}
+
+/// Rule/reporting descriptor
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportingDescriptor {
+    /// Unique identifier for the rule
+    pub id: String,
+    /// Human-readable name of the rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Brief description of the rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short_description: Option<MultiformatMessageString>,
+    /// Detailed description of the rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_description: Option<MultiformatMessageString>,
+    /// Default severity and enablement for the rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_configuration: Option<ReportingConfiguration>,
+    /// Help text or URI for the rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<MultiformatMessageString>,
+    /// Additional properties including tags and severity scores
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<RuleProperties>,
+}
+
+/// Rule properties
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleProperties {
+    /// Tags associated with the rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    /// Precision of the rule (e.g., "very-high", "high")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub precision: Option<String>,
+    /// Problem severity for non-security issues
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "problem.severity")]
+    pub problem_severity: Option<String>,
+    /// CVSS score as a string (0.0-10.0)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "security-severity")]
+    pub security_severity: Option<String>,
+}
+
+/// Reporting configuration for a rule
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportingConfiguration {
+    /// Default level for the rule ("error", "warning", "note")
+    pub level: String,
+}
+
+/// Message with optional markdown
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiformatMessageString {
+    /// Plain text message
+    pub text: String,
+    /// Optional markdown-formatted message
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub markdown: Option<String>,
+}
+
+/// A result (finding/alert)
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Result {
+    /// ID of the rule that was violated
+    pub rule_id: String,
+    /// Index into the tool.driver.rules array
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_index: Option<usize>,
+    /// Message describing the result
+    pub message: Message,
+    /// Severity level of the result
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<String>,
+    /// Locations where the issue was detected
+    pub locations: Vec<Location>,
+    /// Fingerprints for result matching
+    pub partial_fingerprints: HashMap<String, String>,
+}
+
+/// Simple message
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Message {
+    /// The message text
+    pub text: String,
+}
+
+/// Location of a finding
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Location {
+    /// Physical location of the finding
+    pub physical_location: PhysicalLocation,
+}
+
+/// Physical location in a file
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PhysicalLocation {
+    /// The artifact (file) containing the issue
+    pub artifact_location: ArtifactLocation,
+    /// Region within the artifact
+    pub region: Region,
+}
+
+/// Artifact (file) location
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactLocation {
+    /// URI of the artifact
+    pub uri: String,
+}
+
+/// Region within a file
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Region {
+    /// Starting line number (1-based)
+    pub start_line: u32,
+    /// Starting column number (1-based)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_column: Option<u32>,
+    /// Ending line number (1-based)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<u32>,
+    /// Ending column number (1-based)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_column: Option<u32>,
+}
+
+/// Run automation details for distinguishing multiple runs
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunAutomationDetails {
+    /// Unique identifier for the run
+    pub id: String,
+}
+
+/// Convert a cargo-audit report to SARIF format
+pub fn to_sarif(report: &Report, cargo_lock_path: &str) -> SarifLog {
+    let mut rules = Vec::new();
+    let mut results = Vec::new();
+    let mut rule_indices = HashMap::new();
+
+    // Process vulnerabilities
+    for vuln in report.vulnerabilities.list.iter() {
+        let rule_id = vuln.advisory.id.to_string();
+
+        if !rule_indices.contains_key(&rule_id) {
+            rule_indices.insert(rule_id.clone(), rules.len());
+            rules.push(create_rule_from_advisory(&vuln.advisory, true));
+        }
+
+        results.push(create_result_from_vulnerability(
+            vuln,
+            cargo_lock_path,
+            rule_indices[&rule_id],
+        ));
+    }
+
+    // Process warnings
+    for (warning_kind, warnings) in &report.warnings {
+        for warning in warnings {
+            let rule_id = if let Some(advisory) = &warning.advisory {
+                advisory.id.to_string()
+            } else {
+                format!("{:?}", warning_kind).to_lowercase()
+            };
+
+            if !rule_indices.contains_key(&rule_id) {
+                rule_indices.insert(rule_id.clone(), rules.len());
+                if let Some(advisory) = &warning.advisory {
+                    rules.push(create_rule_from_advisory(advisory, false));
+                } else {
+                    rules.push(create_rule_from_warning_kind(*warning_kind));
+                }
+            }
+
+            results.push(create_result_from_warning(
+                warning,
+                cargo_lock_path,
+                rule_indices[&rule_id],
+            ));
+        }
+    }
+
+    SarifLog {
+        schema: "https://json.schemastore.org/sarif-2.1.0.json".to_string(),
+        version: "2.1.0".to_string(),
+        runs: vec![Run {
+            tool: Tool {
+                driver: ToolComponent {
+                    name: "cargo-audit".to_string(),
+                    version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                    semantic_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                    rules,
+                },
+            },
+            results,
+            automation_details: None,
+        }],
+    }
+}
+
+fn create_rule_from_advisory(
+    metadata: &advisory::Metadata,
+    is_vulnerability: bool,
+) -> ReportingDescriptor {
+    let tags = if is_vulnerability {
+        vec!["security".to_string(), "vulnerability".to_string()]
+    } else {
+        vec!["security".to_string(), "warning".to_string()]
+    };
+
+    let security_severity = metadata
+        .cvss
+        .as_ref()
+        .map(|cvss| format!("{:.1}", cvss.score().value()));
+
+    let default_level = if is_vulnerability { "error" } else { "warning" };
+
+    ReportingDescriptor {
+        id: metadata.id.to_string(),
+        name: Some(metadata.id.to_string()),
+        short_description: Some(MultiformatMessageString {
+            text: metadata.title.clone(),
+            markdown: None,
+        }),
+        full_description: if metadata.description.is_empty() {
+            None
+        } else {
+            Some(MultiformatMessageString {
+                text: metadata.description.clone(),
+                markdown: None,
+            })
+        },
+        default_configuration: Some(ReportingConfiguration {
+            level: default_level.to_string(),
+        }),
+        help: metadata.url.as_ref().map(|url| MultiformatMessageString {
+            text: format!("For more information, see: {}", url),
+            markdown: Some(format!(
+                "For more information, see: [{}]({})",
+                metadata.id, url
+            )),
+        }),
+        properties: Some(RuleProperties {
+            tags: Some(tags),
+            precision: Some("very-high".to_string()),
+            problem_severity: if !is_vulnerability {
+                Some("warning".to_string())
+            } else {
+                None
+            },
+            security_severity,
+        }),
+    }
+}
+
+fn create_rule_from_warning_kind(kind: WarningKind) -> ReportingDescriptor {
+    let (name, description) = match kind {
+        WarningKind::Unmaintained => (
+            "unmaintained",
+            "Package is unmaintained and may have unaddressed security vulnerabilities",
+        ),
+        WarningKind::Unsound => (
+            "unsound",
+            "Package has known soundness issues that may lead to memory safety problems",
+        ),
+        WarningKind::Yanked => (
+            "yanked",
+            "Package version has been yanked from the registry",
+        ),
+        _ => ("unknown", "Unknown warning type"),
+    };
+
+    ReportingDescriptor {
+        id: name.to_string(),
+        name: Some(name.to_string()),
+        short_description: Some(MultiformatMessageString {
+            text: description.to_string(),
+            markdown: None,
+        }),
+        full_description: None,
+        default_configuration: Some(ReportingConfiguration {
+            level: "warning".to_string(),
+        }),
+        help: None,
+        properties: Some(RuleProperties {
+            tags: Some(vec!["security".to_string(), "warning".to_string()]),
+            precision: Some("high".to_string()),
+            problem_severity: Some("warning".to_string()),
+            security_severity: None,
+        }),
+    }
+}
+
+fn create_result_from_vulnerability(
+    vuln: &Vulnerability,
+    cargo_lock_path: &str,
+    rule_index: usize,
+) -> Result {
+    let fingerprint = format!(
+        "{}:{}:{}",
+        vuln.advisory.id, vuln.package.name, vuln.package.version
+    );
+
+    Result {
+        rule_id: vuln.advisory.id.to_string(),
+        rule_index: Some(rule_index),
+        message: Message {
+            text: format!(
+                "{} {} is vulnerable to {} ({})",
+                vuln.package.name, vuln.package.version, vuln.advisory.id, vuln.advisory.title
+            ),
+        },
+        level: Some("error".to_string()),
+        locations: vec![Location {
+            physical_location: PhysicalLocation {
+                artifact_location: ArtifactLocation {
+                    uri: cargo_lock_path.to_string(),
+                },
+                region: Region {
+                    start_line: 1,
+                    start_column: None,
+                    end_line: None,
+                    end_column: None,
+                },
+            },
+        }],
+        partial_fingerprints: {
+            let mut fingerprints = HashMap::new();
+            fingerprints.insert("primaryLocationLineHash".to_string(), fingerprint);
+            fingerprints
+        },
+    }
+}
+
+fn create_result_from_warning(
+    warning: &Warning,
+    cargo_lock_path: &str,
+    rule_index: usize,
+) -> Result {
+    let rule_id = if let Some(advisory) = &warning.advisory {
+        advisory.id.to_string()
+    } else {
+        format!("{:?}", warning.kind).to_lowercase()
+    };
+
+    let message_text = if let Some(advisory) = &warning.advisory {
+        format!(
+            "{} {} has a {} warning: {}",
+            warning.package.name,
+            warning.package.version,
+            warning.kind.as_str(),
+            advisory.title
+        )
+    } else {
+        format!(
+            "{} {} has a {} warning",
+            warning.package.name,
+            warning.package.version,
+            warning.kind.as_str()
+        )
+    };
+
+    let fingerprint = format!(
+        "{}:{}:{}",
+        rule_id, warning.package.name, warning.package.version
+    );
+
+    Result {
+        rule_id,
+        rule_index: Some(rule_index),
+        message: Message { text: message_text },
+        level: Some("warning".to_string()),
+        locations: vec![Location {
+            physical_location: PhysicalLocation {
+                artifact_location: ArtifactLocation {
+                    uri: cargo_lock_path.to_string(),
+                },
+                region: Region {
+                    start_line: 1,
+                    start_column: None,
+                    end_line: None,
+                    end_column: None,
+                },
+            },
+        }],
+        partial_fingerprints: {
+            let mut fingerprints = HashMap::new();
+            fingerprints.insert("primaryLocationLineHash".to_string(), fingerprint);
+            fingerprints
+        },
+    }
+}


### PR DESCRIPTION
 ## Summary

This PR adds SARIF (Static Analysis Results Interchange Format) output support to cargo-audit, enabling direct integration with GitHub Security tab and other security analysis platforms.

Fixes #1384