### PR TITLE
admin: limit assigner PR title length

### DIFF
--- a/admin/src/assigner.rs
+++ b/admin/src/assigner.rs
@@ -87,9 +87,19 @@ pub fn assign_ids(repo_path: &Path, output_mode: OutputMode) {
         );
     }
 
-    if output_mode == OutputMode::GithubAction {
-        println!("Assigned {}", assignments.join(", "));
+    if output_mode != OutputMode::GithubAction {
+        return;
     }
+
+    let mut title = format!("Assigned {}", assignments.join(", "));
+    let mut dropped = 0;
+    while title.len() > 255 {
+        dropped += 1;
+        let new = title.rsplit_once(", ").unwrap().0;
+        title = format!("{new} and {dropped} more");
+    }
+
+    println!("{title}");
 }
 
 ///Assign ids to files with placeholder IDs within the directory defined by dir_path


### PR DESCRIPTION
After merging

- https://github.com/rustsec/advisory-db/pull/2424

advisory-db CI [failed to assign IDs](https://github.com/rustsec/advisory-db/actions/runs/18663720173):

```
Attempting creation of pull request
  Error: Validation Failed: {"resource":"Issue","code":"custom","field":"title","message":"title is too long (maximum is 256 characters)"} - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
```

Here, we chop off the end of the title until its length gets under the allowed character limit.