### PR TITLE
ci: ratchet down permissions, address other potential weaknesses

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,12 @@ updates:
   - dependency-name: toml
     versions:
     - 0.5.8
+  cooldown:
+    default-days: 7
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,5 +1,7 @@
 name: admin
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -23,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,5 +1,7 @@
 name: cargo-audit
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -23,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
@@ -44,6 +48,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -58,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: 1.85.0
@@ -70,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable

--- a/.github/workflows/cargo-lock.yml
+++ b/.github/workflows/cargo-lock.yml
@@ -1,5 +1,7 @@
 name: cargo-lock
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -27,6 +29,8 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
@@ -44,6 +48,8 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
@@ -57,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable

--- a/.github/workflows/cvss.yml
+++ b/.github/workflows/cvss.yml
@@ -1,5 +1,7 @@
 name: cvss
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -27,6 +29,8 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
@@ -44,6 +48,8 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
@@ -58,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -1,5 +1,7 @@
 name: platforms
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -27,6 +29,8 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: ${{ matrix.rust }}
@@ -42,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable

--- a/.github/workflows/quitters.yml
+++ b/.github/workflows/quitters.yml
@@ -1,5 +1,7 @@
 name: quitters
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -27,6 +29,8 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: ${{ matrix.rust }}
@@ -39,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -19,6 +21,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: write # to create releases
     strategy:
       matrix:
         name:
@@ -64,16 +68,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
           # The tag to build or the tag received by the tag event
           ref: ${{ github.event.inputs.version || github.ref }}
+          lookup-only: true
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+          lookup-only: true
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
         with:
           toolchain: stable
@@ -94,23 +102,23 @@ jobs:
           ext=""
           [[ "${{ matrix.name }}" == windows-* ]] && ext=".exe"
           bin="../target/${{ matrix.target }}/release/cargo-audit${ext}"
-          version=$(echo "${{ github.ref }}" | cut -d/ -f4)
+          version=$(echo "${GITHUB_REF}" | cut -d/ -f4)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           mkdir "$dst"
           mv "$bin" "$dst/"
           mv README.md CHANGELOG.md LICENSE-APACHE LICENSE-MIT "$dst/"
       - name: Archive (tar)
-        if: '! startsWith(matrix.name, ''windows-'')'
+        if: "! startsWith(matrix.name, 'windows-')"
         shell: bash
         run: |
-          version=$(echo "${{ github.ref }}" | cut -d/ -f4)
+          version=$(echo "${GITHUB_REF}" | cut -d/ -f4)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           tar cavf "../$dst.tgz" "$dst"
       - name: Archive (zip)
         if: startsWith(matrix.name, 'windows-')
         shell: bash
         run: |
-          version=$(echo "${{ github.ref }}" | cut -d/ -f4)
+          version=$(echo "${GITHUB_REF}" | cut -d/ -f4)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           7z a "../$dst.zip" "$dst"
       - uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090

--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -1,5 +1,7 @@
 name: rustsec
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -30,6 +32,8 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: ${{ matrix.rust }}
@@ -45,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: 1.85.0 # MSRV

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,4 +1,7 @@
 name: Security Audit
+
+permissions: {}
+
 on:
   pull_request:
     paths: Cargo.lock
@@ -6,13 +9,15 @@ on:
     branches: main
     paths: Cargo.lock
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -1,7 +1,9 @@
 name: Workspace
 
+permissions: {}
+
 on:
-  pull_request: { }
+  pull_request: {}
   push:
     branches: main
 
@@ -10,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable
@@ -23,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: 1.85.0
@@ -42,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable


### PR DESCRIPTION
This is like https://github.com/rustsec/advisory-db/pull/2444.

Key changes:

* Fully pins all action references, and adds matching version comments. Dependabot will keep both updated.
* Added `cooldown` configurations to all Dependabot updaters, to reduce the risk of opportunistic supply-chain attacks.
* Drop all default permissions as much as possible -- all workflows now have `permissions: {}`, and jobs only declare broader permissions if they need them (currently just the release job, to create the release itself).
* All checkouts include `persist-credentials: false`, to prevent the runtime credential from being unnecessarily persisted to disk.
* The release workflow now uses no caching, to reduce the risk of cache poisoning influencing public build products.
* Fixes a small number of template injections by replacing `${{ github.ref }}` with `${GITHUB_REF}`.

All told, this makes [zizmor](https://docs.zizmor.sh) pass entirely cleanly for non-pedantic audits (there are plenty of pedantic findings that could be addressed as well, but they're less significant). I'm happy to add a [workflow](https://docs.zizmor.sh/integrations/#github-actions) for continuous integration of zizmor as well to prevent regressions, but I figured I'd hold off on adding that until this meets your approval 🙂 

(Note: the pins I've introduced can be cross-checked for honesty with a tool like [pinact](https://github.com/suzuki-shunsuke/pinact) or [gha-update](https://github.com/davidism/gha-update).)

Signed-off-by: William Woodruff <william@yossarian.net>