### PR TITLE
Change generated title for malicious crates

### DIFF
--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -18,7 +18,7 @@ use atom_syndication::{
 use chrono::{Duration, NaiveDate, Utc};
 use comrak::markdown_to_html;
 use rust_embed::RustEmbed;
-use rustsec::advisory::Id;
+use rustsec::advisory::{Category, Id};
 use rustsec::osv::OsvAdvisory;
 use rustsec::repository::git::GitModificationTimes;
 use rustsec::repository::git::GitPath;
@@ -412,6 +412,9 @@ fn title_type(advisory: &rustsec::Advisory) -> String {
         Some(Informational::Unsound) => format!("{id}: Unsoundness in {package}"),
         Some(Informational::Other(s)) => format!("{id}: {package} is {s}"),
         Some(_) => format!("{id}: Advisory for {package}"),
+        None if advisory.metadata.categories.contains(&Category::Malicious) => {
+            format!("{id}: {package} contained malicious code")
+        }
         // Not informational => vulnerability
         None => format!("{id}: Vulnerability in {package}"),
     }


### PR DESCRIPTION
They're not really "vulnerabilities", so let's be more specific.

This is a very minimal change. I'm open to alternative wording, but I think we should change it _somehow_.

Before:

<img width="1270" height="291" alt="image" src="https://github.com/user-attachments/assets/8562d25a-9ee0-4a1d-8fc3-49368ec45fdc" />

After:

<img width="1270" height="287" alt="image" src="https://github.com/user-attachments/assets/a4cb2ec1-7eca-42af-838d-60f48448deb5" />