### PR TITLE
admin: display error chain for lint errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,6 +3084,7 @@ dependencies = [
  "clap",
  "comrak",
  "cvss",
+ "display-error-chain",
  "fs-err",
  "gix",
  "once_cell",

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -20,6 +20,7 @@ chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true }
 comrak = { workspace = true }
 cvss = { workspace = true }
+display-error-chain = { workspace = true }
 fs-err = { workspace = true }
 tame-index = { workspace = true, features = ["sparse"] }
 gix = { workspace = true, optional = true }

--- a/admin/src/commands/lint.rs
+++ b/admin/src/commands/lint.rs
@@ -1,12 +1,14 @@
 //! `rustsec-admin lint` subcommand
 
-use crate::{linter::Linter, prelude::*};
-use abscissa_core::{Command, Runnable};
-use clap::Parser;
 use std::{
     path::{Path, PathBuf},
     process::exit,
 };
+
+use abscissa_core::{Command, Runnable};
+use clap::Parser;
+
+use crate::{display_err_with_source, linter::Linter, prelude::*};
 
 /// `rustsec-admin lint` subcommand
 #[derive(Command, Debug, Default, Parser)]
@@ -28,12 +30,7 @@ impl Runnable for LintCmd {
         };
 
         let linter = Linter::new(repo_path).unwrap_or_else(|e| {
-            status_err!(
-                "error loading advisory DB repo from {}: {}",
-                repo_path.display(),
-                e
-            );
-
+            status_err!("{}", display_err_with_source(&e));
             exit(1);
         });
 
@@ -53,8 +50,7 @@ impl Runnable for LintCmd {
         );
 
         let invalid_advisory_count = linter.lint().unwrap_or_else(|e| {
-            status_err!("error linting advisory DB {}: {}", repo_path.display(), e);
-
+            status_err!("{}", display_err_with_source(&e));
             exit(1);
         });
 

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -18,7 +18,7 @@ pub mod prelude;
 pub mod synchronizer;
 pub mod web;
 
-use std::collections::BTreeMap as Map;
+use std::{collections::BTreeMap as Map, error::Error as StdError};
 
 use tame_index::{SparseIndex, index::AsyncRemoteSparseIndex};
 
@@ -32,4 +32,13 @@ pub fn crates_index() -> Result<AsyncRemoteSparseIndex, tame_index::Error> {
             .build()
             .map_err(tame_index::Error::from)?,
     ))
+}
+
+/// Displays the error and also follows the chain of the `.source` fields,
+/// printing any errors that caused the top-level error.
+///
+/// This is required to properly present some `gix` errors to the user:
+/// <https://github.com/rustsec/rustsec/issues/1029#issuecomment-1777487808>
+pub fn display_err_with_source(error: &impl StdError) -> String {
+    display_error_chain::DisplayErrorChain::new(error).to_string()
 }


### PR DESCRIPTION
IMO the better solution would be to have `main()` yield `Result<(), Error>`, but abscissa requires `Runnable::run()` to be infallible so I guess this will have to do for now.

Before:

<img width="875" height="120" alt="Screenshot 2026-02-05 at 13 14 12" src="https://github.com/user-attachments/assets/77c4cb21-95cf-4b46-8fac-f7286eb30430" />

After:

<img width="736" height="139" alt="Screenshot 2026-02-05 at 13 14 33" src="https://github.com/user-attachments/assets/564b50c2-95ab-4d40-be29-064dba80750e" />