### PR TITLE
cargo-audit: add binary scan size limits

### DIFF
--- a/cargo-audit/audit.toml.example
+++ b/cargo-audit/audit.toml.example
@@ -25,6 +25,11 @@ format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)
 
+# Binary scanning configuration
+[binary]
+max_binary_size = 104857600 # Max size of binary to read in bytes (default: unlimited)
+audit_data_size_limit = 8388608 # Max size of embedded audit data in bytes (default: 8MB)
+
 # Target Configuration
 [target]
 arch = ["x86_64"] # Ignore advisories for CPU architectures other than these

--- a/cargo-audit/src/commands/audit/binary_scanning.rs
+++ b/cargo-audit/src/commands/audit/binary_scanning.rs
@@ -9,6 +9,22 @@ use std::{path::PathBuf, process::exit};
 #[derive(Command, Clone, Default, Debug, Parser)]
 #[command()]
 pub struct BinCommand {
+    /// Maximum binary size in bytes to read
+    #[arg(
+        long = "max-binary-size",
+        value_name = "BYTES",
+        help = "Maximum binary size in bytes to read"
+    )]
+    pub(super) max_binary_size: Option<u64>,
+
+    /// Maximum audit data size in bytes to parse
+    #[arg(
+        long = "audit-data-size-limit",
+        value_name = "BYTES",
+        help = "Maximum audit data size in bytes to parse (default: 8MB)"
+    )]
+    pub(super) audit_data_size_limit: Option<usize>,
+
     /// Paths to the binaries to be scanned
     #[arg(
         value_parser,

--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -27,6 +27,10 @@ pub struct AuditConfig {
     #[serde(default)]
     pub output: OutputConfig,
 
+    /// Binary scanning configuration
+    #[serde(default)]
+    pub binary: BinaryConfig,
+
     /// Target-related configuration
     #[serde(default)]
     pub target: TargetConfig,
@@ -166,6 +170,17 @@ impl OutputConfig {
     pub fn is_quiet(&self) -> bool {
         self.quiet || self.format == OutputFormat::Json || self.format == OutputFormat::Sarif
     }
+}
+
+/// Binary scanning configuration
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BinaryConfig {
+    /// Maximum binary size in bytes to read (no limit if unset)
+    pub max_binary_size: Option<u64>,
+
+    /// Maximum audit data size in bytes to parse (defaults to 8MB if unset)
+    pub audit_data_size_limit: Option<usize>,
 }
 
 /// Warning kinds


### PR DESCRIPTION
## Summary
- add binary scan config/CLI overrides for max input size and audit data size
- enforce bounded binary reads before parsing auditable data
- document new [binary] settings in the example config

## Test plan
- cargo test -p cargo-audit
- cargo test --all-features -p cargo-audit
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --exclude=rustsec -- -D warnings
- cargo clippy --package=rustsec --features=dependency-tree,osv-export,binary-scanning -- -D warnings