### PR TITLE
cargo-audit: bump version to 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "abscissa_core",
  "cargo-lock",

--- a/cargo-audit/Cargo.toml
+++ b/cargo-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-audit"
 description  = "Audit Cargo.lock for crates with security vulnerabilities"
-version      = "0.22.0"
+version      = "0.22.1"
 authors      = ["Tony Arcieri <bascule@gmail.com>"]
 license      = "Apache-2.0 OR MIT"
 homepage     = "https://rustsec.org"


### PR DESCRIPTION
Prepare to release this and also rustsec 0.32.0 (version already bumped in the repo).