### PR TITLE
rustsec: add alternatives field to advisory metadata

### DIFF
--- a/rustsec/src/advisory/metadata.rs
+++ b/rustsec/src/advisory/metadata.rs
@@ -95,4 +95,10 @@ pub struct Metadata {
     /// case, for example if a malicious crate has been completely removed.
     #[serde(rename = "expect-deleted", default)]
     pub expect_deleted: bool,
+
+    /// Recommended alternative crates to use instead of the affected crate.
+    ///
+    /// Typically used with `informational = "unmaintained"` advisories.
+    #[serde(default)]
+    pub alternatives: Vec<package::Name>,
 }


### PR DESCRIPTION
I've been wondering if using this on crates.io in the unmaintained banner would be a nicer experience.

@LawnGnome @Turbo87 thoughts?

Many unmaintained advisories already have a list of recommended alternatives with links to crates.io, so this does not provide a new capability by any means. But it feels like it could make the UX nicer (especially not having to bounce from an unmaintained crate on crates.io -> advisory page -> alternative on crates.io), and makes the alternatives more legible to other code.