### PR TITLE
fix: advisory linter requires affected functions to start with package rather than crate name

### DIFF
--- a/rustsec/src/advisory.rs
+++ b/rustsec/src/advisory.rs
@@ -144,6 +144,11 @@ impl FromStr for Advisory {
             advisory.metadata.description = parts.description.to_owned();
         }
 
+        // Default to normalized package name (see #1575)
+        if advisory.metadata.crate_name.is_empty() {
+            advisory.metadata.crate_name = advisory.metadata.package.as_str().replace("-", "_");
+        }
+
         Ok(advisory)
     }
 }

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -248,11 +248,7 @@ impl Linter {
                 match key.as_str() {
                     "functions" => {
                         for function in self.advisory.affected.as_ref().unwrap().functions.keys() {
-                            // Rust identifiers do not allow '-' character but crate names do,
-                            // thus "crate-name" would be addressed as "crate_name" in function path
-                            let crate_name =
-                                self.advisory.metadata.package.as_str().replace('-', "_");
-                            if function.segments()[0].as_str() != crate_name {
+                            if function.segments()[0].as_str() != self.advisory.metadata.crate_name {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("functions", function.to_string()),
                                     section: Some("affected"),

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -248,11 +248,8 @@ impl Linter {
                 match key.as_str() {
                     "functions" => {
                         for function in self.advisory.affected.as_ref().unwrap().functions.keys() {
-                            // Rust identifiers do not allow '-' character but crate names do,
-                            // thus "crate-name" would be addressed as "crate_name" in function path
-                            let crate_name =
-                                self.advisory.metadata.package.as_str().replace('-', "_");
-                            if function.segments()[0].as_str() != crate_name {
+                            if function.segments()[0].as_str() != self.advisory.metadata.crate_name
+                            {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("functions", function.to_string()),
                                     section: Some("affected"),

--- a/rustsec/src/advisory/metadata.rs
+++ b/rustsec/src/advisory/metadata.rs
@@ -16,8 +16,13 @@ pub struct Metadata {
     /// Security advisory ID (e.g. RUSTSEC-YYYY-NNNN)
     pub id: Id,
 
-    /// Name of affected crate
+    /// Name of affected crates.io package
     pub package: package::Name,
+
+    /// Name of affected crate within the package.
+    /// Defaults to normalized package name.
+    #[serde(default)]
+    pub crate_name: String,
 
     /// One-liner description of a vulnerability
     #[serde(default)]


### PR DESCRIPTION
- allow to specify differing crate_name for affected functions
- most crate names do match the crates.io package name, hence make this optional and keep the existing behavior as default

fixes #1575
related advisory-db template https://github.com/rustsec/advisory-db/pull/2791