### PR TITLE
cargo-lock: bump version to 11.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "10.1.0"
+version = "11.0.0"
 dependencies = [
  "gumdrop",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ atom_syndication = "0.12"
 auditable-info = "0.10"
 auditable-serde = "0.9"
 binfarce = "0.2"
-cargo-lock = { version = "10.1.0", path = "./cargo-lock" }
+cargo-lock = { version = "11", path = "./cargo-lock" }
 chrono = { version = "0.4", default-features = false }
 clap = "4"
 comrak = { version = "0.41", default-features = false }

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "10.1.0"
+version      = "11.0.0"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"


### PR DESCRIPTION
To appease the semver checks that started failing in

- #1425 

Extracted from

- #1414