### PR TITLE
cargo-audit: when run with -q, suppress dependency trees

### DIFF
--- a/cargo-audit/src/commands/audit.rs
+++ b/cargo-audit/src/commands/audit.rs
@@ -247,6 +247,9 @@ impl Override<AuditConfig> for AuditCommand {
         }
 
         config.output.quiet |= self.quiet;
+        if self.quiet {
+            config.output.show_tree = false;
+        }
 
         // Handle output format (--json flag takes precedence for backward compatibility)
         if self.output_json {

--- a/cargo-audit/src/config.rs
+++ b/cargo-audit/src/config.rs
@@ -158,7 +158,8 @@ pub struct OutputConfig {
     pub quiet: bool,
 
     /// Show inverse dependency trees along with advisories (default: true)
-    pub show_tree: Option<bool>,
+    #[serde(default = "default_show_tree")]
+    pub show_tree: bool,
 }
 
 impl OutputConfig {
@@ -166,6 +167,10 @@ impl OutputConfig {
     pub fn is_quiet(&self) -> bool {
         self.quiet || self.format == OutputFormat::Json || self.format == OutputFormat::Sarif
     }
+}
+
+fn default_show_tree() -> bool {
+    true
 }
 
 /// Warning kinds

--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -423,7 +423,7 @@ impl Presenter {
             return;
         }
 
-        if !self.config.show_tree.unwrap_or(true) {
+        if !self.config.show_tree {
             return;
         }
 


### PR DESCRIPTION
Fixes #1581.