### PR TITLE
cvss: use `cargo hack` to test feature combos

### DIFF
--- a/.github/workflows/cvss.yml
+++ b/.github/workflows/cvss.yml
@@ -55,9 +55,10 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - uses: taiki-e/install-action@cargo-hack
       - run: git submodule update --init
       - run: cargo check
-      - run: cargo test --release
+      - run: cargo hack test --feature-powerset
       - run: cargo test --all-features --release
 
   doc:

--- a/cvss/src/cvss.rs
+++ b/cvss/src/cvss.rs
@@ -2,14 +2,13 @@ use alloc::boxed::Box;
 use alloc::str::FromStr;
 use core::fmt;
 
+#[cfg(feature = "std")]
+use crate::Severity;
+use crate::error::{Error, Result};
 #[cfg(feature = "v3")]
 use crate::v3;
 #[cfg(feature = "v4")]
 use crate::v4;
-use crate::{
-    Severity,
-    error::{Error, Result},
-};
 use alloc::borrow::ToOwned;
 #[cfg(feature = "serde")]
 use {


### PR DESCRIPTION
Uses the `--feature-powerset` flag to check all feature combinations, so as to avoid issues like #1471