### PR TITLE
admin: remove unused lint --skip-namecheck option

### DIFF
--- a/admin/src/commands/lint.rs
+++ b/admin/src/commands/lint.rs
@@ -17,9 +17,6 @@ pub struct LintCmd {
         help = "filesystem path to the RustSec advisory DB git repo"
     )]
     path: Vec<PathBuf>,
-
-    #[arg(long, help = "Skip name check comma separated crates list")]
-    skip_namecheck: Option<String>,
 }
 
 impl Runnable for LintCmd {


### PR DESCRIPTION
This has been non-functional since

- #1480 

Seems better to remove it to avoid any confusion.

(Apparently something about the clap/abscissa setup prevents the usual lints from flagging an unread field?)