### PR TITLE
Enable LTO and strip symbols in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,8 @@ cvss = { path = "./cvss" }
 platforms = { path = "./platforms" }
 quitters = { path = "./quitters" }
 rustsec = { path = "./rustsec" }
+
+[profile.release]
+lto = "fat"
+strip = "symbols"
+codegen-units = 1


### PR DESCRIPTION
Comparison of binary sizes

| Binary | Size before | Size afterwards |
| ------ | ----------- | --------------- |
| cargo-audit | 21Mb | 13Mb |
| platforms-data-gen | 2.9Mb | 2.0Mb |
| platforms-table-gen | 485Kb | 369Kb |
| rustsec-admin | 22Mb | 14Mb |
