### PR TITLE
feat: support for CVSSv2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "cvss"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cargo-lock = { version = "11", path = "./cargo-lock" }
 chrono = { version = "0.4", default-features = false }
 clap = "4"
 comrak = { version = "0.53", default-features = false }
-cvss = { version = "2.2", path = "./cvss" }
+cvss = { version = "3.0", path = "./cvss" }
 display-error-chain = "0.2.0"
 fs-err = "3"
 gix = { version = "0.85", default-features = false, features = ["sha1"] }

--- a/cvss/Cargo.toml
+++ b/cvss/Cargo.toml
@@ -14,7 +14,8 @@ rust-version = "1.85"
 serde = { workspace = true, optional = true }
 
 [features]
-default = ["std", "v3", "v4"]
+default = ["std", "v2", "v3", "v4"]
+v2 = []
 v3 = []
 v4 = []
 std = []

--- a/cvss/Cargo.toml
+++ b/cvss/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name         = "cvss"
 description  = "Common Vulnerability Scoring System parser/serializer"
-version      = "2.2.0"
+version      = "3.0.0"
 license      = "Apache-2.0 OR MIT"
 repository   = "https://github.com/rustsec/rustsec"
 readme       = "README.md"
 categories   = ["parser-implementations"]
-keywords     = ["cvssv3", "cvssv4", "security", "advisory", "vulnerability"]
+keywords     = ["cvssv2", "cvssv3", "cvssv4", "security", "advisory", "vulnerability"]
 edition      = "2024"
 rust-version = "1.85"
 

--- a/cvss/src/cvss.rs
+++ b/cvss/src/cvss.rs
@@ -7,6 +7,8 @@ use core::fmt;
 #[cfg(feature = "std")]
 use crate::Severity;
 use crate::error::{Error, Result};
+#[cfg(feature = "v2")]
+use crate::v2;
 #[cfg(feature = "v3")]
 use crate::v3;
 #[cfg(feature = "v4")]
@@ -26,6 +28,9 @@ const PREFIX: &str = "CVSS";
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[non_exhaustive]
 pub enum Cvss {
+    #[cfg(feature = "v2")]
+    /// A CVSS 2.0 base vector
+    CvssV20(v2::Vector),
     #[cfg(feature = "v3")]
     /// A CVSS 3.0 base vector
     CvssV30(v3::Base),
@@ -45,6 +50,8 @@ impl Cvss {
     #[cfg(feature = "std")]
     pub fn score(&self) -> f64 {
         match self {
+            #[cfg(feature = "v2")]
+            Self::CvssV20(base) => base.score().value(),
             #[cfg(feature = "v3")]
             Self::CvssV30(base) => base.score().value(),
             #[cfg(feature = "v3")]
@@ -58,6 +65,8 @@ impl Cvss {
     #[cfg(feature = "std")]
     pub fn severity(&self) -> Severity {
         match self {
+            #[cfg(feature = "v2")]
+            Self::CvssV20(base) => base.score().severity(),
             #[cfg(feature = "v3")]
             Self::CvssV30(base) => base.score().severity(),
             #[cfg(feature = "v3")]
@@ -70,6 +79,8 @@ impl Cvss {
     /// Get an iterator over all defined metrics
     pub fn metrics(&self) -> Box<dyn Iterator<Item = (MetricType, &dyn fmt::Debug)> + '_> {
         match self {
+            #[cfg(feature = "v2")]
+            Self::CvssV20(base) => Box::new(base.metrics().map(|(m, v)| (MetricType::V2(m), v))),
             #[cfg(feature = "v3")]
             Self::CvssV30(base) => Box::new(base.metrics().map(|(m, v)| (MetricType::V3(m), v))),
             #[cfg(feature = "v3")]
@@ -116,12 +127,17 @@ impl FromStr for Cvss {
         let (prefix, version) = id.split_once(':').ok_or_else(|| Error::InvalidComponent {
             component: id.to_owned(),
         })?;
-        let (major_version, minor_version) =
-            version
-                .split_once('.')
-                .ok_or_else(|| Error::InvalidComponent {
-                    component: id.to_owned(),
-                })?;
+
+        let Some((major_version, minor_version)) = version.split_once('.') else {
+            // CVSS v2.0 vectors have no "CVSS:x.y/" prefix at all, so a
+            // missing dotted version is the signal to try v2 instead.
+            #[cfg(feature = "v2")]
+            return v2::Vector::from_str(s).map(Self::CvssV20);
+            #[cfg(not(feature = "v2"))]
+            return Err(Error::InvalidComponent {
+                component: id.to_owned(),
+            });
+        };
 
         match (prefix, major_version, minor_version) {
             #[cfg(feature = "v3")]
@@ -143,6 +159,8 @@ impl FromStr for Cvss {
 impl fmt::Display for Cvss {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "v2")]
+            Self::CvssV20(base) => write!(f, "{}", base),
             #[cfg(feature = "v3")]
             Self::CvssV30(base) => write!(f, "{}", base),
             #[cfg(feature = "v3")]
@@ -157,6 +175,9 @@ impl fmt::Display for Cvss {
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MetricType {
+    /// V2 metric type
+    #[cfg(feature = "v2")]
+    V2(v2::MetricType),
     /// V3 metric type
     #[cfg(feature = "v3")]
     V3(v3::MetricType),
@@ -169,6 +190,8 @@ impl MetricType {
     /// Get the name of this metric (i.e. acronym)
     pub fn name(self) -> &'static str {
         match self {
+            #[cfg(feature = "v2")]
+            Self::V2(m) => m.name(),
             #[cfg(feature = "v3")]
             Self::V3(m) => m.name(),
             #[cfg(feature = "v4")]
@@ -179,6 +202,8 @@ impl MetricType {
     /// Get a description of this metric.
     pub fn description(self) -> &'static str {
         match self {
+            #[cfg(feature = "v2")]
+            Self::V2(m) => m.description(),
             #[cfg(feature = "v3")]
             Self::V3(m) => m.description(),
             #[cfg(feature = "v4")]

--- a/cvss/src/error.rs
+++ b/cvss/src/error.rs
@@ -6,6 +6,9 @@ use crate::v4;
 use alloc::string::String;
 use core::fmt;
 
+#[cfg(feature = "v2")]
+use crate::v2;
+
 /// Result type with the `cvss` crate's [`Error`] type.
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -26,6 +29,30 @@ pub enum Error {
 
         /// The value that was provided which is invalid.
         value: String,
+    },
+
+    #[cfg(feature = "v2")]
+    /// Invalid metric for CVSS 2.0
+    InvalidMetricV2 {
+        /// The metric that was invalid.
+        metric_type: v2::MetricType,
+
+        /// The value that was provided which is invalid.
+        value: String,
+    },
+
+    #[cfg(feature = "v2")]
+    /// Metric is duplicated for CVSS v2.0.
+    DuplicateMetricV2 {
+        /// Prefix which is doubled.
+        metric_type: v2::MetricType,
+    },
+
+    #[cfg(feature = "v2")]
+    /// Missing metric for CVSS v2.0.
+    MissingMandatoryMetricV2 {
+        /// Metric which is missing.
+        metric_type: v2::MetricType,
     },
 
     #[cfg(feature = "v4")]
@@ -97,6 +124,34 @@ impl fmt::Display for Error {
                     metric_type.name(),
                     metric_type.description(),
                     value
+                )
+            }
+            #[cfg(feature = "v2")]
+            Self::InvalidMetricV2 { metric_type, value } => {
+                write!(
+                    f,
+                    "invalid CVSSv2 {} ({}) metric: `{}`",
+                    metric_type.name(),
+                    metric_type.description(),
+                    value
+                )
+            }
+            #[cfg(feature = "v2")]
+            Self::DuplicateMetricV2 { metric_type } => {
+                write!(
+                    f,
+                    "duplicate CVSSv2 {} ({}) metric",
+                    metric_type.name(),
+                    metric_type.description(),
+                )
+            }
+            #[cfg(feature = "v2")]
+            Self::MissingMandatoryMetricV2 { metric_type } => {
+                write!(
+                    f,
+                    "missing mandatory CVSSv2 {} ({}) metric",
+                    metric_type.name(),
+                    metric_type.description(),
                 )
             }
             #[cfg(feature = "v4")]

--- a/cvss/src/lib.rs
+++ b/cvss/src/lib.rs
@@ -20,6 +20,7 @@
 //!
 //! Serde support is available through the optional `serde` Cargo feature.
 //!
+//! [CVSS v2.0 Specification]: https://www.first.org/cvss/v2/guide
 //! [CVSS v3.1 Specification]: https://www.first.org/cvss/v3.1/specification-document
 //! [CVSS v4.0 Specification]: https://www.first.org/cvss/v4.0/specification-document
 
@@ -30,12 +31,14 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "v2")]
+pub mod v2;
 // A part of the v3 API is exposed even without the feature for compatibility.
 pub mod v3;
 #[cfg(feature = "v4")]
 pub mod v4;
 
-#[cfg(any(feature = "v3", feature = "v4"))]
+#[cfg(any(feature = "v2", feature = "v3", feature = "v4"))]
 pub mod cvss;
 mod error;
 mod severity;
@@ -43,7 +46,7 @@ mod severity;
 // For compatibility
 pub use crate::v3::metric::{Metric, MetricType};
 
-#[cfg(any(feature = "v3", feature = "v4"))]
+#[cfg(any(feature = "v2", feature = "v3", feature = "v4"))]
 pub use crate::cvss::Cvss;
 
 pub use crate::{

--- a/cvss/src/v2.rs
+++ b/cvss/src/v2.rs
@@ -1,0 +1,10 @@
+//! Common Vulnerability Scoring System (v2.0)
+//!
+//! <https://www.first.org/cvss/v2/guide>
+
+pub mod metric;
+
+mod score;
+mod vector;
+
+pub use self::{metric::Metric, metric::MetricType, score::Score, vector::Vector};

--- a/cvss/src/v2/metric.rs
+++ b/cvss/src/v2/metric.rs
@@ -1,0 +1,165 @@
+//! CVSS v2.0 metrics.
+
+pub mod base;
+pub mod environmental;
+pub mod temporal;
+
+use alloc::borrow::ToOwned;
+use core::{
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
+
+use crate::{Error, Result};
+
+/// Trait for CVSS v2.0 metrics.
+pub trait Metric: Copy + Clone + Debug + Display + Eq + FromStr + Ord {
+    /// Get the name of this metric.
+    fn name() -> &'static str {
+        Self::TYPE.name()
+    }
+
+    /// Get CVSS v2.0 score for this metric.
+    fn score(self) -> f64;
+
+    /// Get `str` describing this metric's value
+    fn as_str(self) -> &'static str;
+
+    /// [`MetricType`] of this metric.
+    const TYPE: MetricType;
+}
+
+/// Enum over all of the available v3.1 metrics.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum MetricType {
+    /// Availability Impact (A)
+    A,
+
+    /// Access Complexity (AC)
+    AC,
+
+    /// Access Vector (AV)
+    AV,
+
+    /// Authentication (Au)
+    Au,
+
+    /// Confidentiality Impact (C)
+    C,
+
+    /// Integrity Impact (I)
+    I,
+
+    /// Exploitability (E)
+    E,
+
+    /// Remediation Level (RL)
+    RL,
+
+    /// Report Confidence (RC)
+    RC,
+
+    /// Collateral Damage Potential (CDP)
+    CDP,
+
+    /// Target Distribution (TD)
+    TD,
+
+    /// Confidentiality Requirement (CR)
+    CR,
+
+    /// Integrity Requirement (IR)
+    IR,
+
+    /// Availability Requirement (AR)   
+    AR,
+}
+
+impl MetricType {
+    /// Get the name of this metric (i.e. acronym)
+    pub fn name(self) -> &'static str {
+        match self {
+            // Base Metrics
+            Self::A => "A",
+            Self::AC => "AC",
+            Self::Au => "Au",
+            Self::AV => "AV",
+            Self::C => "C",
+            Self::I => "I",
+
+            // Temporal Metrics
+            Self::E => "E",
+            Self::RL => "RL",
+            Self::RC => "RC",
+
+            // Environmental Metrics
+            Self::CDP => "CDP",
+            Self::TD => "TD",
+            Self::CR => "CR",
+            Self::IR => "IR",
+            Self::AR => "AR",
+        }
+    }
+
+    /// Get a description of this metric.
+    pub fn description(self) -> &'static str {
+        match self {
+            // Base Metrics
+            Self::A => "Availability Impact",
+            Self::AC => "Access Complexity",
+            Self::Au => "Authentication",
+            Self::AV => "Access Vector",
+            Self::C => "Confidentiality Impact",
+            Self::I => "Integrity Impact",
+
+            // Temporal Metrics
+            Self::E => "Exploitability",
+            Self::RL => "Remediation Level",
+            Self::RC => "Report Confidence",
+
+            // Environmental Metrics
+            Self::CDP => "Collateral Damage Potential",
+            Self::TD => "Target Distribution",
+            Self::CR => "Confidentiality Requirement",
+            Self::IR => "Integrity Requirement",
+            Self::AR => "Availability Requirement",
+        }
+    }
+}
+
+impl Display for MetricType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl FromStr for MetricType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            // Base Metrics
+            "A" => Ok(Self::A),
+            "AC" => Ok(Self::AC),
+            "Au" => Ok(Self::Au),
+            "AV" => Ok(Self::AV),
+            "C" => Ok(Self::C),
+            "I" => Ok(Self::I),
+
+            // Temporal Metrics
+            "E" => Ok(Self::E),
+            "RL" => Ok(Self::RL),
+            "RC" => Ok(Self::RC),
+
+            // Environmental Metrics
+            "CDP" => Ok(Self::CDP),
+            "TD" => Ok(Self::TD),
+            "CR" => Ok(Self::CR),
+            "IR" => Ok(Self::IR),
+            "AR" => Ok(Self::AR),
+
+            _ => Err(Error::UnknownMetric { name: s.to_owned() }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/base.rs
+++ b/cvss/src/v2/metric/base.rs
@@ -1,0 +1,19 @@
+//! CVSS 2.0 Base Metric Group
+
+mod a;
+pub use a::AvailabilityImpact;
+
+mod ac;
+pub use self::ac::AccessComplexity;
+
+mod au;
+pub use self::au::Authentication;
+
+mod av;
+pub use self::av::AccessVector;
+
+mod c;
+pub use self::c::ConfidentialityImpact;
+
+mod i;
+pub use self::i::IntegrityImpact;

--- a/cvss/src/v2/metric/base/a.rs
+++ b/cvss/src/v2/metric/base/a.rs
@@ -1,0 +1,78 @@
+//! CVSS v2.0 Base Metric Group - Availability Impact (C)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Availability Impact (C) - CVSS v2.0 Base Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.1.6:
+/// <https://www.first.org/cvss/v2/guide#2-1-6-Availability-Impact-A>
+///
+/// > This metric measures the impact to availability of a successfully
+/// > exploited vulnerability. Availability refers to the accessibility of
+/// > information resources. Attacks that consume network bandwidth, processor
+/// > cycles, or disk space all impact the availability of a system. The
+/// > possible values for this metric are listed in Table 6. Increased
+/// > availability impact increases the vulnerability score.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum AvailabilityImpact {
+    /// None (N)
+    /// > There is no impact to the availability of the system.
+    None,
+
+    /// Partial (P)
+    /// > There is reduced performance or interruptions in resource
+    /// > availability. An example is a network-based flood attack that permits
+    /// > a limited number of successful connections to an Internet service.
+    Partial,
+
+    /// Complete (C)
+    /// > There is a total shutdown of the affected resource. The attacker can
+    /// > render the resource completely unavailable.
+    Complete,
+}
+
+impl Metric for AvailabilityImpact {
+    fn score(self) -> f64 {
+        match self {
+            Self::None => 0.0,
+            Self::Partial => 0.275,
+            Self::Complete => 0.660,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "N",
+            Self::Partial => "P",
+            Self::Complete => "C",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::A;
+}
+
+impl fmt::Display for AvailabilityImpact {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for AvailabilityImpact {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "N" => Ok(Self::None),
+            "P" => Ok(Self::Partial),
+            "C" => Ok(Self::Complete),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/base/ac.rs
+++ b/cvss/src/v2/metric/base/ac.rs
@@ -1,0 +1,112 @@
+//! CVSS v2.0 Base Metric Group - Access Complexity (AC)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Access Complexity (AC) - CVSS v2.0 Base Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.1.2:
+/// <https://www.first.org/cvss/v2/guide#2-1-2-Access-Complexity-AC>
+///
+/// > This metric measures the complexity of the attack required to exploit the
+/// > vulnerability once an attacker has gained access to the target system. For
+/// > example, consider a buffer overflow in an Internet service: once the
+/// > target system is located, the attacker can launch an exploit at will.
+/// >
+/// > Other vulnerabilities, however, may require additional steps in order to
+/// > be exploited. For example, a vulnerability in an email client is only
+/// > exploited after the user downloads and opens a tainted attachment. The
+/// > possible values for this metric are listed in Table 2. The lower the
+/// > required complexity, the higher the vulnerability score.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum AccessComplexity {
+    /// High (H)
+    ///
+    /// > Specialized access conditions exist. For example:
+    /// > - In most configurations, the attacking party must already have elevated
+    /// >   privileges or spoof additional systems in addition to the attacking
+    /// >   system (e.g., DNS hijacking).
+    /// > - The attack depends on social engineering methods that would be easily
+    /// >   detected by knowledgeable people. For example, the victim must perform
+    /// >   several suspicious or atypical actions.
+    /// > - The vulnerable configuration is seen very rarely in practice.
+    /// > - If a race condition exists, the window is very narrow.
+    High,
+
+    /// Medium (M)
+    ///
+    /// > The access conditions are somewhat specialized; the following are
+    /// > examples:
+    /// > - The attacking party is limited to a group of systems or users at
+    /// >   some level of authorization, possibly untrusted.
+    /// > - Some information must be gathered before a successful attack can be
+    /// >   launched.
+    /// > - The affected configuration is non-default, and is not commonly
+    /// >   configured (e.g., a vulnerability present when a server performs
+    /// >   user account authentication via a specific scheme, but not present
+    /// >   for another authentication scheme).
+    /// > - The attack requires a small amount of social engineering that might
+    /// >   occasionally fool cautious users (e.g., phishing attacks that modify
+    /// >   a web browsers status bar to show a false link, having to be on
+    /// >   someones buddy list before sending an IM exploit).
+    Medium,
+
+    /// Low (L)
+    ///
+    /// > Specialized access conditions or extenuating circumstances do not
+    /// > exist. The following are examples:
+    /// > - The affected product typically requires access to a wide range of
+    /// >   systems and users, possibly anonymous and untrusted (e.g.,
+    /// >   Internet-facing web or mail server).
+    /// > - The affected configuration is default or ubiquitous.
+    /// > - The attack can be performed manually and requires little skill or
+    /// >   additional information gathering.
+    /// > - The race condition is a lazy one (i.e., it is technically a race but
+    /// >   easily winnable).
+    Low,
+}
+
+impl Metric for AccessComplexity {
+    fn score(self) -> f64 {
+        match self {
+            Self::High => 0.35,
+            Self::Medium => 0.61,
+            Self::Low => 0.71,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::High => "H",
+            Self::Medium => "M",
+            Self::Low => "L",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::AC;
+}
+
+impl fmt::Display for AccessComplexity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for AccessComplexity {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "H" => Ok(Self::High),
+            "M" => Ok(Self::Medium),
+            "L" => Ok(Self::Low),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/base/au.rs
+++ b/cvss/src/v2/metric/base/au.rs
@@ -1,0 +1,81 @@
+//! CVSS v2.0 Base Metric Group - Authentication (Au)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Authentication (Au) - CVSS v2.0 Base Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.1.3:
+/// <https://www.first.org/cvss/v2/guide#2-1-3-Authentication-Au>
+///
+/// > This metric measures the number of times an attacker must authenticate to
+/// > a target in order to exploit a vulnerability. This metric does not gauge
+/// > the strength or complexity of the authentication process, only that an
+/// > attacker is required to provide credentials before an exploit may occur.
+/// > The possible values for this metric are listed in Table 3. The fewer
+/// > authentication instances that are required, the higher the vulnerability
+/// > score.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Authentication {
+    /// Multiple (M)
+    /// > Exploiting the vulnerability requires that the attacker authenticate
+    /// > two or more times, even if the same credentials are used each time. An
+    /// > example is an attacker authenticating to an operating system in
+    /// > addition to providing credentials to access an application hosted on
+    /// > that system.
+    Multiple,
+
+    /// Single (S)
+    /// > The vulnerability requires an attacker to be logged into the system
+    /// > (such as at a command line or via a desktop session or web interface).
+    Single,
+
+    /// None (N)
+    /// > Authentication is not required to exploit the vulnerability.
+    None,
+}
+
+impl Metric for Authentication {
+    fn score(self) -> f64 {
+        match self {
+            Self::Multiple => 0.45,
+            Self::Single => 0.56,
+            Self::None => 0.704,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Multiple => "M",
+            Self::Single => "S",
+            Self::None => "N",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::Au;
+}
+
+impl fmt::Display for Authentication {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for Authentication {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "M" => Ok(Self::Multiple),
+            "S" => Ok(Self::Single),
+            "N" => Ok(Self::None),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/base/av.rs
+++ b/cvss/src/v2/metric/base/av.rs
@@ -1,0 +1,86 @@
+//! CVSS v2.0 Base Metric Group - Access Vector (AV)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Access Vector (AV) - CVSS v2.0 Base Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.1.1:
+/// <https://www.first.org/cvss/v2/guide#2-1-1-Access-Vector-AV>
+///
+/// > This metric reflects how the vulnerability is exploited. The possible
+/// > values for this metric are listed in Table 1. The more remote an attacker
+/// > can be to attack a host, the greater the vulnerability score.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum AccessVector {
+    /// Local (L)
+    ///
+    /// > A vulnerability exploitable with only local access requires the
+    /// > attacker to have either physical access to the vulnerable system or a
+    /// > local (shell) account. Examples of locally exploitable vulnerabilities
+    /// > are peripheral attacks such as Firewire/USB DMA attacks, and local
+    /// > privilege escalations (e.g., sudo).
+    Local,
+
+    /// AdjacentNetwork (A)
+    ///
+    /// > A vulnerability exploitable with adjacent network access requires the
+    /// > attacker to have access to either the broadcast or collision domain of
+    /// > the vulnerable software.  Examples of local networks include local IP
+    /// > subnet, Bluetooth, IEEE 802.11, and local Ethernet segment.
+    AdjacentNetwork,
+
+    /// Network (N)
+    ///
+    /// > A vulnerability exploitable with network access means the vulnerable
+    /// > software is bound to the network stack and the attacker does not
+    /// > require local network access or local access. Such a vulnerability is
+    /// > often termed "remotely exploitable". An example of a network attack is
+    /// > an RPC buffer overflow.
+    Network,
+}
+
+impl Metric for AccessVector {
+    fn score(self) -> f64 {
+        match self {
+            Self::Local => 0.395,
+            Self::AdjacentNetwork => 0.646,
+            Self::Network => 1.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "L",
+            Self::AdjacentNetwork => "A",
+            Self::Network => "N",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::AV;
+}
+
+impl fmt::Display for AccessVector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for AccessVector {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "L" => Ok(Self::Local),
+            "A" => Ok(Self::AdjacentNetwork),
+            "N" => Ok(Self::Network),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/base/c.rs
+++ b/cvss/src/v2/metric/base/c.rs
@@ -1,0 +1,80 @@
+//! CVSS v2.0 Base Metric Group - Confidentiality Impact (C)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Confidentiality Impact (C) - CVSS v2.0 Base Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.1.4:
+/// <https://www.first.org/cvss/v2/guide#2-1-4-Confidentiality-Impact-C>
+///
+/// > This metric measures the impact on confidentiality of a successfully
+/// > exploited vulnerability. Confidentiality refers to limiting information
+/// > access and disclosure to only authorized users, as well as preventing
+/// > access by, or disclosure to, unauthorized ones. The possible values for
+/// > this metric are listed in Table 4. Increased confidentiality impact
+/// > increases the vulnerability score.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum ConfidentialityImpact {
+    /// None (N)
+    /// > There is no impact to the confidentiality of the system.
+    None,
+
+    /// Partial (P)
+    /// > There is considerable informational disclosure. Access to some system
+    /// > files is possible, but the attacker does not have control over what is
+    /// > obtained, or the scope of the loss is constrained. An example is a
+    /// > vulnerability that divulges only certain tables in a database.
+    Partial,
+
+    /// Complete (C)
+    /// > There is total information disclosure, resulting in all system files
+    /// > being revealed. The attacker is able to read all of the system's data
+    /// > (memory, files, etc.)
+    Complete,
+}
+
+impl Metric for ConfidentialityImpact {
+    fn score(self) -> f64 {
+        match self {
+            Self::None => 0.0,
+            Self::Partial => 0.275,
+            Self::Complete => 0.660,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "N",
+            Self::Partial => "P",
+            Self::Complete => "C",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::C;
+}
+
+impl fmt::Display for ConfidentialityImpact {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for ConfidentialityImpact {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "N" => Ok(Self::None),
+            "P" => Ok(Self::Partial),
+            "C" => Ok(Self::Complete),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/base/i.rs
+++ b/cvss/src/v2/metric/base/i.rs
@@ -1,0 +1,81 @@
+//! CVSS v2.0 Base Metric Group - Integrity Impact (C)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Integrity Impact (C) - CVSS v2.0 Base Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.1.5:
+/// <https://www.first.org/cvss/v2/guide#2-1-5-Integrity-Impact-I>
+///
+/// > This metric measures the impact to integrity of a successfully exploited
+/// > vulnerability. Integrity refers to the trustworthiness and guaranteed
+/// > veracity of information. The possible values for this metric are listed in
+/// > Table 5. Increased integrity impact increases the vulnerability score.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum IntegrityImpact {
+    /// None (N)
+    /// > There is no impact to the integrity of the system.
+    None,
+
+    /// Partial (P)
+    /// > Modification of some system files or information is possible, but the
+    /// > attacker does not have control over what can be modified, or the scope
+    /// > of what the attacker can affect is limited. For example, system or
+    /// > application files may be overwritten or modified, but either the
+    /// > attacker has no control over which files are affected or the attacker
+    /// > can modify files within only a limited context or scope.
+    Partial,
+
+    /// Complete (C)
+    /// > There is a total compromise of system integrity. There is a complete
+    /// > loss of system protection, resulting in the entire system being
+    /// > compromised. The attacker is able to modify any files on the target
+    /// > system.
+    Complete,
+}
+
+impl Metric for IntegrityImpact {
+    fn score(self) -> f64 {
+        match self {
+            Self::None => 0.0,
+            Self::Partial => 0.275,
+            Self::Complete => 0.660,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "N",
+            Self::Partial => "P",
+            Self::Complete => "C",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::I;
+}
+
+impl fmt::Display for IntegrityImpact {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for IntegrityImpact {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "N" => Ok(Self::None),
+            "P" => Ok(Self::Partial),
+            "C" => Ok(Self::Complete),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/environmental.rs
+++ b/cvss/src/v2/metric/environmental.rs
@@ -1,0 +1,16 @@
+//! CVSS 2.0 Environmental Metric Group
+
+mod ar;
+pub use ar::AvailabilityRequirement;
+
+mod cdp;
+pub use cdp::CollateralDamagePotential;
+
+mod cr;
+pub use cr::ConfidentialityRequirement;
+
+mod ir;
+pub use ir::IntegrityRequirement;
+
+mod td;
+pub use td::TargetDistribution;

--- a/cvss/src/v2/metric/environmental/ar.rs
+++ b/cvss/src/v2/metric/environmental/ar.rs
@@ -1,0 +1,86 @@
+//! CVSS v2.0 Environmental Metric - Availability Requirement (AR)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Availability Requirement (AR) - CVSS v2.0 Environmental Metric
+///
+/// Described in CVSS v2.0 Specification: Section 2.3.3:
+/// <https://www.first.org/cvss/v2/guide#2-3-3-Security-Requirements-CR-IR-AR>
+///
+/// > These metrics enable the analyst to customize the CVSS score depending on
+/// > the importance of the affected IT asset to a users organization, measured
+/// > in terms of confidentiality, integrity, and availability.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum AvailabilityRequirement {
+    /// Low (L)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > only a limited adverse effect on the organization or individuals
+    /// > associated with the organization (e.g., employees, customers).
+    Low,
+
+    /// Medium (M)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > a serious adverse effect on the organization or individuals associated
+    /// > with the organization (e.g., employees, customers).
+    Medium,
+
+    /// High (H)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > a catastrophic adverse effect on the organization or individuals
+    /// > associated with the organization (e.g., employees, customers).
+    High,
+
+    /// Not Defined (ND)
+    /// > Assigning this value to the metric will not influence the score. It is
+    /// > a signal to the equation to skip this metric.
+    NotDefined,
+}
+
+impl Metric for AvailabilityRequirement {
+    fn score(self) -> f64 {
+        match self {
+            Self::Low => 0.5,
+            Self::Medium => 1.0,
+            Self::High => 1.51,
+            Self::NotDefined => 1.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "L",
+            Self::Medium => "M",
+            Self::High => "H",
+            Self::NotDefined => "ND",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::AR;
+}
+
+impl fmt::Display for AvailabilityRequirement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for AvailabilityRequirement {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "L" => Ok(Self::Low),
+            "M" => Ok(Self::Medium),
+            "H" => Ok(Self::High),
+            "ND" => Ok(Self::NotDefined),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/environmental/cdp.rs
+++ b/cvss/src/v2/metric/environmental/cdp.rs
@@ -1,0 +1,103 @@
+//! CVSS v2.0 Environmental Metric - Collateral Damage Potential (CDP)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Collateral Damage Potential (CDP) - CVSS v2.0 Environmental Metric
+///
+/// Described in CVSS v2.0 Specification: Section 2.3.1:
+/// <https://www.first.org/cvss/v2/guide#2-3-1-Collateral-Damage-Potential-CDP>
+///
+/// > This metric measures the potential for loss of life or physical assets
+/// > through damage or theft of property or equipment.  The metric may also
+/// > measure economic loss of productivity or revenue.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum CollateralDamagePotential {
+    /// None (N)
+    /// > There is no potential for loss of life, physical assets, productivity
+    /// > or revenue.
+    None,
+
+    /// Low (L)
+    /// > A successful exploit of this vulnerability may result in slight
+    /// > physical or property damage. Or, there may be a slight loss of revenue
+    /// > or productivity to the organization.
+    Low,
+
+    /// Low-Medium (LM)
+    /// > A successful exploit of this vulnerability may result in moderate
+    /// > physical or property damage. Or, there may be a moderate loss of
+    /// > revenue or productivity to the organization.
+    LowMedium,
+
+    /// Medium-High (MH)
+    /// > A successful exploit of this vulnerability may result in significant
+    /// > physical or property damage or loss. Or, there may be a significant
+    /// > loss of revenue or productivity.
+    MediumHigh,
+
+    /// High (H)
+    /// > A successful exploit of this vulnerability may result in catastrophic
+    /// > physical or property damage and loss. Or, there may be a catastrophic
+    /// > loss of revenue or productivity.
+    High,
+
+    /// Not Defined (ND)
+    /// > Assigning this value to the metric will not influence the score. It is
+    /// > a signal to the equation to skip this metric.
+    NotDefined,
+}
+
+impl Metric for CollateralDamagePotential {
+    fn score(self) -> f64 {
+        match self {
+            Self::None => 0.0,
+            Self::Low => 0.1,
+            Self::LowMedium => 0.3,
+            Self::MediumHigh => 0.4,
+            Self::High => 0.5,
+            Self::NotDefined => 0.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "N",
+            Self::Low => "L",
+            Self::LowMedium => "LM",
+            Self::MediumHigh => "MH",
+            Self::High => "H",
+            Self::NotDefined => "ND",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::CDP;
+}
+
+impl fmt::Display for CollateralDamagePotential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for CollateralDamagePotential {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "N" => Ok(Self::None),
+            "L" => Ok(Self::Low),
+            "LM" => Ok(Self::LowMedium),
+            "MH" => Ok(Self::MediumHigh),
+            "H" => Ok(Self::High),
+            "ND" => Ok(Self::NotDefined),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/environmental/cr.rs
+++ b/cvss/src/v2/metric/environmental/cr.rs
@@ -1,0 +1,86 @@
+//! CVSS v2.0 Environmental Metric - Confidentiality Requirement (CR)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Confidentiality Requirement (CR) - CVSS v2.0 Environmental Metric
+///
+/// Described in CVSS v2.0 Specification: Section 2.3.3:
+/// <https://www.first.org/cvss/v2/guide#2-3-3-Security-Requirements-CR-IR-AR>
+///
+/// > These metrics enable the analyst to customize the CVSS score depending on
+/// > the importance of the affected IT asset to a users organization, measured
+/// > in terms of confidentiality, integrity, and availability.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum ConfidentialityRequirement {
+    /// Low (L)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > only a limited adverse effect on the organization or individuals
+    /// > associated with the organization (e.g., employees, customers).
+    Low,
+
+    /// Medium (M)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > a serious adverse effect on the organization or individuals associated
+    /// > with the organization (e.g., employees, customers).
+    Medium,
+
+    /// High (H)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > a catastrophic adverse effect on the organization or individuals
+    /// > associated with the organization (e.g., employees, customers).
+    High,
+
+    /// Not Defined (ND)
+    /// > Assigning this value to the metric will not influence the score. It is
+    /// > a signal to the equation to skip this metric.
+    NotDefined,
+}
+
+impl Metric for ConfidentialityRequirement {
+    fn score(self) -> f64 {
+        match self {
+            Self::Low => 0.5,
+            Self::Medium => 1.0,
+            Self::High => 1.51,
+            Self::NotDefined => 1.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "L",
+            Self::Medium => "M",
+            Self::High => "H",
+            Self::NotDefined => "ND",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::CR;
+}
+
+impl fmt::Display for ConfidentialityRequirement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for ConfidentialityRequirement {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "L" => Ok(Self::Low),
+            "M" => Ok(Self::Medium),
+            "H" => Ok(Self::High),
+            "ND" => Ok(Self::NotDefined),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/environmental/ir.rs
+++ b/cvss/src/v2/metric/environmental/ir.rs
@@ -1,0 +1,86 @@
+//! CVSS v2.0 Environmental Metric - Integrity Requirement (IR)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Integrity Requirement (IR) - CVSS v2.0 Environmental Metric
+///
+/// Described in CVSS v2.0 Specification: Section 2.3.3:
+/// <https://www.first.org/cvss/v2/guide#2-3-3-Security-Requirements-CR-IR-AR>
+///
+/// > These metrics enable the analyst to customize the CVSS score depending on
+/// > the importance of the affected IT asset to a users organization, measured
+/// > in terms of confidentiality, integrity, and availability.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum IntegrityRequirement {
+    /// Low (L)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > only a limited adverse effect on the organization or individuals
+    /// > associated with the organization (e.g., employees, customers).
+    Low,
+
+    /// Medium (M)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > a serious adverse effect on the organization or individuals associated
+    /// > with the organization (e.g., employees, customers).
+    Medium,
+
+    /// High (H)
+    /// > Loss of [confidentiality / integrity / availability] is likely to have
+    /// > a catastrophic adverse effect on the organization or individuals
+    /// > associated with the organization (e.g., employees, customers).
+    High,
+
+    /// Not Defined (ND)
+    /// > Assigning this value to the metric will not influence the score. It is
+    /// > a signal to the equation to skip this metric.
+    NotDefined,
+}
+
+impl Metric for IntegrityRequirement {
+    fn score(self) -> f64 {
+        match self {
+            Self::Low => 0.5,
+            Self::Medium => 1.0,
+            Self::High => 1.51,
+            Self::NotDefined => 1.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "L",
+            Self::Medium => "M",
+            Self::High => "H",
+            Self::NotDefined => "ND",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::IR;
+}
+
+impl fmt::Display for IntegrityRequirement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for IntegrityRequirement {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "L" => Ok(Self::Low),
+            "M" => Ok(Self::Medium),
+            "H" => Ok(Self::High),
+            "ND" => Ok(Self::NotDefined),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/environmental/td.rs
+++ b/cvss/src/v2/metric/environmental/td.rs
@@ -1,0 +1,90 @@
+//! CVSS v2.0 Environmental Metric - Target Distribution (TD)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Target Distribution (TD) - CVSS v2.0 Environmental Metric
+///
+/// Described in CVSS v2.0 Specification: Section 2.3.2:
+/// <https://www.first.org/cvss/v2/guide#2-3-2-Target-Distribution-TD>
+///
+/// > This metric measures the proportion of vulnerable systems. It is meant as
+/// > an environment-specific indicator in order to approximate the percentage
+/// > of systems that could be affected by the vulnerability.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum TargetDistribution {
+    /// None (N)
+    /// > No target systems exist, or targets are so highly specialized that they only exist in a laboratory setting. Effectively 0% of the environment is at risk.
+    None,
+
+    /// Low (L)
+    /// > Targets exist inside the environment, but on a small scale. Between 1%
+    /// > - 25% of the total environment is at risk.
+    Low,
+
+    /// Medium (M)
+    /// > Targets exist inside the environment, but on a medium scale. Between
+    /// > 26% - 75% of the total environment is at risk.
+    Medium,
+
+    /// High (H)
+    /// > Targets exist inside the environment on a considerable scale. Between
+    /// > 76% - 100% of the total environment is considered at risk.
+    High,
+
+    /// Not Defined (ND)
+    /// > Assigning this value to the metric will not influence the score. It is
+    /// > a signal to the equation to skip this metric.
+    NotDefined,
+}
+
+impl Metric for TargetDistribution {
+    fn score(self) -> f64 {
+        match self {
+            Self::None => 0.0,
+            Self::Low => 0.25,
+            Self::Medium => 0.75,
+            Self::High => 1.0,
+            Self::NotDefined => 1.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "N",
+            Self::Low => "L",
+            Self::Medium => "M",
+            Self::High => "H",
+            Self::NotDefined => "ND",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::TD;
+}
+
+impl fmt::Display for TargetDistribution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for TargetDistribution {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "N" => Ok(Self::None),
+            "L" => Ok(Self::Low),
+            "M" => Ok(Self::Medium),
+            "H" => Ok(Self::High),
+            "ND" => Ok(Self::NotDefined),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/temporal.rs
+++ b/cvss/src/v2/metric/temporal.rs
@@ -1,0 +1,10 @@
+//! CVSS 2.0 Temporal Metric Group
+
+mod e;
+pub use e::Exploitability;
+
+mod rc;
+pub use rc::ReportConfidence;
+
+mod rl;
+pub use rl::RemediationLevel;

--- a/cvss/src/v2/metric/temporal/e.rs
+++ b/cvss/src/v2/metric/temporal/e.rs
@@ -1,0 +1,96 @@
+//! CVSS v2.0 Temporal Metric - Exploitability (E)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Exploitability (E) - CVSS v2.0 Temporal Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.2.1:
+/// <https://www.first.org/cvss/v2/guide#2-2-1-Exploitability-E>
+///
+/// > This metric measures the current state of exploit techniques or code
+/// > availability. Public availability of easy-to-use exploit code increases
+/// > the number of potential attackers by including those who are unskilled,
+/// > thereby increasing the severity of the vulnerability.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Exploitability {
+    /// Unproven (U)
+    /// > No exploit code is available, or an exploit is entirely theoretical.
+    Unproven,
+
+    /// Proof-of-Concept (POC)
+    /// > Proof-of-concept exploit code or an attack demonstration that is not
+    /// > practical for most systems is available. The code or technique is not
+    /// > functional in all situations and may require substantial modification
+    /// > by a skilled attacker.
+    ProofOfConcept,
+
+    /// Functional (F)
+    /// > Functional exploit code is available. The code works in most
+    /// > situations where the vulnerability exists.
+    Functional,
+
+    /// High (H)
+    /// > Either the vulnerability is exploitable by functional mobile
+    /// > autonomous code, or no exploit is required (manual trigger) and
+    /// > details are widely available. The code works in every situation, or is
+    /// > actively being delivered via a mobile autonomous agent (such as a worm
+    /// > or virus).
+    High,
+
+    /// Not Defined (ND)
+    /// > Assigning this value to the metric will not influence the score. It is
+    /// > a signal to the equation to skip this metric.
+    NotDefined,
+}
+
+impl Metric for Exploitability {
+    fn score(self) -> f64 {
+        match self {
+            Self::Unproven => 0.85,
+            Self::ProofOfConcept => 0.9,
+            Self::Functional => 0.95,
+            Self::High => 1.0,
+            Self::NotDefined => 1.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Unproven => "U",
+            Self::ProofOfConcept => "POC",
+            Self::Functional => "F",
+            Self::High => "H",
+            Self::NotDefined => "ND",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::E;
+}
+
+impl fmt::Display for Exploitability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for Exploitability {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "U" => Ok(Self::Unproven),
+            "POC" => Ok(Self::ProofOfConcept),
+            "F" => Ok(Self::Functional),
+            "H" => Ok(Self::High),
+            "ND" => Ok(Self::NotDefined),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/temporal/rc.rs
+++ b/cvss/src/v2/metric/temporal/rc.rs
@@ -1,0 +1,88 @@
+//! CVSS v2.0 Temporal Metric - Report Confidence (RC)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Report Confidence (RC) - CVSS v2.0 Temporal Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.2.3:
+/// <https://www.first.org/cvss/v2/guide#2-2-3-Report-Confidence-RC>
+///
+/// > This metric measures the degree of confidence in the existence of the
+/// > vulnerability and the credibility of the known technical details.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum ReportConfidence {
+    /// Unconfirmed (UC)
+    /// > There is a single unconfirmed source or possibly multiple conflicting
+    /// > reports. There is little confidence in the validity of the reports. An
+    /// > example is a rumor that surfaces from the hacker underground.
+    Unconfirmed,
+
+    /// Uncorroborated (UR)
+    /// > There are multiple non-official sources, possibly including
+    /// > independent security companies or research organizations. At this
+    /// > point there may be conflicting technical details or some other
+    /// > lingering ambiguity.
+    Uncorroborated,
+
+    /// Confirmed (C)
+    /// > The vulnerability has been acknowledged by the vendor or author of the
+    /// > affected technology. The vulnerability may also be Confirmed when its
+    /// > existence is confirmed from an external event such as publication of
+    /// > functional or proof-of-concept exploit code or widespread
+    /// > exploitation.
+    Confirmed,
+
+    /// Not Defined (ND)
+    /// > Assigning this value to the metric will not influence the score. It is
+    /// > a signal to the equation to skip this metric.
+    NotDefined,
+}
+
+impl Metric for ReportConfidence {
+    fn score(self) -> f64 {
+        match self {
+            Self::Unconfirmed => 0.90,
+            Self::Uncorroborated => 0.95,
+            Self::Confirmed => 1.0,
+            Self::NotDefined => 1.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Unconfirmed => "UC",
+            Self::Uncorroborated => "UR",
+            Self::Confirmed => "C",
+            Self::NotDefined => "ND",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::RC;
+}
+
+impl fmt::Display for ReportConfidence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for ReportConfidence {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "UC" => Ok(Self::Unconfirmed),
+            "UR" => Ok(Self::Uncorroborated),
+            "C" => Ok(Self::Confirmed),
+            "ND" => Ok(Self::NotDefined),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/metric/temporal/rl.rs
+++ b/cvss/src/v2/metric/temporal/rl.rs
@@ -1,0 +1,92 @@
+//! CVSS v2.0 Temporal Metric - Remediation Level (RL)
+
+use alloc::borrow::ToOwned;
+use core::{fmt, str::FromStr};
+
+use crate::Error;
+use crate::v2::{Metric, MetricType};
+
+/// Remediation Level (RL) - CVSS v2.0 Temporal Metric Group
+///
+/// Described in CVSS v2.0 Specification: Section 2.2.2:
+/// <https://www.first.org/cvss/v2/guide#2-2-2-Remediation-Level-RL>
+///
+/// > The remediation level of a vulnerability is an important factor for
+/// > prioritization. The typical vulnerability is unpatched when initially
+/// > published.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum RemediationLevel {
+    /// Official Fix (OF)
+    /// > A complete vendor solution is available. Either the vendor has issued
+    /// > an official patch, or an upgrade is available.
+    OfficialFix,
+
+    /// Temporary Fix (TF)
+    /// > There is an official but temporary fix available. This includes
+    /// > instances where the vendor issues a temporary hotfix, tool, or
+    /// > workaround.
+    TemporaryFix,
+
+    /// Workaround (W)
+    /// > There is an unofficial, non-vendor solution available. In some cases,
+    /// > users of the affected technology will create a patch of their own or
+    /// > provide steps to work around or otherwise mitigate the vulnerability.
+    Workaround,
+
+    //// Unavailable (U)
+    /// > There is either no solution available or it is impossible to apply.
+    Unavailable,
+
+    /// Not Defined (ND)
+    /// > Assigning this value to the metric will not influence the score. It is
+    /// > a signal to the equation to skip this metric.
+    NotDefined,
+}
+
+impl Metric for RemediationLevel {
+    fn score(self) -> f64 {
+        match self {
+            Self::OfficialFix => 0.87,
+            Self::TemporaryFix => 0.90,
+            Self::Workaround => 0.95,
+            Self::Unavailable => 1.0,
+            Self::NotDefined => 1.0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::OfficialFix => "OF",
+            Self::TemporaryFix => "TF",
+            Self::Workaround => "W",
+            Self::Unavailable => "U",
+            Self::NotDefined => "ND",
+        }
+    }
+
+    const TYPE: MetricType = MetricType::RL;
+}
+
+impl fmt::Display for RemediationLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", Self::name(), self.as_str())
+    }
+}
+
+impl FromStr for RemediationLevel {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "OF" => Ok(Self::OfficialFix),
+            "TF" => Ok(Self::TemporaryFix),
+            "W" => Ok(Self::Workaround),
+            "U" => Ok(Self::Unavailable),
+            "ND" => Ok(Self::NotDefined),
+            _ => Err(Error::InvalidMetricV2 {
+                metric_type: Self::TYPE,
+                value: s.to_owned(),
+            }),
+        }
+    }
+}

--- a/cvss/src/v2/score.rs
+++ b/cvss/src/v2/score.rs
@@ -1,0 +1,61 @@
+//! CVSS v2.0 scores
+
+use crate::severity::Severity;
+
+/// CVSS V2.0 scores.
+///
+/// Formula described in CVSS v2.0 Specification: Section 3.2:
+/// <https://www.first.org/cvss/v2/guide#3-2-Equations>
+#[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
+pub struct Score(f64);
+
+impl Score {
+    /// Create a new score object
+    pub fn new(score: f64) -> Self {
+        Self(score)
+    }
+
+    /// Get the score as a floating point value
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    /// Round the score up to 1 decimal (`round_to_1_decimal`)
+    #[cfg(feature = "std")]
+    pub fn roundup(self) -> Self {
+        let rounded = (self.0 * 10.0).round() / 10.0;
+        Self(rounded)
+    }
+
+    /// Convert the numeric score into a `Severity`
+    ///
+    /// CVSS v2.0 does not explictly define the severity levels, therefore the
+    /// definition of NIST is used.
+    pub fn severity(self) -> Severity {
+        if self.0 < 4.0 {
+            Severity::Low
+        } else if self.0 < 7.0 {
+            Severity::Medium
+        } else {
+            Severity::High
+        }
+    }
+}
+
+impl From<f64> for Score {
+    fn from(score: f64) -> Self {
+        Self(score)
+    }
+}
+
+impl From<Score> for f64 {
+    fn from(score: Score) -> Self {
+        score.value()
+    }
+}
+
+impl From<Score> for Severity {
+    fn from(score: Score) -> Self {
+        score.severity()
+    }
+}

--- a/cvss/src/v2/vector.rs
+++ b/cvss/src/v2/vector.rs
@@ -1,0 +1,496 @@
+//! CVSS v2.0 vector and score calculations
+
+#[cfg(feature = "serde")]
+use alloc::string::{String, ToString};
+use alloc::{borrow::ToOwned, vec::Vec};
+use core::fmt;
+use core::str::FromStr;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize, de, ser};
+
+use crate::{
+    Error, Result,
+    v2::{
+        Metric, MetricType, Score,
+        metric::{
+            base::{
+                AccessComplexity, AccessVector, Authentication, AvailabilityImpact,
+                ConfidentialityImpact, IntegrityImpact,
+            },
+            environmental::{
+                AvailabilityRequirement, CollateralDamagePotential, ConfidentialityRequirement,
+                IntegrityRequirement, TargetDistribution,
+            },
+            temporal::{Exploitability, RemediationLevel, ReportConfidence},
+        },
+    },
+};
+
+/// CVSS v2.0 Vector
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Vector {
+    /// Access Vector (AV)
+    pub av: Option<AccessVector>,
+
+    /// Access Complexity (AC)
+    pub ac: Option<AccessComplexity>,
+
+    /// Authentication (Au)
+    pub au: Option<Authentication>,
+
+    /// Confidentiality Impact (C)
+    pub c: Option<ConfidentialityImpact>,
+
+    /// Integrity Impact (I)
+    pub i: Option<IntegrityImpact>,
+
+    /// Availability Impact (A)
+    pub a: Option<AvailabilityImpact>,
+
+    /// Exploitability (E)
+    pub e: Option<Exploitability>,
+
+    /// Remediation Level (RL)
+    pub rl: Option<RemediationLevel>,
+
+    /// Report Confidence (RC)
+    pub rc: Option<ReportConfidence>,
+
+    /// Collateral Damage Potential (CDP)
+    pub cdp: Option<CollateralDamagePotential>,
+
+    /// Target Distribution (TD)
+    pub td: Option<TargetDistribution>,
+
+    /// Confidentiality Requirement (CR)
+    pub cr: Option<ConfidentialityRequirement>,
+
+    /// Integrity Requirement (IR)
+    pub ir: Option<IntegrityRequirement>,
+
+    /// Availability Requirement (AR)
+    pub ar: Option<AvailabilityRequirement>,
+}
+
+impl Vector {
+    /// Calculate Base CVSS score: overall value for determining the severity
+    /// of a vulnerability, generally referred to as the "CVSS score".
+    ///
+    /// Described in CVSS v2.0 Specification: Section 3.2.1:
+    /// <https://www.first.org/cvss/v2/guide#3-2-1-Base-Equation>
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub fn score(&self) -> Score {
+        self.base_score_internal(self.impact())
+    }
+
+    /// Internal calculation of Base CVSS that takes impact as parameter.
+    ///
+    /// This is primarily needed in environmental score calculation where the
+    /// impact is adjusted. Rounded to 1 decimal, per the CVSS v2.0 spec's
+    /// definition of `BaseScore` (Section 3.2.1).
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub(crate) fn base_score_internal(&self, impact: Score) -> Score {
+        let exploitability = self.exploitability();
+        let f_impact = if impact.value() == 0.0 { 0.0 } else { 1.176 };
+
+        let score = ((0.6 * impact.value()) + (0.4 * exploitability.value()) - 1.5) * f_impact;
+        Score::new(score).roundup()
+    }
+
+    /// Calculate Base Exploitability score: sub-score for measuring
+    /// ease of exploitation.
+    ///
+    /// Described in CVSS v2.0 Specification: Section 3.2.1:
+    /// <https://www.first.org/cvss/v2/guide#3-2-1-Base-Equation>
+    pub fn exploitability(&self) -> Score {
+        let av_score = self.av.map(|av| av.score()).unwrap_or(0.0);
+        let ac_score = self.ac.map(|ac| ac.score()).unwrap_or(0.0);
+        let au_score = self.au.map(|au| au.score()).unwrap_or(0.0);
+
+        (20.0 * av_score * ac_score * au_score).into()
+    }
+
+    /// Calculate Base Impact Score: sub-score for measuring the
+    /// consequences of successful exploitation.
+    ///
+    /// Described in CVSS v2.0 Specification: Section 3.2.1:
+    /// <https://www.first.org/cvss/v2/guide#3-2-1-Base-Equation>
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub fn impact(&self) -> Score {
+        let c_score = self.c.map(|c| c.score()).unwrap_or(0.0);
+        let i_score = self.i.map(|i| i.score()).unwrap_or(0.0);
+        let a_score = self.a.map(|a| a.score()).unwrap_or(0.0);
+        (10.41 * (1.0 - ((1.0 - c_score) * (1.0 - i_score) * (1.0 - a_score)))).into()
+    }
+
+    /// Calculate Environmental CVSS score
+    ///
+    /// Described in CVSS v2.0 Specification: Section 3.2.3:
+    /// <https://www.first.org/cvss/v2/guide#3-2-3-Environmental-Equation>
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub fn environmental_score(&self) -> Score {
+        let adjusted_temporal = self.temporal_score_internal(self.adjusted_impact());
+        let cdp_score = self.cdp.map(|cdp| cdp.score()).unwrap_or(0.0);
+        let td_score = self.td.map(|td| td.score()).unwrap_or(1.0);
+        let score =
+            (adjusted_temporal.value() + (10.0 - adjusted_temporal.value()) * cdp_score) * td_score;
+
+        Score::new(score).roundup()
+    }
+
+    /// Calculate Adjusted Impact: modified impact score based on
+    /// environmental requirements.
+    pub fn adjusted_impact(&self) -> Score {
+        let c_score = self.c.map(|c| c.score()).unwrap_or(0.0);
+        let i_score = self.i.map(|i| i.score()).unwrap_or(0.0);
+        let a_score = self.a.map(|a| a.score()).unwrap_or(0.0);
+
+        let cr_score = self.cr.map(|cr| cr.score()).unwrap_or(1.0);
+        let ir_score = self.ir.map(|ir| ir.score()).unwrap_or(1.0);
+        let ar_score = self.ar.map(|ar| ar.score()).unwrap_or(1.0);
+
+        (10.0_f64.min(
+            10.41
+                * (1.0
+                    - (1.0 - c_score * cr_score)
+                        * (1.0 - i_score * ir_score)
+                        * (1.0 - a_score * ar_score)),
+        ))
+        .into()
+    }
+
+    /// Calculate Temporal CVSS score
+    ///
+    /// Described in CVSS v2.0 Specification: Section 3.2.2:
+    /// <https://www.first.org/cvss/v2/guide#3-2-2-Temporal-Equation>
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub fn temporal_score(&self) -> Score {
+        self.temporal_score_internal(self.impact())
+    }
+
+    /// Internal calculation of Temporal CVSS that takes impact as parameter.
+    ///
+    /// This is primarily needed in environmental score calculation where the
+    /// impact is adjusted. Both the (Adjusted) `BaseScore` and the returned
+    /// Temporal/Adjusted Temporal value are rounded to 1 decimal, per the
+    /// CVSS v2.0 spec's definition of `TemporalScore` (Section 3.2.2):
+    /// `TemporalScore = round_to_1_decimal(BaseScore*E*RL*RC)`. Confirmed
+    /// against FIRST.org's own worked examples in the spec guide (e.g. for
+    /// CVE-2003-0818, the guide shows an intermediate Adjusted Temporal of
+    /// 8.0, which only matches when this rounding is applied -- the raw
+    /// unrounded product is 8.017).
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub fn temporal_score_internal(&self, impact: Score) -> Score {
+        let base_score = self.base_score_internal(impact).value();
+        let e_score = self.e.map(|e| e.score()).unwrap_or(1.0);
+        let rl_score = self.rl.map(|rl| rl.score()).unwrap_or(1.0);
+        let rc_score = self.rc.map(|rc| rc.score()).unwrap_or(1.0);
+
+        let score = base_score * e_score * rl_score * rc_score;
+        Score::new(score).roundup()
+    }
+
+    /// Iterate over all defined metrics
+    pub fn metrics(&self) -> impl Iterator<Item = (MetricType, &dyn fmt::Debug)> {
+        [
+            (
+                MetricType::AC,
+                self.ac.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (
+                MetricType::Au,
+                self.au.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (
+                MetricType::AV,
+                self.av.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (MetricType::C, self.c.as_ref().map(|m| m as &dyn fmt::Debug)),
+            (MetricType::I, self.i.as_ref().map(|m| m as &dyn fmt::Debug)),
+            (MetricType::A, self.a.as_ref().map(|m| m as &dyn fmt::Debug)),
+            (
+                MetricType::CR,
+                self.cr.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (
+                MetricType::IR,
+                self.ir.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (
+                MetricType::AR,
+                self.ar.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (
+                MetricType::CDP,
+                self.cdp.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (
+                MetricType::TD,
+                self.td.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (MetricType::E, self.e.as_ref().map(|m| m as &dyn fmt::Debug)),
+            (
+                MetricType::RC,
+                self.rc.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+            (
+                MetricType::RL,
+                self.rl.as_ref().map(|m| m as &dyn fmt::Debug),
+            ),
+        ]
+        .into_iter()
+        .filter_map(|(name, metric)| metric.as_ref().map(|&m| (name, m)))
+    }
+
+    /// Check for required base metrics presence
+    fn check_mandatory_metrics(&self) -> Result<()> {
+        fn ensure_present<T>(metric: Option<T>, metric_type: MetricType) -> Result<()> {
+            if metric.is_none() {
+                return Err(Error::MissingMandatoryMetricV2 { metric_type });
+            }
+            Ok(())
+        }
+
+        ensure_present(self.av.as_ref(), MetricType::AV)?;
+        ensure_present(self.ac.as_ref(), MetricType::AC)?;
+        ensure_present(self.au.as_ref(), MetricType::Au)?;
+        ensure_present(self.c.as_ref(), MetricType::C)?;
+        ensure_present(self.i.as_ref(), MetricType::I)?;
+        ensure_present(self.a.as_ref(), MetricType::A)?;
+        Ok(())
+    }
+}
+
+macro_rules! write_metrics {
+    ($f:expr, $($metric:expr),+) => {
+        let mut __first = true;
+        $(
+            if let Some(metric) = $metric {
+                if __first {
+                    write!($f, "{}", metric)?;
+                    __first = false;
+                } else {
+                    write!($f, "/{}", metric)?;
+                }
+            }
+        )+
+    };
+}
+
+impl fmt::Display for Vector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_metrics!(
+            f, self.av, self.ac, self.au, self.c, self.i, self.a, self.e, self.rl, self.rc,
+            self.cdp, self.td, self.cr, self.ir, self.ar
+        );
+        Ok(())
+    }
+}
+
+impl FromStr for Vector {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let component_vec = s
+            .split('/')
+            .map(|component| {
+                let mut parts = component.split(':');
+
+                let id = parts.next().ok_or_else(|| Error::InvalidComponent {
+                    component: component.to_owned(),
+                })?;
+
+                let value = parts.next().ok_or_else(|| Error::InvalidComponent {
+                    component: component.to_owned(),
+                })?;
+
+                if parts.next().is_some() {
+                    return Err(Error::InvalidComponent {
+                        component: component.to_owned(),
+                    });
+                }
+
+                Ok((id, value))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let components = component_vec.iter();
+        let mut metrics = Self::default();
+
+        fn get_value<T: FromStr<Err = Error>>(
+            metric_type: MetricType,
+            current_val: Option<T>,
+            new_val: &str,
+        ) -> Result<Option<T>> {
+            let parsed = T::from_str(new_val)?;
+            if current_val.is_some() {
+                return Err(Error::DuplicateMetricV2 { metric_type });
+            }
+            Ok(Some(parsed))
+        }
+
+        for &component in components {
+            let key = component.0;
+            let value = component.1;
+
+            let metric_type = key.parse::<MetricType>()?;
+            match metric_type {
+                // Base metrics
+                MetricType::AV => metrics.av = get_value(metric_type, metrics.av, value)?,
+                MetricType::AC => metrics.ac = get_value(metric_type, metrics.ac, value)?,
+                MetricType::Au => metrics.au = get_value(metric_type, metrics.au, value)?,
+                MetricType::C => metrics.c = get_value(metric_type, metrics.c, value)?,
+                MetricType::I => metrics.i = get_value(metric_type, metrics.i, value)?,
+                MetricType::A => metrics.a = get_value(metric_type, metrics.a, value)?,
+
+                // Temporal metrics
+                MetricType::E => metrics.e = get_value(metric_type, metrics.e, value)?,
+                MetricType::RL => metrics.rl = get_value(metric_type, metrics.rl, value)?,
+                MetricType::RC => metrics.rc = get_value(metric_type, metrics.rc, value)?,
+
+                // Environmental metrics
+                MetricType::CDP => metrics.cdp = get_value(metric_type, metrics.cdp, value)?,
+                MetricType::TD => metrics.td = get_value(metric_type, metrics.td, value)?,
+                MetricType::CR => metrics.cr = get_value(metric_type, metrics.cr, value)?,
+                MetricType::IR => metrics.ir = get_value(metric_type, metrics.ir, value)?,
+                MetricType::AR => metrics.ar = get_value(metric_type, metrics.ar, value)?,
+            }
+        }
+
+        metrics.check_mandatory_metrics()?;
+
+        Ok(metrics)
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<'de> Deserialize<'de> for Vector {
+    fn deserialize<D: de::Deserializer<'de>>(
+        deserializer: D,
+    ) -> core::result::Result<Self, D::Error> {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(de::Error::custom)
+    }
+}
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl Serialize for Vector {
+    fn serialize<S: ser::Serializer>(
+        &self,
+        serializer: S,
+    ) -> core::result::Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(all(feature = "std", test))]
+mod tests {
+    use super::Vector;
+    use core::str::FromStr;
+
+    fn approx_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() < 0.0001
+    }
+
+    #[test]
+    fn spec_cve_2002_0392() {
+        // See https://www.first.org/cvss/v2/guide (Section 3.3.1 worked
+        // example). Note NVD's own v2 calculator
+        // (https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator) reports an
+        // environmental score of 9.1 for this vector, which does not match
+        // FIRST.org's own published value of 9.2 for CDP:H/TD:H.
+        let v = "AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:H";
+        let cvss = Vector::from_str(v).expect("parse vector");
+
+        let base = cvss.score().value();
+        let impact = cvss.impact().roundup().value();
+        let exploitability = cvss.exploitability().roundup().value();
+        let temporal = cvss.temporal_score().value();
+        let environmental = cvss.environmental_score().value();
+        let adjusted_impact = cvss.adjusted_impact().roundup().value();
+        assert!(
+            approx_eq(base, 7.8),
+            "base score expected 7.8, got {}",
+            base
+        );
+        assert!(
+            approx_eq(impact, 6.9),
+            "impact expected 6.9, got {}",
+            impact
+        );
+        assert!(
+            approx_eq(exploitability, 10.0),
+            "exploitability expected 10.0, got {}",
+            exploitability
+        );
+        assert!(
+            approx_eq(temporal, 6.4),
+            "temporal expected 6.4, got {}",
+            temporal
+        );
+        assert!(
+            approx_eq(adjusted_impact, 10.0),
+            "adjusted impact expected 10.0, got {}",
+            adjusted_impact
+        );
+        assert!(
+            approx_eq(environmental, 9.2),
+            "environmental expected 9.2, got {}",
+            environmental
+        );
+    }
+
+    #[test]
+    fn spec_cve_2003_0818() {
+        // See https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:L)
+        let v = "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:L";
+        let cvss = Vector::from_str(v).expect("parse vector");
+
+        let base = cvss.score().value();
+        let impact = cvss.impact().roundup().value();
+        let exploitability = cvss.exploitability().roundup().value();
+        let temporal = cvss.temporal_score().value();
+        let environmental = cvss.environmental_score().value();
+        let adjusted_impact = cvss.adjusted_impact().roundup().value();
+
+        assert!(
+            approx_eq(base, 10.0),
+            "base score expected 10.0, got {}",
+            base
+        );
+        assert!(
+            approx_eq(impact, 10.0),
+            "impact expected 10.0, got {}",
+            impact
+        );
+        assert!(
+            approx_eq(exploitability, 10.0),
+            "exploitability expected 10.0, got {}",
+            exploitability
+        );
+        assert!(
+            approx_eq(temporal, 8.3),
+            "temporal expected 8.3, got {}",
+            temporal
+        );
+        assert!(
+            approx_eq(adjusted_impact, 9.6),
+            "adjusted impact expected 9.6, got {}",
+            adjusted_impact
+        );
+        assert!(
+            approx_eq(environmental, 9.0),
+            "environmental expected 9.0, got {}",
+            environmental
+        );
+    }
+}

--- a/cvss/tests/redhat-v2.rs
+++ b/cvss/tests/redhat-v2.rs
@@ -1,0 +1,37 @@
+#![cfg(all(feature = "v2", feature = "std"))]
+
+use cvss::v2::Vector;
+use std::{fs, str::FromStr};
+
+#[test]
+fn cvss_v2_simple() {
+    run_tests_from_file("vectors_simple2");
+}
+
+#[test]
+fn cvss_v2_random() {
+    run_tests_from_file("vectors_random2");
+}
+
+// Run the test set from Red Hat's Security Python implementation: https://github.com/RedHatProductSecurity/cvss
+fn run_tests_from_file(name: &str) {
+    let content = fs::read_to_string(format!("tests/cvss-redhat/tests/{}", name)).unwrap();
+    for l in content.lines() {
+        let parts = l.split(" - ").collect::<Vec<&str>>();
+        let vector = parts[0];
+        if vector.len() > 44 {
+            // more than base, skip
+            continue;
+        }
+        // "(base, _, _)"
+        let score = parts[1].split(',').next().unwrap().trim_start_matches('(');
+
+        let cvss = Vector::from_str(vector).unwrap();
+        // Test correct serialization.
+        assert_eq!(cvss.to_string(), parts[0]);
+        assert!(cvss.score().value() >= 0.0);
+        assert!(cvss.score().value() <= 10.0);
+        let diff: f64 = cvss.score().value() - score.parse::<f64>().unwrap();
+        assert!(diff.abs() < 0.0001);
+    }
+}

--- a/rustsec/src/osv/advisory.rs
+++ b/rustsec/src/osv/advisory.rs
@@ -69,6 +69,7 @@ impl From<&cargo_lock::Name> for OsvPackage {
 #[allow(non_camel_case_types)]
 #[serde(tag = "type", content = "score")]
 enum OsvSeverity {
+    CVSS_V2(cvss::v2::Vector),
     CVSS_V3(cvss::v3::Base),
     CVSS_V4(cvss::v4::Vector),
 }
@@ -78,6 +79,7 @@ impl TryFrom<Cvss> for OsvSeverity {
 
     fn try_from(cvss: Cvss) -> Result<Self, Self::Error> {
         match cvss {
+            Cvss::CvssV20(vector) => Ok(Self::CVSS_V2(vector)),
             Cvss::CvssV30(base) => Ok(Self::CVSS_V3(base)),
             Cvss::CvssV31(base) => Ok(Self::CVSS_V3(base)),
             Cvss::CvssV40(vector) => Ok(Self::CVSS_V4(vector)),


### PR DESCRIPTION
This PR introduces full support for CVSSv2 including temporal and environmental metrics. The style used is somewhat between the v3 and v4 implementation, but leaning more towards v4 where we have a `Vector` struct representing it all and then individual implementations of scores into that vector.

Side node: if interested, I can try to provide the temporal and environmental calculation for v3 as well, in a similar manner.

Fixes #1379