### PR TITLE
rustsec: privatize some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,6 +2976,7 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
+ "fs-err 3.1.1",
  "gix",
  "once_cell",
  "rust-embed",

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -19,6 +19,7 @@ atom_syndication = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true }
 comrak = { workspace = true }
+fs-err = { workspace = true }
 tame-index = { workspace = true, features = ["git"] }
 gix = { workspace = true, optional = true }
 rust-embed = { workspace = true }

--- a/admin/src/osv_export.rs
+++ b/admin/src/osv_export.rs
@@ -2,10 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
+use fs_err as fs;
 use rustsec::{
     Advisory, Collection,
     advisory::Informational,
-    fs,
     osv::OsvAdvisory,
     repository::git::{GitModificationTimes, GitPath, Repository},
 };

--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -118,7 +118,7 @@ impl Auditor {
                     status_ok!("Updating", "crates.io index");
                 }
 
-                let mut result = registry::CachedIndex::fetch(None, Duration::from_secs(0));
+                let mut result = registry::CachedIndex::fetch(Duration::from_secs(0));
 
                 // If the directory is locked, print a message and wait for it to become unlocked.
                 // If we don't print the message, `cargo audit` would just hang with no explanation.
@@ -129,7 +129,7 @@ impl Auditor {
                             advisory_db_path.display(),
                             DEFAULT_LOCK_TIMEOUT.as_secs()
                         );
-                        result = registry::CachedIndex::fetch(None, DEFAULT_LOCK_TIMEOUT);
+                        result = registry::CachedIndex::fetch(DEFAULT_LOCK_TIMEOUT);
                     }
                 }
 

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -70,7 +70,6 @@ allowed_external_types = [
     "fs_err",
     "platforms",
     "platforms::*",
-    "reqwest::async_impl::client::ClientBuilder",
     "semver",
     "semver::*",
     "serde::*",

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -68,7 +68,6 @@ allowed_external_types = [
     "cargo_lock::*",
     "cvss::*",
     "fs_err",
-    "gix_date::Time",
     "platforms",
     "platforms::*",
     "reqwest::async_impl::client::ClientBuilder",

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -67,7 +67,6 @@ allowed_external_types = [
     "cargo_lock",
     "cargo_lock::*",
     "cvss::*",
-    "fs_err",
     "platforms",
     "platforms::*",
     "semver",

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -76,6 +76,5 @@ allowed_external_types = [
     "semver::*",
     "serde::*",
     "time::offset_date_time::OffsetDateTime",
-    "toml::ser::Error",
     "url::Url",
 ]

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -72,8 +72,8 @@ impl CachedIndex {
     ///
     /// If `lock_timeout` is set to `std::time::Duration::from_secs(0)`, it will not wait at all,
     /// and instead return an error immediately if it fails to aquire the lock.
-    pub fn fetch(client: Option<ClientBuilder>, lock_timeout: Duration) -> Result<Self, Error> {
-        Self::fetch_inner(client, lock_timeout).map_err(Error::from_tame)
+    pub fn fetch(lock_timeout: Duration) -> Result<Self, Error> {
+        Self::fetch_inner(None, lock_timeout).map_err(Error::from_tame)
     }
 
     fn fetch_inner(

--- a/rustsec/src/error.rs
+++ b/rustsec/src/error.rs
@@ -201,9 +201,3 @@ impl Error {
         format_err!(ErrorKind::Parse, &other)
     }
 }
-
-impl From<toml::ser::Error> for Error {
-    fn from(other: toml::ser::Error) -> Self {
-        format_err!(ErrorKind::Parse, &other)
-    }
-}

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -27,7 +27,7 @@ mod cached_index;
 #[cfg_attr(docsrs, doc(cfg(feature = "git")))]
 pub mod registry {
     //! Support for interacting with the local crates.io registry index
-    pub use super::cached_index::{CachedIndex, ClientBuilder};
+    pub use super::cached_index::CachedIndex;
 }
 
 pub use cargo_lock::{self, Lockfile, SourceId, package};

--- a/rustsec/src/lib.rs
+++ b/rustsec/src/lib.rs
@@ -31,7 +31,7 @@ pub mod registry {
 }
 
 pub use cargo_lock::{self, Lockfile, SourceId, package};
-pub use fs_err as fs;
+use fs_err as fs;
 pub use platforms;
 pub use semver::{self, Version, VersionReq};
 

--- a/rustsec/src/repository/git/modification_time.rs
+++ b/rustsec/src/repository/git/modification_time.rs
@@ -8,6 +8,7 @@ use std::{
     path::PathBuf,
 };
 use tame_index::external::gix;
+use time::OffsetDateTime;
 
 use super::GitPath;
 
@@ -159,8 +160,9 @@ impl GitModificationTimes {
 
     /// Looks up the Git modification time for a given file path.
     /// The path must be relative to the root of the repository.
-    pub fn for_path(&self, path: GitPath<'_>) -> Time {
-        *self.mtimes.get(path.path()).unwrap()
+    pub fn for_path(&self, path: GitPath<'_>) -> OffsetDateTime {
+        crate::repository::git::gix_time_to_time(*self.mtimes.get(path.path()).unwrap())
+            .to_offset(time::UtcOffset::UTC)
     }
 
     /// Looks up the Git creation time for a given file path.


### PR DESCRIPTION
Try to avoid some of the worst offenders in requiring semver-incompatible bumps.