### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,7 +2987,7 @@ dependencies = [
  "thiserror",
  "toml",
  "toml_edit",
- "xml-rs",
+ "xml",
 ]
 
 [[package]]
@@ -4185,10 +4185,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
-name = "xml-rs"
-version = "0.8.27"
+name = "xml"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+checksum = "72e6e0a83ae73d886ab66fc2f82b598fbbb8f373357d5f2f9f783e50e4d06435"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ time = { version = "0.3", default-features = false }
 toml = "0.8"
 toml_edit = "0.22.6"
 url = "2"
-xml-rs = "0.8"
+xml = "1"
 
 [patch.crates-io]
 cargo-lock = { path = "./cargo-lock" }

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -29,7 +29,7 @@ termcolor = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
-xml-rs = { workspace = true }
+xml = { workspace = true }
 
 [dev-dependencies]
 abscissa_core = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
Replaces #1389. Upgrades past https://rustsec.org/advisories/RUSTSEC-2025-0055.html.