### PR TITLE
fix(cargo-audit): expand tilde in advisory-db path from config

### DIFF
--- a/cargo-audit/audit.toml.example
+++ b/cargo-audit/audit.toml.example
@@ -13,7 +13,10 @@ severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "cr
 
 # Advisory Database Configuration
 [database]
-path = "~/.cargo/advisory-db" # Path where advisory git repo will be cloned
+# path = "/home/user/.cargo/advisory-db" # Path where advisory git repo will be cloned
+#   Note: use an absolute path here. Shell tilde expansion (~) is not supported
+#   in config files. The default is the `advisory-db` directory inside your
+#   Cargo home (usually $HOME/.cargo/advisory-db).
 url = "https://github.com/RustSec/advisory-db.git" # URL to git repo
 fetch = true # Perform a `git fetch` before auditing (default: true)
 stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: false)

--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -9,10 +9,32 @@ use rustsec::binary_scanning::BinaryFormat;
 
 use std::{
     io::{self, Read},
-    path::Path,
+    path::{Path, PathBuf},
     process::exit,
     time::Duration,
 };
+
+/// Expand a leading `~/` or bare `~` in a path to the user's home directory.
+///
+/// Shell tilde expansion is not performed when paths are read from config
+/// files, so a user who writes `path = "~/.cargo/advisory-db"` in
+/// `audit.toml` would otherwise get a literal `~` directory created in their
+/// working directory. This helper makes such paths work as expected.
+fn expand_tilde(path: PathBuf) -> PathBuf {
+    let s = match path.to_str() {
+        Some(s) => s,
+        None => return path,
+    };
+    if s == "~" {
+        return home::home_dir().unwrap_or(path);
+    }
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = home::home_dir() {
+            return home.join(rest);
+        }
+    }
+    path
+}
 
 // TODO: make configurable
 const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
@@ -58,6 +80,7 @@ impl Auditor {
             .path
             .as_ref()
             .cloned()
+            .map(expand_tilde)
             .unwrap_or_else(rustsec::repository::git::Repository::default_path);
 
         let database = if config.database.fetch {

--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -28,10 +28,10 @@ fn expand_tilde(path: PathBuf) -> PathBuf {
     if s == "~" {
         return home::home_dir().unwrap_or(path);
     }
-    if let Some(rest) = s.strip_prefix("~/") {
-        if let Some(home) = home::home_dir() {
-            return home.join(rest);
-        }
+    if let Some(rest) = s.strip_prefix("~/")
+        && let Some(home) = home::home_dir()
+    {
+        return home.join(rest);
     }
     path
 }

--- a/cargo-audit/tests/config.rs
+++ b/cargo-audit/tests/config.rs
@@ -1,6 +1,6 @@
 //! Configuration file tests
 
-use std::{fs, path::Path};
+use std::fs;
 
 use cargo_audit::config::AuditConfig;
 use rustsec::platforms::{Arch, OS};
@@ -11,10 +11,9 @@ fn parse_audit_toml_example() {
     let toml_string = fs::read_to_string("audit.toml.example").unwrap();
     let config: AuditConfig = toml::from_str(&toml_string).unwrap();
 
-    assert_eq!(
-        config.database.path.unwrap(),
-        Path::new("~/.cargo/advisory-db")
-    );
+    // path is intentionally omitted from the example config to avoid tilde
+    // expansion issues (see https://github.com/rustsec/rustsec/issues/585)
+    assert!(config.database.path.is_none());
     assert_eq!(
         config.database.url.unwrap(),
         "https://github.com/RustSec/advisory-db.git"


### PR DESCRIPTION
## Summary

Fixes #585

Shell tilde expansion is not applied to values read from TOML config files. A user who copies `audit.toml.example` and keeps the default `path = "~/.cargo/advisory-db"` ends up with a literal `./~/.cargo/advisory-db` directory created inside their project directory.

## Root cause

The `audit.toml.example` file contained:
\`\`\`toml
path = "~/.cargo/advisory-db"
\`\`\`

When this is deserialized into a `PathBuf`, the `~` is treated as a literal directory name rather than being expanded to the home directory. Shell tilde expansion only happens when the shell parses arguments — not when reading config files.

## Fix

Two-part:

**1. `audit.toml.example`** — comment out the `path` field and document that absolute paths must be used when specifying a custom path. When the field is absent the default (`cargo_home()/advisory-db`) is used, which is always correct.

**2. `auditor.rs`** — add an `expand_tilde()` helper (using the already-present `home` crate) applied to any configured path before use. This makes `~/...` paths work correctly whether set via config file or `--db` flag, and is consistent with user expectations.

## Test plan

- [x] Existing tests updated — `parse_audit_toml_example` now asserts `path` is `None` (commented out in example)
- [x] `cargo test -p cargo-audit` passes
- [x] `cargo build -p cargo-audit` clean with no warnings