### PR TITLE
admin: don't rely on cached data

### DIFF
--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -20,15 +20,15 @@ pub mod web;
 
 use std::collections::BTreeMap as Map;
 
-use tame_index::{SparseIndex, index::AsyncRemoteSparseIndex};
+use tame_index::{SparseIndex, index::RemoteSparseIndex};
 
 /// Get an async crates.io index
-pub fn crates_index() -> Result<AsyncRemoteSparseIndex, tame_index::Error> {
-    Ok(AsyncRemoteSparseIndex::new(
+pub fn crates_index() -> Result<RemoteSparseIndex, tame_index::Error> {
+    Ok(RemoteSparseIndex::new(
         SparseIndex::new(tame_index::IndexLocation::new(
             tame_index::IndexUrl::crates_io(None, None, None)?,
         ))?,
-        tame_index::external::reqwest::ClientBuilder::new()
+        tame_index::external::reqwest::blocking::ClientBuilder::new()
             .build()
             .map_err(tame_index::Error::from)?,
     ))

--- a/admin/src/linter.rs
+++ b/admin/src/linter.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use tame_index::index::AsyncRemoteSparseIndex;
+use tame_index::index::RemoteSparseIndex;
 
 use crate::{
     crates_index,
@@ -25,7 +25,7 @@ pub struct Linter {
     repo_path: PathBuf,
 
     /// Loaded crates.io index
-    crates_index: AsyncRemoteSparseIndex,
+    crates_index: RemoteSparseIndex,
 
     /// Loaded Advisory DB
     advisory_db: rustsec::Database,
@@ -148,7 +148,7 @@ impl Linter {
         };
         if let Ok(Some(crate_)) = self
             .crates_index
-            .cached_krate(name.try_into().unwrap(), &lock)
+            .krate(name.try_into().unwrap(), true, &lock)
         {
             // This check verifies name normalization.
             // A request for "serde-json" might return "serde_json",

--- a/admin/src/list_versions.rs
+++ b/admin/src/list_versions.rs
@@ -3,14 +3,14 @@
 use std::path::PathBuf;
 
 use rustsec::{Advisory, Database};
-use tame_index::index::AsyncRemoteSparseIndex;
+use tame_index::index::RemoteSparseIndex;
 
 use crate::{crates_index, error::Error, lock::acquire_cargo_package_lock, prelude::*};
 
 /// Lists all versions for a crate and prints info on which ones are affected
 pub struct AffectedVersionLister {
     /// Loaded crates.io index
-    crates_index: AsyncRemoteSparseIndex,
+    crates_index: RemoteSparseIndex,
 
     /// Loaded Advisory DB
     advisory_db: Database,
@@ -45,7 +45,7 @@ impl AffectedVersionLister {
         let lock = acquire_cargo_package_lock().unwrap();
         let crate_info = self
             .crates_index
-            .cached_krate(crate_name.try_into().unwrap(), &lock)
+            .krate(crate_name.try_into().unwrap(), true, &lock)
             .unwrap()
             .unwrap_or_else(|| panic!("expected crate {crate_name} to exist"));
         for version in crate_info.versions {

--- a/admin/src/synchronizer.rs
+++ b/admin/src/synchronizer.rs
@@ -79,7 +79,7 @@ use std::{
 use rustsec::advisory::{Id, IdKind, Parts};
 use rustsec::osv::OsvAdvisory;
 use rustsec::{Advisory, Collection};
-use tame_index::{KrateName, index::AsyncRemoteSparseIndex};
+use tame_index::{KrateName, index::RemoteSparseIndex};
 use toml_edit::{DocumentMut, value};
 
 use crate::{
@@ -96,7 +96,7 @@ pub struct Synchronizer {
     repo_path: PathBuf,
 
     /// Loaded crates.io index
-    crates_index: AsyncRemoteSparseIndex,
+    crates_index: RemoteSparseIndex,
 
     /// Loaded Advisory DB
     advisory_db: rustsec::Database,
@@ -197,10 +197,11 @@ impl Synchronizer {
                         }
                     };
 
-                    if let Ok(Some(_)) = self
-                        .crates_index
-                        .cached_krate(crate_name, &acquire_cargo_package_lock().unwrap())
-                    {
+                    if let Ok(Some(_)) = self.crates_index.krate(
+                        crate_name,
+                        true,
+                        &acquire_cargo_package_lock().unwrap(),
+                    ) {
                         self.missing_advisories.push(osv.clone());
                     } else {
                         status_info!(


### PR DESCRIPTION
Fixes a regression from:

- #1525

That PR used `cached_krate()` everywhere, which meant that most crates were not populated and yielded lint errors for failing to find a matching package on the index. Fix it by using `krate()` instead -- avoid async code, which is awkward in the context of abscissa.