### PR TITLE
Disable embedded file timestamps in rust-embed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ petgraph = "0.8.2"
 platforms = { version = "3", path = "./platforms" }
 quitters = { version = "0.1.0", path = "./quitters" }
 regex = { version = "1.10.6", default-features = false }
-rust-embed = "8.5.0"
+rust-embed = { version = "8.5.0", features = ["deterministic-timestamps"] }
 rustsec = { version = "0.32", path = "./rustsec" }
 semver = "1.0.23"
 serde = "1"


### PR DESCRIPTION
I noticed cargo-audit is not reproducible in [Arch Linux' tests](https://web.archive.org/web/20260302221354/https://reproducible.archlinux.org/api/v0/builds/989601/diffoscope), it took me some time and many builds, but I eventually tracked it down to rust-embed recording timestamps from my local filesystem into the binary.

This change enables a feature on the crate to use 1970-01-01 instead.