### PR TITLE
Validate advisory dates with jiff crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,6 +3297,7 @@ dependencies = [
  "fs-err",
  "gix",
  "home",
+ "jiff",
  "once_cell",
  "platforms",
  "quitters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tempfile = "3"
 termcolor = "1"
 thiserror = "2"
 time = { version = "0.3", default-features = false }
+jiff = { version = "0.2", default-features = false }
 toml = "1.0"
 toml_edit = "0.25"
 url = "2"

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -22,7 +22,7 @@ serde = { workspace = true, features = ["serde_derive"] }
 thiserror = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true, features = ["serde"] }
-time = { workspace = true, features = ["parsing"] }
+jiff = { workspace = true, features = ["std"] }
 
 # for scanning binary files
 auditable-info = { workspace = true, features = ["wasm"], optional = true }
@@ -34,6 +34,7 @@ binfarce = { workspace = true, optional = true }
 # optional dependencies
 tame-index = { workspace = true, features = ["sparse"], optional = true }
 home = { workspace = true, optional = true }
+time = { workspace = true, features = ["formatting", "serde", "parsing"], optional = true }
 gix = { workspace = true, features = ["worktree-mutation", "revision", "max-performance-safe"], optional = true }
 
 [dev-dependencies]
@@ -46,9 +47,8 @@ default = ["gix-reqwest"]
 git = [
     "dep:tame-index",
     "dep:home",
+    "dep:time",
     "dep:gix",
-    "time/formatting",
-    "time/serde",
 ]
 # Exactly one of 'gix-reqwest' or 'gix-curl' must be enabled when using the 'git' feature.
 gix-reqwest = ["gix/blocking-http-transport-reqwest-rust-tls", "git"]

--- a/rustsec/Cargo.toml
+++ b/rustsec/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true, features = ["serde_derive"] }
 thiserror = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true, features = ["serde"] }
+time = { workspace = true, features = ["parsing"] }
 
 # for scanning binary files
 auditable-info = { workspace = true, features = ["wasm"], optional = true }
@@ -33,7 +34,6 @@ binfarce = { workspace = true, optional = true }
 # optional dependencies
 tame-index = { workspace = true, features = ["sparse"], optional = true }
 home = { workspace = true, optional = true }
-time = { workspace = true, features = ["formatting", "serde", "parsing"], optional = true }
 gix = { workspace = true, features = ["worktree-mutation", "revision", "max-performance-safe"], optional = true }
 
 [dev-dependencies]
@@ -46,8 +46,9 @@ default = ["gix-reqwest"]
 git = [
     "dep:tame-index",
     "dep:home",
-    "dep:time",
     "dep:gix",
+    "time/formatting",
+    "time/serde",
 ]
 # Exactly one of 'gix-reqwest' or 'gix-curl' must be enabled when using the 'git' feature.
 gix-reqwest = ["gix/blocking-http-transport-reqwest-rust-tls", "git"]

--- a/rustsec/src/advisory/date.rs
+++ b/rustsec/src/advisory/date.rs
@@ -6,6 +6,10 @@ use std::{
     fmt::{self, Display},
     str::FromStr,
 };
+use time::{
+    Date as TimeDate,
+    format_description::well_known::Iso8601,
+};
 
 /// Minimum allowed year on advisory dates
 pub(crate) const YEAR_MIN: u32 = 2000;
@@ -64,7 +68,20 @@ impl FromStr for Date {
 
     /// Create a `Date` from the given RFC 3339 date string
     fn from_str(rfc3339_date: &str) -> Result<Self, Error> {
-        validate_date(rfc3339_date)?;
+        let date = TimeDate::parse(rfc3339_date, &Iso8601::DATE).map_err(|_| {
+            Error::new(ErrorKind::Parse, format!("invalid date: {rfc3339_date}"))
+        })?;
+
+        if !(YEAR_MIN..=YEAR_MAX).contains(&(date.year() as u32)) {
+            fail!(
+                ErrorKind::Parse,
+                "year must be between {} and {}: {}",
+                YEAR_MIN,
+                YEAR_MAX,
+                rfc3339_date
+            );
+        }
+
         Ok(Date(rfc3339_date.into()))
     }
 }
@@ -76,39 +93,6 @@ impl<'de> Deserialize<'de> for Date {
             .parse()
             .map_err(D::Error::custom)
     }
-}
-
-macro_rules! check_date_part {
-    ($name:expr, $string:expr, $parts:expr, $len:expr, $min:expr, $max:expr) => {
-        let part = $parts
-            .next()
-            .ok_or_else(|| Error::new(ErrorKind::Parse, format!("invalid date: {}", $string)))?;
-
-        if part.len() != $len {
-            fail!(ErrorKind::Parse, "malformed {}: {}", $name, $string);
-        }
-
-        match part.parse::<u32>() {
-            Ok($min..=$max) => (),
-            _ => fail!(ErrorKind::Parse, "malformed {}: {}", $name, $string),
-        }
-    };
-}
-
-/// Validate that a date is well-formed
-fn validate_date(string: &str) -> Result<(), Error> {
-    let mut parts = string.split('-');
-
-    check_date_part!("year", string, parts, 4, YEAR_MIN, YEAR_MAX);
-    check_date_part!("month", string, parts, 2, 1, 12);
-    // TODO: ensure day is in range for month
-    check_date_part!("day", string, parts, 2, 1, 31);
-
-    if parts.next().is_some() {
-        fail!(ErrorKind::Parse, "invalid date: {}", string)
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -133,6 +117,14 @@ mod tests {
         assert!(Date::from_str("2017-01-32").is_err());
         assert!(Date::from_str("2017-01-").is_err());
         assert!(Date::from_str("2017-01-01-01").is_err());
+        assert!(Date::from_str("2017-02-29").is_err());
+        assert!(Date::from_str("2017-04-31").is_err());
+        assert!(Date::from_str("2017-02-30").is_err());
+
+        // Leap year February 29th
+        assert!(Date::from_str("2000-02-29").is_ok());
+        assert!(Date::from_str("2004-02-29").is_ok());
+        assert!(Date::from_str("2100-02-29").is_err());
     }
 
     #[test]

--- a/rustsec/src/advisory/date.rs
+++ b/rustsec/src/advisory/date.rs
@@ -1,12 +1,12 @@
 //! Advisory dates
 
 use crate::error::{Error, ErrorKind};
+use jiff::civil::Date as CivilDate;
 use serde::{Deserialize, Serialize, de};
 use std::{
     fmt::{self, Display},
     str::FromStr,
 };
-use time::{Date as TimeDate, format_description::well_known::Iso8601};
 
 /// Minimum allowed year on advisory dates
 pub(crate) const YEAR_MIN: u32 = 2000;
@@ -65,7 +65,7 @@ impl FromStr for Date {
 
     /// Create a `Date` from the given RFC 3339 date string
     fn from_str(rfc3339_date: &str) -> Result<Self, Error> {
-        let date = TimeDate::parse(rfc3339_date, &Iso8601::DATE)
+        let date = CivilDate::from_str(rfc3339_date)
             .map_err(|_| Error::new(ErrorKind::Parse, format!("invalid date: {rfc3339_date}")))?;
 
         if !(YEAR_MIN..=YEAR_MAX).contains(&(date.year() as u32)) {

--- a/rustsec/src/advisory/date.rs
+++ b/rustsec/src/advisory/date.rs
@@ -6,10 +6,7 @@ use std::{
     fmt::{self, Display},
     str::FromStr,
 };
-use time::{
-    Date as TimeDate,
-    format_description::well_known::Iso8601,
-};
+use time::{Date as TimeDate, format_description::well_known::Iso8601};
 
 /// Minimum allowed year on advisory dates
 pub(crate) const YEAR_MIN: u32 = 2000;
@@ -68,9 +65,8 @@ impl FromStr for Date {
 
     /// Create a `Date` from the given RFC 3339 date string
     fn from_str(rfc3339_date: &str) -> Result<Self, Error> {
-        let date = TimeDate::parse(rfc3339_date, &Iso8601::DATE).map_err(|_| {
-            Error::new(ErrorKind::Parse, format!("invalid date: {rfc3339_date}"))
-        })?;
+        let date = TimeDate::parse(rfc3339_date, &Iso8601::DATE)
+            .map_err(|_| Error::new(ErrorKind::Parse, format!("invalid date: {rfc3339_date}")))?;
 
         if !(YEAR_MIN..=YEAR_MAX).contains(&(date.year() as u32)) {
             fail!(


### PR DESCRIPTION
Tackles a 7-year-old TODO by @tarcieri: replace hand-rolled advisory date parsing with ~~`time`~~ `jiff`.