### PR TITLE
Hide the link to crates.io for "expect_deleted" crates

### DIFF
--- a/admin/src/web/templates/advisory-content.html
+++ b/admin/src/web/templates/advisory-content.html
@@ -52,7 +52,9 @@
         {% when Some with (collection) %}
         {% if collection.to_string() == "crates" %}
         <a href="/packages/{{ advisory.metadata.package }}.html">{{ advisory.metadata.package }}</a>
+          {% if !advisory.metadata.expect_deleted %} 
           (<a href="https://crates.io/crates/{{ advisory.metadata.package }}">crates.io</a>)
+          {% endif %}
         {% else %}
         <code><a href="/packages/{{ advisory.metadata.package }}.html">{{ advisory.metadata.package }}</a></code>
         {% endif %}


### PR DESCRIPTION
Don't add a link expected to be broken.