### PR TITLE
cargo-audit: Put a newline character at the end of json reports

### DIFF
--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -103,8 +103,10 @@ impl Presenter {
     ) {
         match self.config.format {
             OutputFormat::Json => {
-                serde_json::to_writer(io::stdout(), &report).unwrap();
-                io::stdout().flush().unwrap();
+                let mut stdout = io::stdout().lock();
+                serde_json::to_writer(&mut stdout, &report).unwrap();
+                // End with a newline as a terminator/separator. Another json report may follow.
+                writeln!(&mut stdout).unwrap();
                 return;
             }
             OutputFormat::Sarif => {
@@ -112,8 +114,10 @@ impl Presenter {
                     .map(|p| p.to_string_lossy().into_owned())
                     .unwrap_or_else(|| "Cargo.lock".to_string());
                 let sarif_log = crate::sarif::SarifLog::from_report(report, &cargo_lock_path);
-                serde_json::to_writer(io::stdout(), &sarif_log).unwrap();
-                io::stdout().flush().unwrap();
+                let mut stdout = io::stdout().lock();
+                serde_json::to_writer(&mut stdout, &sarif_log).unwrap();
+                // End with a newline as a terminator/separator. Another sarif report may follow.
+                writeln!(&mut stdout).unwrap();
                 return;
             }
             OutputFormat::Terminal => {


### PR DESCRIPTION
Put a newline character at the end of json reports to make multi-report outputs (bin audit) easily parse-able.

Also control the locking explicitly.
This avoids taking and releasing the lock multiple times in a row.

Also remove the flushing.
According to the documentation the flushing is always automatically done:
```When the handle goes out of scope, the buffer is automatically flushed.```

Fixes: #1511 