### PR TITLE
Add reachsec as an experimental tool to complement cargo-audit

### DIFF
--- a/cargo-audit/README.md
+++ b/cargo-audit/README.md
@@ -10,6 +10,12 @@
 Audit your dependencies for crates with security vulnerabilities reported to the
 [RustSec Advisory Database].
 
+## Related Experimental Tool
+
+If you want additional function-level reachability context, see
+[`reachsec`](https://github.com/xizheyin/reachsec), an experimental standalone
+companion to `cargo audit`.
+
 ## Requirements
 
 `cargo audit` requires Rust **1.74** or later.


### PR DESCRIPTION
As discussed in https://github.com/rustsec/advisory-db/issues/2758#issuecomment-4205492739, I make the tool focus on function reachibility and update the readme.

cc @djc 