### PR TITLE
Revert "Document to use cargo install with --locked (fixes #1152)"

### DIFF
--- a/cargo-audit/README.md
+++ b/cargo-audit/README.md
@@ -27,7 +27,7 @@ companion to `cargo audit`.
 `cargo audit` is a Cargo subcommand and can be installed with `cargo install`:
 
 ```
-$ cargo install cargo-audit --locked
+$ cargo install cargo-audit
 ```
 
 Once installed, run `cargo audit` at the toplevel of any Cargo project.
@@ -68,7 +68,7 @@ to fix vulnerable dependency requirements.
 To enable it, install `cargo audit` with the `fix` feature enabled:
 
 ```
-$ cargo install cargo-audit --locked --features=fix
+$ cargo install cargo-audit --features=fix
 ```
 
 Once installed, run `cargo audit fix` to automatically fix vulnerable
@@ -123,7 +123,7 @@ To automatically run `cargo audit` on every build in Travis CI, you can add the 
 language: rust
 cache: cargo # cache cargo-audit once installed
 before_script:
-  - cargo install --force --locked cargo-audit
+  - cargo install --force cargo-audit
   - cargo generate-lockfile
 script:
   - cargo audit

--- a/cargo-audit/src/lib.rs
+++ b/cargo-audit/src/lib.rs
@@ -3,7 +3,7 @@
 //! `cargo audit` is a Cargo subcommand. Install it using the following:
 //!
 //! ```text
-//! $ cargo install cargo-audit --locked
+//! $ cargo install cargo-audit
 //! ```
 //!
 //! Then run `cargo audit` in the toplevel directory of any crate or workspace.

--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -258,7 +258,7 @@ impl Presenter {
         }
         // Print out any self-advisories
         let msg = "This copy of cargo-audit has known advisories! Upgrade cargo-audit to the \
-        latest version: cargo install --force cargo-audit --locked";
+        latest version: cargo install --force cargo-audit";
 
         if self.config.deny.contains(&DenyOption::Warnings) {
             status_err!(msg);


### PR DESCRIPTION
Fixes #1592 by avoiding instructions that are more likely to result in vulnerable dependencies being compiled into cargo-audit.

I think the reasons for doing that in the first place have mostly been addressed:

> since the rustsec crate is more careful about which dependencies it exposes and the tame-index crate no longer depends on gitoxide directly.

This reverts commit 654ac4d260f2ebaf644685bca4b696020914cf71.