### PR TITLE
regenerate platform support for 1.92 and bump to platforms@3.7.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platforms"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "serde",
 ]

--- a/platforms/Cargo.toml
+++ b/platforms/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from the Rust compiler.
 """
-version    = "3.6.0"
+version    = "3.7.0"
 authors    = ["Tony Arcieri <bascule@gmail.com>", "Sergey \"Shnatsel\" Davidoff <shnatsel@gmail.com>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://rustsec.org"

--- a/platforms/README.md
+++ b/platforms/README.md
@@ -65,10 +65,10 @@ If we remove platforms, we will bump the minor version of this crate.
 | target triple                          | target_arch | target_os  | target_env |
 |----------------------------------------|-------------|------------|------------|
 | [aarch64-apple-darwin]                 | aarch64     | macos      |            |
+| [aarch64-pc-windows-msvc]              | aarch64     | windows    | msvc       |
 | [aarch64-unknown-linux-gnu]            | aarch64     | linux      | gnu        |
 | [i686-pc-windows-msvc]                 | x86         | windows    | msvc       |
 | [i686-unknown-linux-gnu]               | x86         | linux      | gnu        |
-| [x86_64-apple-darwin]                  | x86_64      | macos      |            |
 | [x86_64-pc-windows-gnu]                | x86_64      | windows    | gnu        |
 | [x86_64-pc-windows-msvc]               | x86_64      | windows    | msvc       |
 | [x86_64-unknown-linux-gnu]             | x86_64      | linux      | gnu        |
@@ -78,11 +78,10 @@ If we remove platforms, we will bump the minor version of this crate.
 | target triple                          | target_arch | target_os  | target_env |
 |----------------------------------------|-------------|------------|------------|
 | [aarch64-apple-ios]                    | aarch64     | ios        |            |
-| [aarch64-apple-ios-macabi]             | aarch64     | ios        |            |
-| [aarch64-apple-ios-sim]                | aarch64     | ios        |            |
+| [aarch64-apple-ios-macabi]             | aarch64     | ios        | macabi     |
+| [aarch64-apple-ios-sim]                | aarch64     | ios        | sim        |
 | [aarch64-linux-android]                | aarch64     | android    |            |
 | [aarch64-pc-windows-gnullvm]           | aarch64     | windows    | gnu        |
-| [aarch64-pc-windows-msvc]              | aarch64     | windows    | msvc       |
 | [aarch64-unknown-fuchsia]              | aarch64     | fuchsia    |            |
 | [aarch64-unknown-linux-musl]           | aarch64     | linux      | musl       |
 | [aarch64-unknown-linux-ohos]           | aarch64     | linux      | ohos       |
@@ -95,8 +94,6 @@ If we remove platforms, we will bump the minor version of this crate.
 | [arm-unknown-linux-musleabi]           | arm         | linux      | musl       |
 | [arm-unknown-linux-musleabihf]         | arm         | linux      | musl       |
 | [arm64ec-pc-windows-msvc]              | arm64ec     | windows    | msvc       |
-| [armebv7r-none-eabi]                   | arm         | none       |            |
-| [armebv7r-none-eabihf]                 | arm         | none       |            |
 | [armv5te-unknown-linux-gnueabi]        | arm         | linux      | gnu        |
 | [armv5te-unknown-linux-musleabi]       | arm         | linux      | musl       |
 | [armv7-linux-androideabi]              | arm         | android    |            |
@@ -151,9 +148,11 @@ If we remove platforms, we will bump the minor version of this crate.
 | [wasm32-wasip1]                        | wasm32      | wasi       | p1         |
 | [wasm32-wasip1-threads]                | wasm32      | wasi       | p1         |
 | [wasm32-wasip2]                        | wasm32      | wasi       | p2         |
+| [wasm32-wasip3]                        | wasm32      | wasi       | p3         |
 | [wasm32v1-none]                        | wasm32      | none       |            |
-| [x86_64-apple-ios]                     | x86_64      | ios        |            |
-| [x86_64-apple-ios-macabi]              | x86_64      | ios        |            |
+| [x86_64-apple-darwin]                  | x86_64      | macos      |            |
+| [x86_64-apple-ios]                     | x86_64      | ios        | sim        |
+| [x86_64-apple-ios-macabi]              | x86_64      | ios        | macabi     |
 | [x86_64-fortanix-unknown-sgx]          | x86_64      | unknown    | sgx        |
 | [x86_64-linux-android]                 | x86_64      | android    |            |
 | [x86_64-pc-solaris]                    | x86_64      | solaris    |            |
@@ -174,17 +173,18 @@ If we remove platforms, we will bump the minor version of this crate.
 | target triple                          | target_arch | target_os  | target_env |
 |----------------------------------------|-------------|------------|------------|
 | [aarch64-apple-tvos]                   | aarch64     | tvos       |            |
-| [aarch64-apple-tvos-sim]               | aarch64     | tvos       |            |
+| [aarch64-apple-tvos-sim]               | aarch64     | tvos       | sim        |
 | [aarch64-apple-visionos]               | aarch64     | visionos   |            |
-| [aarch64-apple-visionos-sim]           | aarch64     | visionos   |            |
+| [aarch64-apple-visionos-sim]           | aarch64     | visionos   | sim        |
 | [aarch64-apple-watchos]                | aarch64     | watchos    |            |
-| [aarch64-apple-watchos-sim]            | aarch64     | watchos    |            |
+| [aarch64-apple-watchos-sim]            | aarch64     | watchos    | sim        |
 | [aarch64-kmc-solid_asp3]               | aarch64     | solid_asp3 |            |
 | [aarch64-nintendo-switch-freestanding] | aarch64     | horizon    |            |
 | [aarch64-unknown-freebsd]              | aarch64     | freebsd    |            |
 | [aarch64-unknown-hermit]               | aarch64     | hermit     |            |
 | [aarch64-unknown-illumos]              | aarch64     | illumos    |            |
 | [aarch64-unknown-linux-gnu_ilp32]      | aarch64     | linux      | gnu        |
+| [aarch64-unknown-managarm-mlibc]       | aarch64     | managarm   | mlibc      |
 | [aarch64-unknown-netbsd]               | aarch64     | netbsd     |            |
 | [aarch64-unknown-nto-qnx700]           | aarch64     | nto        | nto70      |
 | [aarch64-unknown-nto-qnx710]           | aarch64     | nto        | nto71      |
@@ -197,15 +197,20 @@ If we remove platforms, we will bump the minor version of this crate.
 | [aarch64-unknown-trusty]               | aarch64     | trusty     |            |
 | [aarch64-uwp-windows-msvc]             | aarch64     | windows    | msvc       |
 | [aarch64-wrs-vxworks]                  | aarch64     | vxworks    | gnu        |
+| [aarch64_be-unknown-hermit]            | aarch64     | hermit     |            |
 | [aarch64_be-unknown-linux-gnu]         | aarch64     | linux      | gnu        |
 | [aarch64_be-unknown-linux-gnu_ilp32]   | aarch64     | linux      | gnu        |
+| [aarch64_be-unknown-linux-musl]        | aarch64     | linux      | musl       |
 | [aarch64_be-unknown-netbsd]            | aarch64     | netbsd     |            |
+| [aarch64_be-unknown-none-softfloat]    | aarch64     | none       |            |
 | [amdgcn-amd-amdhsa]                    | amdgpu      | amdhsa     |            |
 | [arm64_32-apple-watchos]               | aarch64     | watchos    |            |
 | [arm64e-apple-darwin]                  | aarch64     | macos      |            |
 | [arm64e-apple-ios]                     | aarch64     | ios        |            |
 | [arm64e-apple-tvos]                    | aarch64     | tvos       |            |
 | [armeb-unknown-linux-gnueabi]          | arm         | linux      | gnu        |
+| [armebv7r-none-eabi]                   | arm         | none       |            |
+| [armebv7r-none-eabihf]                 | arm         | none       |            |
 | [armv4t-none-eabi]                     | arm         | none       |            |
 | [armv4t-unknown-linux-gnueabi]         | arm         | linux      | gnu        |
 | [armv5te-none-eabi]                    | arm         | none       |            |
@@ -226,6 +231,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [armv7a-none-eabihf]                   | arm         | none       |            |
 | [armv7a-nuttx-eabi]                    | arm         | nuttx      |            |
 | [armv7a-nuttx-eabihf]                  | arm         | nuttx      |            |
+| [armv7a-vex-v5]                        | arm         | vexos      | v5         |
 | [armv7k-apple-watchos]                 | arm         | watchos    |            |
 | [armv7s-apple-ios]                     | arm         | ios        |            |
 | [armv8r-none-eabihf]                   | arm         | none       |            |
@@ -236,7 +242,7 @@ If we remove platforms, we will bump the minor version of this crate.
 | [csky-unknown-linux-gnuabiv2hf]        | csky        | linux      | gnu        |
 | [hexagon-unknown-linux-musl]           | hexagon     | linux      | musl       |
 | [hexagon-unknown-none-elf]             | hexagon     | none       |            |
-| [i386-apple-ios]                       | x86         | ios        |            |
+| [i386-apple-ios]                       | x86         | ios        | sim        |
 | [i586-unknown-netbsd]                  | x86         | netbsd     |            |
 | [i586-unknown-redox]                   | x86         | redox      | relibc     |
 | [i686-apple-darwin]                    | x86         | macos      |            |
@@ -250,6 +256,8 @@ If we remove platforms, we will bump the minor version of this crate.
 | [i686-win7-windows-gnu]                | x86         | windows    | gnu        |
 | [i686-win7-windows-msvc]               | x86         | windows    | msvc       |
 | [i686-wrs-vxworks]                     | x86         | vxworks    | gnu        |
+| [loongarch32-unknown-none]             | loongarch32 | none       |            |
+| [loongarch32-unknown-none-softfloat]   | loongarch32 | none       |            |
 | [loongarch64-unknown-linux-ohos]       | loongarch64 | linux      | ohos       |
 | [m68k-unknown-linux-gnu]               | m68k        | linux      | gnu        |
 | [m68k-unknown-none-elf]                | m68k        | none       |            |
@@ -306,9 +314,11 @@ If we remove platforms, we will bump the minor version of this crate.
 | [riscv32imc-unknown-nuttx-elf]         | riscv32     | nuttx      |            |
 | [riscv64-linux-android]                | riscv64     | android    |            |
 | [riscv64-wrs-vxworks]                  | riscv64     | vxworks    | gnu        |
+| [riscv64a23-unknown-linux-gnu]         | riscv64     | linux      | gnu        |
 | [riscv64gc-unknown-freebsd]            | riscv64     | freebsd    |            |
 | [riscv64gc-unknown-fuchsia]            | riscv64     | fuchsia    |            |
 | [riscv64gc-unknown-hermit]             | riscv64     | hermit     |            |
+| [riscv64gc-unknown-managarm-mlibc]     | riscv64     | managarm   | mlibc      |
 | [riscv64gc-unknown-netbsd]             | riscv64     | netbsd     |            |
 | [riscv64gc-unknown-nuttx-elf]          | riscv64     | nuttx      |            |
 | [riscv64gc-unknown-openbsd]            | riscv64     | openbsd    |            |
@@ -334,8 +344,8 @@ If we remove platforms, we will bump the minor version of this crate.
 | [thumbv8m.main-nuttx-eabihf]           | arm         | nuttx      |            |
 | [wasm32-wali-linux-musl]               | wasm32      | linux      | musl       |
 | [wasm64-unknown-unknown]               | wasm64      | unknown    |            |
-| [x86_64-apple-tvos]                    | x86_64      | tvos       |            |
-| [x86_64-apple-watchos-sim]             | x86_64      | watchos    |            |
+| [x86_64-apple-tvos]                    | x86_64      | tvos       | sim        |
+| [x86_64-apple-watchos-sim]             | x86_64      | watchos    | sim        |
 | [x86_64-lynx-lynxos178]                | x86_64      | lynxos178  |            |
 | [x86_64-pc-cygwin]                     | x86_64      | cygwin     |            |
 | [x86_64-pc-nto-qnx710]                 | x86_64      | nto        | nto71      |
@@ -348,6 +358,8 @@ If we remove platforms, we will bump the minor version of this crate.
 | [x86_64-unknown-hurd-gnu]              | x86_64      | hurd       | gnu        |
 | [x86_64-unknown-l4re-uclibc]           | x86_64      | l4re       | uclibc     |
 | [x86_64-unknown-linux-none]            | x86_64      | linux      |            |
+| [x86_64-unknown-managarm-mlibc]        | x86_64      | managarm   | mlibc      |
+| [x86_64-unknown-motor]                 | x86_64      | motor      |            |
 | [x86_64-unknown-openbsd]               | x86_64      | openbsd    |            |
 | [x86_64-unknown-trusty]                | x86_64      | trusty     |            |
 | [x86_64-uwp-windows-gnu]               | x86_64      | windows    | gnu        |
@@ -386,6 +398,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [aarch64-unknown-linux-gnu_ilp32]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_LINUX_GNU_ILP32.html
 [aarch64-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_LINUX_MUSL.html
 [aarch64-unknown-linux-ohos]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_LINUX_OHOS.html
+[aarch64-unknown-managarm-mlibc]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_MANAGARM_MLIBC.html
 [aarch64-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_NETBSD.html
 [aarch64-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_NONE.html
 [aarch64-unknown-none-softfloat]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_NONE_SOFTFLOAT.html
@@ -401,9 +414,12 @@ If we remove platforms, we will bump the minor version of this crate.
 [aarch64-unknown-uefi]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UNKNOWN_UEFI.html
 [aarch64-uwp-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_UWP_WINDOWS_MSVC.html
 [aarch64-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_WRS_VXWORKS.html
+[aarch64_be-unknown-hermit]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_BE_UNKNOWN_HERMIT.html
 [aarch64_be-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_BE_UNKNOWN_LINUX_GNU.html
 [aarch64_be-unknown-linux-gnu_ilp32]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_BE_UNKNOWN_LINUX_GNU_ILP32.html
+[aarch64_be-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_BE_UNKNOWN_LINUX_MUSL.html
 [aarch64_be-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_BE_UNKNOWN_NETBSD.html
+[aarch64_be-unknown-none-softfloat]: https://docs.rs/platforms/latest/platforms/platform/constant.AARCH64_BE_UNKNOWN_NONE_SOFTFLOAT.html
 [amdgcn-amd-amdhsa]: https://docs.rs/platforms/latest/platforms/platform/constant.AMDGCN_AMD_AMDHSA.html
 [arm-linux-androideabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM_LINUX_ANDROIDEABI.html
 [arm-unknown-linux-gnueabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARM_UNKNOWN_LINUX_GNUEABI.html
@@ -447,6 +463,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [armv7a-none-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7A_NONE_EABIHF.html
 [armv7a-nuttx-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7A_NUTTX_EABI.html
 [armv7a-nuttx-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7A_NUTTX_EABIHF.html
+[armv7a-vex-v5]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7A_VEX_V5.html
 [armv7k-apple-watchos]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7K_APPLE_WATCHOS.html
 [armv7r-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7R_NONE_EABI.html
 [armv7r-none-eabihf]: https://docs.rs/platforms/latest/platforms/platform/constant.ARMV7R_NONE_EABIHF.html
@@ -483,6 +500,8 @@ If we remove platforms, we will bump the minor version of this crate.
 [i686-win7-windows-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_WIN7_WINDOWS_GNU.html
 [i686-win7-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_WIN7_WINDOWS_MSVC.html
 [i686-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.I686_WRS_VXWORKS.html
+[loongarch32-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH32_UNKNOWN_NONE.html
+[loongarch32-unknown-none-softfloat]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH32_UNKNOWN_NONE_SOFTFLOAT.html
 [loongarch64-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_LINUX_GNU.html
 [loongarch64-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_LINUX_MUSL.html
 [loongarch64-unknown-linux-ohos]: https://docs.rs/platforms/latest/platforms/platform/constant.LOONGARCH64_UNKNOWN_LINUX_OHOS.html
@@ -553,11 +572,13 @@ If we remove platforms, we will bump the minor version of this crate.
 [riscv32imc-unknown-nuttx-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV32IMC_UNKNOWN_NUTTX_ELF.html
 [riscv64-linux-android]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64_LINUX_ANDROID.html
 [riscv64-wrs-vxworks]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64_WRS_VXWORKS.html
+[riscv64a23-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64A23_UNKNOWN_LINUX_GNU.html
 [riscv64gc-unknown-freebsd]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_FREEBSD.html
 [riscv64gc-unknown-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_FUCHSIA.html
 [riscv64gc-unknown-hermit]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_HERMIT.html
 [riscv64gc-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_LINUX_GNU.html
 [riscv64gc-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_LINUX_MUSL.html
+[riscv64gc-unknown-managarm-mlibc]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_MANAGARM_MLIBC.html
 [riscv64gc-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_NETBSD.html
 [riscv64gc-unknown-none-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_NONE_ELF.html
 [riscv64gc-unknown-nuttx-elf]: https://docs.rs/platforms/latest/platforms/platform/constant.RISCV64GC_UNKNOWN_NUTTX_ELF.html
@@ -601,6 +622,7 @@ If we remove platforms, we will bump the minor version of this crate.
 [wasm32-wasip1]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP1.html
 [wasm32-wasip1-threads]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP1_THREADS.html
 [wasm32-wasip2]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP2.html
+[wasm32-wasip3]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32_WASIP3.html
 [wasm32v1-none]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM32V1_NONE.html
 [wasm64-unknown-unknown]: https://docs.rs/platforms/latest/platforms/platform/constant.WASM64_UNKNOWN_UNKNOWN.html
 [x86_64-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_APPLE_DARWIN.html
@@ -633,6 +655,8 @@ If we remove platforms, we will bump the minor version of this crate.
 [x86_64-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_MUSL.html
 [x86_64-unknown-linux-none]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_NONE.html
 [x86_64-unknown-linux-ohos]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_LINUX_OHOS.html
+[x86_64-unknown-managarm-mlibc]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_MANAGARM_MLIBC.html
+[x86_64-unknown-motor]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_MOTOR.html
 [x86_64-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_NETBSD.html
 [x86_64-unknown-none]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_NONE.html
 [x86_64-unknown-openbsd]: https://docs.rs/platforms/latest/platforms/platform/constant.X86_64_UNKNOWN_OPENBSD.html

--- a/platforms/src/platform/platforms.rs
+++ b/platforms/src/platform/platforms.rs
@@ -38,6 +38,7 @@ pub(crate) const ALL: &[Platform] = &[
     AARCH64_UNKNOWN_LINUX_GNU_ILP32,
     AARCH64_UNKNOWN_LINUX_MUSL,
     AARCH64_UNKNOWN_LINUX_OHOS,
+    AARCH64_UNKNOWN_MANAGARM_MLIBC,
     AARCH64_UNKNOWN_NETBSD,
     AARCH64_UNKNOWN_NONE,
     AARCH64_UNKNOWN_NONE_SOFTFLOAT,
@@ -53,9 +54,12 @@ pub(crate) const ALL: &[Platform] = &[
     AARCH64_UNKNOWN_UEFI,
     AARCH64_UWP_WINDOWS_MSVC,
     AARCH64_WRS_VXWORKS,
+    AARCH64_BE_UNKNOWN_HERMIT,
     AARCH64_BE_UNKNOWN_LINUX_GNU,
     AARCH64_BE_UNKNOWN_LINUX_GNU_ILP32,
+    AARCH64_BE_UNKNOWN_LINUX_MUSL,
     AARCH64_BE_UNKNOWN_NETBSD,
+    AARCH64_BE_UNKNOWN_NONE_SOFTFLOAT,
     AMDGCN_AMD_AMDHSA,
     ARM_LINUX_ANDROIDEABI,
     ARM_UNKNOWN_LINUX_GNUEABI,
@@ -99,6 +103,7 @@ pub(crate) const ALL: &[Platform] = &[
     ARMV7A_NONE_EABIHF,
     ARMV7A_NUTTX_EABI,
     ARMV7A_NUTTX_EABIHF,
+    ARMV7A_VEX_V5,
     ARMV7K_APPLE_WATCHOS,
     ARMV7R_NONE_EABI,
     ARMV7R_NONE_EABIHF,
@@ -135,6 +140,8 @@ pub(crate) const ALL: &[Platform] = &[
     I686_WIN7_WINDOWS_GNU,
     I686_WIN7_WINDOWS_MSVC,
     I686_WRS_VXWORKS,
+    LOONGARCH32_UNKNOWN_NONE,
+    LOONGARCH32_UNKNOWN_NONE_SOFTFLOAT,
     LOONGARCH64_UNKNOWN_LINUX_GNU,
     LOONGARCH64_UNKNOWN_LINUX_MUSL,
     LOONGARCH64_UNKNOWN_LINUX_OHOS,
@@ -205,11 +212,13 @@ pub(crate) const ALL: &[Platform] = &[
     RISCV32IMC_UNKNOWN_NUTTX_ELF,
     RISCV64_LINUX_ANDROID,
     RISCV64_WRS_VXWORKS,
+    RISCV64A23_UNKNOWN_LINUX_GNU,
     RISCV64GC_UNKNOWN_FREEBSD,
     RISCV64GC_UNKNOWN_FUCHSIA,
     RISCV64GC_UNKNOWN_HERMIT,
     RISCV64GC_UNKNOWN_LINUX_GNU,
     RISCV64GC_UNKNOWN_LINUX_MUSL,
+    RISCV64GC_UNKNOWN_MANAGARM_MLIBC,
     RISCV64GC_UNKNOWN_NETBSD,
     RISCV64GC_UNKNOWN_NONE_ELF,
     RISCV64GC_UNKNOWN_NUTTX_ELF,
@@ -253,6 +262,7 @@ pub(crate) const ALL: &[Platform] = &[
     WASM32_WASIP1,
     WASM32_WASIP1_THREADS,
     WASM32_WASIP2,
+    WASM32_WASIP3,
     WASM32V1_NONE,
     WASM64_UNKNOWN_UNKNOWN,
     X86_64_APPLE_DARWIN,
@@ -285,6 +295,8 @@ pub(crate) const ALL: &[Platform] = &[
     X86_64_UNKNOWN_LINUX_MUSL,
     X86_64_UNKNOWN_LINUX_NONE,
     X86_64_UNKNOWN_LINUX_OHOS,
+    X86_64_UNKNOWN_MANAGARM_MLIBC,
+    X86_64_UNKNOWN_MOTOR,
     X86_64_UNKNOWN_NETBSD,
     X86_64_UNKNOWN_NONE,
     X86_64_UNKNOWN_OPENBSD,
@@ -332,7 +344,7 @@ pub(crate) const AARCH64_APPLE_IOS_MACABI: Platform = Platform {
     target_triple: "aarch64-apple-ios-macabi",
     target_arch: Arch::AArch64,
     target_os: OS::iOS,
-    target_env: Env::None,
+    target_env: Env::Macabi,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
@@ -343,7 +355,7 @@ pub(crate) const AARCH64_APPLE_IOS_SIM: Platform = Platform {
     target_triple: "aarch64-apple-ios-sim",
     target_arch: Arch::AArch64,
     target_os: OS::iOS,
-    target_env: Env::None,
+    target_env: Env::Sim,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
@@ -365,7 +377,7 @@ pub(crate) const AARCH64_APPLE_TVOS_SIM: Platform = Platform {
     target_triple: "aarch64-apple-tvos-sim",
     target_arch: Arch::AArch64,
     target_os: OS::TvOS,
-    target_env: Env::None,
+    target_env: Env::Sim,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
@@ -387,7 +399,7 @@ pub(crate) const AARCH64_APPLE_VISIONOS_SIM: Platform = Platform {
     target_triple: "aarch64-apple-visionos-sim",
     target_arch: Arch::AArch64,
     target_os: OS::VisionOS,
-    target_env: Env::None,
+    target_env: Env::Sim,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
@@ -409,7 +421,7 @@ pub(crate) const AARCH64_APPLE_WATCHOS_SIM: Platform = Platform {
     target_triple: "aarch64-apple-watchos-sim",
     target_arch: Arch::AArch64,
     target_os: OS::WatchOS,
-    target_env: Env::None,
+    target_env: Env::Sim,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
@@ -467,7 +479,7 @@ pub(crate) const AARCH64_PC_WINDOWS_MSVC: Platform = Platform {
     target_env: Env::Msvc,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::Two,
+    tier: Tier::One,
 };
 
 /// ARM64 FreeBSD
@@ -514,7 +526,7 @@ pub(crate) const AARCH64_UNKNOWN_ILLUMOS: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// ARM64 Linux (kernel 4.1, glibc 2.17+)
+/// ARM64 Linux (kernel 4.1+, glibc 2.17+)
 pub(crate) const AARCH64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "aarch64-unknown-linux-gnu",
     target_arch: Arch::AArch64,
@@ -556,6 +568,17 @@ pub(crate) const AARCH64_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
+};
+
+/// ARM64 Managarm
+pub(crate) const AARCH64_UNKNOWN_MANAGARM_MLIBC: Platform = Platform {
+    target_triple: "aarch64-unknown-managarm-mlibc",
+    target_arch: Arch::AArch64,
+    target_os: OS::Managarm,
+    target_env: Env::Mlibc,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
 };
 
 /// ARM64 NetBSD
@@ -716,6 +739,17 @@ pub(crate) const AARCH64_WRS_VXWORKS: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// ARM64 Hermit (big-endian)
+pub(crate) const AARCH64_BE_UNKNOWN_HERMIT: Platform = Platform {
+    target_triple: "aarch64_be-unknown-hermit",
+    target_arch: Arch::AArch64,
+    target_os: OS::Hermit,
+    target_env: Env::None,
+    target_endian: Endian::Big,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// ARM64 Linux (big-endian)
 pub(crate) const AARCH64_BE_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "aarch64_be-unknown-linux-gnu",
@@ -738,11 +772,33 @@ pub(crate) const AARCH64_BE_UNKNOWN_LINUX_GNU_ILP32: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// ARM64 Linux (big-endian) with musl-libc 1.2.5
+pub(crate) const AARCH64_BE_UNKNOWN_LINUX_MUSL: Platform = Platform {
+    target_triple: "aarch64_be-unknown-linux-musl",
+    target_arch: Arch::AArch64,
+    target_os: OS::Linux,
+    target_env: Env::Musl,
+    target_endian: Endian::Big,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// ARM64 NetBSD (big-endian)
 pub(crate) const AARCH64_BE_UNKNOWN_NETBSD: Platform = Platform {
     target_triple: "aarch64_be-unknown-netbsd",
     target_arch: Arch::AArch64,
     target_os: OS::NetBSD,
+    target_env: Env::None,
+    target_endian: Endian::Big,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
+/// Bare big-endian ARM64, softfloat
+pub(crate) const AARCH64_BE_UNKNOWN_NONE_SOFTFLOAT: Platform = Platform {
+    target_triple: "aarch64_be-unknown-none-softfloat",
+    target_arch: Arch::AArch64,
+    target_os: OS::None,
     target_env: Env::None,
     target_endian: Endian::Big,
     target_pointer_width: PointerWidth::U64,
@@ -771,7 +827,7 @@ pub(crate) const ARM_LINUX_ANDROIDEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Armv6 Linux (kernel 3.2, glibc 2.17)
+/// Armv6 Linux (kernel 3.2+, glibc 2.17)
 pub(crate) const ARM_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "arm-unknown-linux-gnueabi",
     target_arch: Arch::Arm,
@@ -782,7 +838,7 @@ pub(crate) const ARM_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Armv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
+/// Armv6 Linux, hardfloat (kernel 3.2+, glibc 2.17)
 pub(crate) const ARM_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "arm-unknown-linux-gnueabihf",
     target_arch: Arch::Arm,
@@ -889,7 +945,7 @@ pub(crate) const ARMEBV7R_NONE_EABI: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Big,
     target_pointer_width: PointerWidth::U32,
-    tier: Tier::Two,
+    tier: Tier::Three,
 };
 
 /// Bare Armv7-R, Big Endian, hardfloat
@@ -900,7 +956,7 @@ pub(crate) const ARMEBV7R_NONE_EABIHF: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Big,
     target_pointer_width: PointerWidth::U32,
-    tier: Tier::Two,
+    tier: Tier::Three,
 };
 
 /// Bare Armv4T
@@ -936,7 +992,7 @@ pub(crate) const ARMV5TE_NONE_EABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Armv5TE Linux (kernel 4.4, glibc 2.23)
+/// Armv5TE Linux (kernel 4.4+, glibc 2.23)
 pub(crate) const ARMV5TE_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armv5te-unknown-linux-gnueabi",
     target_arch: Arch::Arm,
@@ -1046,7 +1102,7 @@ pub(crate) const ARMV7_UNKNOWN_FREEBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// Armv7-A Linux (kernel 4.15, glibc 2.27)
+/// Armv7-A Linux (kernel 4.15+, glibc 2.27)
 pub(crate) const ARMV7_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     target_triple: "armv7-unknown-linux-gnueabi",
     target_arch: Arch::Arm,
@@ -1057,7 +1113,7 @@ pub(crate) const ARMV7_UNKNOWN_LINUX_GNUEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Armv7-A Linux, hardfloat (kernel 3.2, glibc 2.17)
+/// Armv7-A Linux, hardfloat (kernel 3.2+, glibc 2.17)
 pub(crate) const ARMV7_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "armv7-unknown-linux-gnueabihf",
     target_arch: Arch::Arm,
@@ -1221,6 +1277,17 @@ pub(crate) const ARMV7A_NUTTX_EABIHF: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// Armv7-A Cortex-A9 VEX V5 Brain, VEXos
+pub(crate) const ARMV7A_VEX_V5: Platform = Platform {
+    target_triple: "armv7a-vex-v5",
+    target_arch: Arch::Arm,
+    target_os: OS::VexOS,
+    target_env: Env::V5,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
 /// Armv7-A Apple WatchOS
 pub(crate) const ARMV7K_APPLE_WATCHOS: Platform = Platform {
     target_triple: "armv7k-apple-watchos",
@@ -1358,13 +1425,13 @@ pub(crate) const I386_APPLE_IOS: Platform = Platform {
     target_triple: "i386-apple-ios",
     target_arch: Arch::X86,
     target_os: OS::iOS,
-    target_env: Env::None,
+    target_env: Env::Sim,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U32,
     tier: Tier::Three,
 };
 
-/// 32-bit Linux (kernel 3.2, glibc 2.17, original Pentium) [^x86_32-floats-x87]
+/// 32-bit Linux (kernel 3.2+, glibc 2.17, original Pentium) [^x86_32-floats-x87]
 pub(crate) const I586_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "i586-unknown-linux-gnu",
     target_arch: Arch::X86,
@@ -1617,7 +1684,29 @@ pub(crate) const I686_WRS_VXWORKS: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// LoongArch64 Linux, LP64D ABI (kernel 5.19, glibc 2.36)
+/// LoongArch32 Bare-metal (ILP32D ABI)
+pub(crate) const LOONGARCH32_UNKNOWN_NONE: Platform = Platform {
+    target_triple: "loongarch32-unknown-none",
+    target_arch: Arch::Loongarch32,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// LoongArch32 Bare-metal (ILP32S ABI)
+pub(crate) const LOONGARCH32_UNKNOWN_NONE_SOFTFLOAT: Platform = Platform {
+    target_triple: "loongarch32-unknown-none-softfloat",
+    target_arch: Arch::Loongarch32,
+    target_os: OS::None,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Three,
+};
+
+/// LoongArch64 Linux, LP64D ABI (kernel 5.19+, glibc 2.36), LSX required
 pub(crate) const LOONGARCH64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "loongarch64-unknown-linux-gnu",
     target_arch: Arch::Loongarch64,
@@ -1628,7 +1717,7 @@ pub(crate) const LOONGARCH64_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// LoongArch64 Linux, LP64D ABI (kernel 5.19, musl 1.2.5)
+/// LoongArch64 Linux, LP64D ABI (kernel 5.19+, musl 1.2.5), LSX required
 pub(crate) const LOONGARCH64_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "loongarch64-unknown-linux-musl",
     target_arch: Arch::Loongarch64,
@@ -1958,7 +2047,7 @@ pub(crate) const POWERPC_UNKNOWN_FREEBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// PowerPC Linux (kernel 3.2, glibc 2.17)
+/// PowerPC Linux (kernel 3.2+, glibc 2.17)
 pub(crate) const POWERPC_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "powerpc-unknown-linux-gnu",
     target_arch: Arch::PowerPc,
@@ -2065,7 +2154,7 @@ pub(crate) const POWERPC64_UNKNOWN_FREEBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// PPC64 Linux (kernel 3.2, glibc 2.17)
+/// PPC64 Linux (kernel 3.2+, glibc 2.17)
 pub(crate) const POWERPC64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "powerpc64-unknown-linux-gnu",
     target_arch: Arch::PowerPc64,
@@ -2119,7 +2208,7 @@ pub(crate) const POWERPC64LE_UNKNOWN_FREEBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// PPC64LE Linux (kernel 3.10, glibc 2.17)
+/// PPC64LE Linux (kernel 3.10+, glibc 2.17)
 pub(crate) const POWERPC64LE_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "powerpc64le-unknown-linux-gnu",
     target_arch: Arch::PowerPc64,
@@ -2130,7 +2219,7 @@ pub(crate) const POWERPC64LE_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// PPC64LE Linux (kernel 4.19, musl 1.2.3)
+/// PPC64LE Linux (kernel 4.19+, musl 1.2.3)
 pub(crate) const POWERPC64LE_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "powerpc64le-unknown-linux-musl",
     target_arch: Arch::PowerPc64,
@@ -2381,6 +2470,17 @@ pub(crate) const RISCV64_WRS_VXWORKS: Platform = Platform {
     tier: Tier::Three,
 };
 
+/// RISC-V Linux (kernel 6.8.0+, glibc 2.39)
+pub(crate) const RISCV64A23_UNKNOWN_LINUX_GNU: Platform = Platform {
+    target_triple: "riscv64a23-unknown-linux-gnu",
+    target_arch: Arch::Riscv64,
+    target_os: OS::Linux,
+    target_env: Env::Gnu,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
 /// RISC-V FreeBSD
 pub(crate) const RISCV64GC_UNKNOWN_FREEBSD: Platform = Platform {
     target_triple: "riscv64gc-unknown-freebsd",
@@ -2414,7 +2514,7 @@ pub(crate) const RISCV64GC_UNKNOWN_HERMIT: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// RISC-V Linux (kernel 4.20, glibc 2.29)
+/// RISC-V Linux (kernel 4.20+, glibc 2.29)
 pub(crate) const RISCV64GC_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "riscv64gc-unknown-linux-gnu",
     target_arch: Arch::Riscv64,
@@ -2425,7 +2525,7 @@ pub(crate) const RISCV64GC_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// RISC-V Linux (kernel 4.20, musl 1.2.3)
+/// RISC-V Linux (kernel 4.20+, musl 1.2.3)
 pub(crate) const RISCV64GC_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_triple: "riscv64gc-unknown-linux-musl",
     target_arch: Arch::Riscv64,
@@ -2434,6 +2534,17 @@ pub(crate) const RISCV64GC_UNKNOWN_LINUX_MUSL: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
+};
+
+/// RISC-V Managarm
+pub(crate) const RISCV64GC_UNKNOWN_MANAGARM_MLIBC: Platform = Platform {
+    target_triple: "riscv64gc-unknown-managarm-mlibc",
+    target_arch: Arch::Riscv64,
+    target_os: OS::Managarm,
+    target_env: Env::Mlibc,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
 };
 
 /// RISC-V NetBSD
@@ -2502,7 +2613,7 @@ pub(crate) const RISCV64IMAC_UNKNOWN_NUTTX_ELF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// S390x Linux (kernel 3.2, glibc 2.17)
+/// S390x Linux (kernel 3.2+, glibc 2.17)
 pub(crate) const S390X_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "s390x-unknown-linux-gnu",
     target_arch: Arch::S390X,
@@ -2546,7 +2657,7 @@ pub(crate) const SPARC_UNKNOWN_NONE_ELF: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// SPARC Linux (kernel 4.4, glibc 2.23)
+/// SPARC Linux (kernel 4.4+, glibc 2.23)
 pub(crate) const SPARC64_UNKNOWN_LINUX_GNU: Platform = Platform {
     target_triple: "sparc64-unknown-linux-gnu",
     target_arch: Arch::Sparc64,
@@ -2753,7 +2864,7 @@ pub(crate) const THUMBV7NEON_LINUX_ANDROIDEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// Thumb2-mode Armv7-A Linux with NEON (kernel 4.4, glibc 2.23)
+/// Thumb2-mode Armv7-A Linux with NEON (kernel 4.4+, glibc 2.23)
 pub(crate) const THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "thumbv7neon-unknown-linux-gnueabihf",
     target_arch: Arch::Arm,
@@ -2907,6 +3018,17 @@ pub(crate) const WASM32_WASIP2: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// WebAssembly with WASIp3
+pub(crate) const WASM32_WASIP3: Platform = Platform {
+    target_triple: "wasm32-wasip3",
+    target_arch: Arch::Wasm32,
+    target_os: OS::Wasi,
+    target_env: Env::P3,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U32,
+    tier: Tier::Two,
+};
+
 /// WebAssembly limited to 1.0 features and no imports
 pub(crate) const WASM32V1_NONE: Platform = Platform {
     target_triple: "wasm32v1-none",
@@ -2937,7 +3059,7 @@ pub(crate) const X86_64_APPLE_DARWIN: Platform = Platform {
     target_env: Env::None,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
-    tier: Tier::One,
+    tier: Tier::Two,
 };
 
 /// 64-bit x86 iOS
@@ -2945,7 +3067,7 @@ pub(crate) const X86_64_APPLE_IOS: Platform = Platform {
     target_triple: "x86_64-apple-ios",
     target_arch: Arch::X86_64,
     target_os: OS::iOS,
-    target_env: Env::None,
+    target_env: Env::Sim,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
@@ -2956,7 +3078,7 @@ pub(crate) const X86_64_APPLE_IOS_MACABI: Platform = Platform {
     target_triple: "x86_64-apple-ios-macabi",
     target_arch: Arch::X86_64,
     target_os: OS::iOS,
-    target_env: Env::None,
+    target_env: Env::Macabi,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
@@ -2967,7 +3089,7 @@ pub(crate) const X86_64_APPLE_TVOS: Platform = Platform {
     target_triple: "x86_64-apple-tvos",
     target_arch: Arch::X86_64,
     target_os: OS::TvOS,
-    target_env: Env::None,
+    target_env: Env::Sim,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
@@ -2978,7 +3100,7 @@ pub(crate) const X86_64_APPLE_WATCHOS_SIM: Platform = Platform {
     target_triple: "x86_64-apple-watchos-sim",
     target_arch: Arch::X86_64,
     target_os: OS::WatchOS,
-    target_env: Env::None,
+    target_env: Env::Sim,
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Three,
@@ -3210,7 +3332,7 @@ pub(crate) const X86_64_UNKNOWN_LINUX_GNU: Platform = Platform {
     tier: Tier::One,
 };
 
-/// 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
+/// 64-bit Linux (x32 ABI) (kernel 4.15+, glibc 2.27)
 pub(crate) const X86_64_UNKNOWN_LINUX_GNUX32: Platform = Platform {
     target_triple: "x86_64-unknown-linux-gnux32",
     target_arch: Arch::X86_64,
@@ -3252,6 +3374,28 @@ pub(crate) const X86_64_UNKNOWN_LINUX_OHOS: Platform = Platform {
     target_endian: Endian::Little,
     target_pointer_width: PointerWidth::U64,
     tier: Tier::Two,
+};
+
+/// x86_64 Managarm
+pub(crate) const X86_64_UNKNOWN_MANAGARM_MLIBC: Platform = Platform {
+    target_triple: "x86_64-unknown-managarm-mlibc",
+    target_arch: Arch::X86_64,
+    target_os: OS::Managarm,
+    target_env: Env::Mlibc,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
+};
+
+/// x86_64 Motor OS
+pub(crate) const X86_64_UNKNOWN_MOTOR: Platform = Platform {
+    target_triple: "x86_64-unknown-motor",
+    target_arch: Arch::X86_64,
+    target_os: OS::Motor,
+    target_env: Env::None,
+    target_endian: Endian::Little,
+    target_pointer_width: PointerWidth::U64,
+    tier: Tier::Three,
 };
 
 /// NetBSD/amd64

--- a/platforms/src/target/arch.rs
+++ b/platforms/src/target/arch.rs
@@ -34,6 +34,9 @@ pub enum Arch {
     /// `hexagon`
     Hexagon,
 
+    /// `loongarch32`
+    Loongarch32,
+
     /// `loongarch64`
     Loongarch64,
 
@@ -107,6 +110,7 @@ impl Arch {
             Arch::Bpf => "bpf",
             Arch::Csky => "csky",
             Arch::Hexagon => "hexagon",
+            Arch::Loongarch32 => "loongarch32",
             Arch::Loongarch64 => "loongarch64",
             Arch::M68k => "m68k",
             Arch::Mips => "mips",
@@ -145,6 +149,7 @@ impl FromStr for Arch {
             "bpf" => Arch::Bpf,
             "csky" => Arch::Csky,
             "hexagon" => Arch::Hexagon,
+            "loongarch32" => Arch::Loongarch32,
             "loongarch64" => Arch::Loongarch64,
             "m68k" => Arch::M68k,
             "mips" => Arch::Mips,

--- a/platforms/src/target/env.rs
+++ b/platforms/src/target/env.rs
@@ -20,6 +20,12 @@ pub enum Env {
     /// `gnu`: The GNU C Library (glibc)
     Gnu,
 
+    /// `macabi`
+    Macabi,
+
+    /// `mlibc`
+    Mlibc,
+
     /// `msvc`: Microsoft Visual C(++)
     Msvc,
 
@@ -50,14 +56,23 @@ pub enum Env {
     /// `p2`
     P2,
 
+    /// `p3`
+    P3,
+
     /// `relibc`
     Relibc,
 
     /// `sgx`: Intel Software Guard Extensions (SGX) Enclave
     Sgx,
 
+    /// `sim`
+    Sim,
+
     /// `uclibc`: C library for developing embedded Linux systems
     UClibc,
+
+    /// `v5`
+    V5,
 }
 
 impl Env {
@@ -66,6 +81,8 @@ impl Env {
         match self {
             Env::None => "",
             Env::Gnu => "gnu",
+            Env::Macabi => "macabi",
+            Env::Mlibc => "mlibc",
             Env::Msvc => "msvc",
             Env::Musl => "musl",
             Env::Newlib => "newlib",
@@ -76,9 +93,12 @@ impl Env {
             Env::OhOS => "ohos",
             Env::P1 => "p1",
             Env::P2 => "p2",
+            Env::P3 => "p3",
             Env::Relibc => "relibc",
             Env::Sgx => "sgx",
+            Env::Sim => "sim",
             Env::UClibc => "uclibc",
+            Env::V5 => "v5",
         }
     }
 }
@@ -91,6 +111,8 @@ impl FromStr for Env {
         let result = match name {
             "" => Env::None,
             "gnu" => Env::Gnu,
+            "macabi" => Env::Macabi,
+            "mlibc" => Env::Mlibc,
             "msvc" => Env::Msvc,
             "musl" => Env::Musl,
             "newlib" => Env::Newlib,
@@ -101,9 +123,12 @@ impl FromStr for Env {
             "ohos" => Env::OhOS,
             "p1" => Env::P1,
             "p2" => Env::P2,
+            "p3" => Env::P3,
             "relibc" => Env::Relibc,
             "sgx" => Env::Sgx,
+            "sim" => Env::Sim,
             "uclibc" => Env::UClibc,
+            "v5" => Env::V5,
             _ => return Err(Error),
         };
 

--- a/platforms/src/target/os.rs
+++ b/platforms/src/target/os.rs
@@ -74,6 +74,12 @@ pub enum OS {
     /// `macos`: Apple's Mac OS X
     MacOS,
 
+    /// `managarm`
+    Managarm,
+
+    /// `motor`
+    Motor,
+
     /// `netbsd`: The NetBSD operating system
     NetBSD,
 
@@ -121,6 +127,9 @@ pub enum OS {
 
     /// `unknown`
     Unknown,
+
+    /// `vexos`
+    VexOS,
 
     /// `visionos`
     VisionOS,
@@ -171,6 +180,8 @@ impl OS {
             OS::Linux => "linux",
             OS::Lynxos178 => "lynxos178",
             OS::MacOS => "macos",
+            OS::Managarm => "managarm",
+            OS::Motor => "motor",
             OS::NetBSD => "netbsd",
             OS::None => "none",
             OS::Nto => "nto",
@@ -187,6 +198,7 @@ impl OS {
             OS::TvOS => "tvos",
             OS::Uefi => "uefi",
             OS::Unknown => "unknown",
+            OS::VexOS => "vexos",
             OS::VisionOS => "visionos",
             OS::Vita => "vita",
             OS::VxWorks => "vxworks",
@@ -225,6 +237,8 @@ impl FromStr for OS {
             "linux" => OS::Linux,
             "lynxos178" => OS::Lynxos178,
             "macos" => OS::MacOS,
+            "managarm" => OS::Managarm,
+            "motor" => OS::Motor,
             "netbsd" => OS::NetBSD,
             "none" => OS::None,
             "nto" => OS::Nto,
@@ -241,6 +255,7 @@ impl FromStr for OS {
             "tvos" => OS::TvOS,
             "uefi" => OS::Uefi,
             "unknown" => OS::Unknown,
+            "vexos" => OS::VexOS,
             "visionos" => OS::VisionOS,
             "vita" => OS::Vita,
             "vxworks" => OS::VxWorks,


### PR DESCRIPTION
To update platform support for Rust 1.92, added more supported platform by running the `regenerate-platforms-crate.sh`

Bumped to platforms@3.7