### PR TITLE
Set user agent for index clients

### DIFF
--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -29,6 +29,7 @@ pub fn crates_index() -> Result<RemoteSparseIndex, tame_index::Error> {
             tame_index::IndexUrl::crates_io(None, None, None)?,
         ))?,
         tame_index::external::reqwest::blocking::ClientBuilder::new()
+            .user_agent(format!("rustsec-admin/{}", env!("CARGO_PKG_VERSION")))
             .build()
             .map_err(tame_index::Error::from)?,
     ))

--- a/cargo-audit/src/auditor.rs
+++ b/cargo-audit/src/auditor.rs
@@ -3,7 +3,8 @@
 use crate::{
     config::AuditConfig, error::display_err_with_source, prelude::*, presenter::Presenter,
 };
-use rustsec::{Error, ErrorKind, Lockfile, Warning, WarningKind, registry, report};
+use rustsec::registry::CachedIndex;
+use rustsec::{Error, ErrorKind, Lockfile, Warning, WarningKind, report};
 
 use rustsec::binary_scanning::BinaryFormat;
 
@@ -26,7 +27,7 @@ pub struct Auditor {
     database: rustsec::Database,
 
     /// Crates.io registry index
-    registry_index: Option<registry::CachedIndex>,
+    registry_index: Option<CachedIndex>,
 
     /// Presenter for displaying the report
     presenter: Presenter,
@@ -129,7 +130,8 @@ impl Auditor {
                     status_ok!("Updating", "crates.io index");
                 }
 
-                let mut result = registry::CachedIndex::fetch(Duration::from_secs(0));
+                let user_agent = format!("cargo-audit/{}", crate::VERSION);
+                let mut result = CachedIndex::fetch_as(Duration::from_secs(0), user_agent.clone());
 
                 // If the directory is locked, print a message and wait for it to become unlocked.
                 // If we don't print the message, `cargo audit` would just hang with no explanation.
@@ -141,7 +143,7 @@ impl Auditor {
                         advisory_db_path.display(),
                         DEFAULT_LOCK_TIMEOUT.as_secs()
                     );
-                    result = registry::CachedIndex::fetch(DEFAULT_LOCK_TIMEOUT);
+                    result = CachedIndex::fetch_as(DEFAULT_LOCK_TIMEOUT, user_agent);
                 }
 
                 match result {
@@ -155,7 +157,7 @@ impl Auditor {
                     }
                 }
             } else {
-                let mut result = registry::CachedIndex::open(Duration::from_secs(0));
+                let mut result = CachedIndex::open(Duration::from_secs(0));
 
                 // If the directory is locked, print a message and wait for it to become unlocked.
                 // If we don't print the message, `cargo audit` would just hang with no explanation.
@@ -167,7 +169,7 @@ impl Auditor {
                         advisory_db_path.display(),
                         DEFAULT_LOCK_TIMEOUT.as_secs()
                     );
-                    result = registry::CachedIndex::open(DEFAULT_LOCK_TIMEOUT)
+                    result = CachedIndex::open(DEFAULT_LOCK_TIMEOUT)
                 }
 
                 match result {

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -68,13 +68,25 @@ impl CachedIndex {
     /// It will fail with [`rustsec::Error::LockTimeout`](Error) if the lock is still held
     /// after that time.
     ///
-    /// If `lock_timeout` is set to `std::time::Duration::from_secs(0)`, it will not wait at all,
+    /// If `lock_timeout` is set to `Duration::from_secs(0)`, it will not wait at all,
     /// and instead return an error immediately if it fails to aquire the lock.
-    pub fn fetch(lock_timeout: Duration) -> Result<Self, Error> {
-        Self::fetch_inner(lock_timeout).map_err(Error::from_tame)
+    pub fn fetch_as(lock_timeout: Duration, user_agent: String) -> Result<Self, Error> {
+        Self::fetch_inner(lock_timeout, user_agent).map_err(Error::from_tame)
     }
 
-    fn fetch_inner(lock_timeout: Duration) -> Result<Self, tame_index::Error> {
+    /// Open the local crates.io index
+    ///
+    /// Synthesizes a user agent string based on the current version of `rustsec`.
+    #[deprecated(since = "0.30.0", note = "Use `CachedIndex::fetch_as()` instead")]
+    pub fn fetch(lock_timeout: Duration) -> Result<Self, Error> {
+        Self::fetch_inner(
+            lock_timeout,
+            format!("rustsec/{}", env!("CARGO_PKG_VERSION")),
+        )
+        .map_err(Error::from_tame)
+    }
+
+    fn fetch_inner(lock_timeout: Duration, user_agent: String) -> Result<Self, tame_index::Error> {
         let si = tame_index::index::SparseIndex::new(tame_index::IndexLocation::new(
             tame_index::IndexUrl::crates_io(None, None, None)?,
         ))?;
@@ -85,6 +97,7 @@ impl CachedIndex {
         // to query other indices that _might_ not support HTTP/2, but
         // hopefully that would never need to happen
         let client = ClientBuilder::default()
+            .user_agent(user_agent)
             .build()
             .map_err(tame_index::Error::from)?;
 

--- a/rustsec/src/cached_index.rs
+++ b/rustsec/src/cached_index.rs
@@ -71,29 +71,25 @@ impl CachedIndex {
     /// If `lock_timeout` is set to `std::time::Duration::from_secs(0)`, it will not wait at all,
     /// and instead return an error immediately if it fails to aquire the lock.
     pub fn fetch(lock_timeout: Duration) -> Result<Self, Error> {
-        Self::fetch_inner(None, lock_timeout).map_err(Error::from_tame)
+        Self::fetch_inner(lock_timeout).map_err(Error::from_tame)
     }
 
-    fn fetch_inner(
-        client: Option<ClientBuilder>,
-        lock_timeout: Duration,
-    ) -> Result<Self, tame_index::Error> {
+    fn fetch_inner(lock_timeout: Duration) -> Result<Self, tame_index::Error> {
         let si = tame_index::index::SparseIndex::new(tame_index::IndexLocation::new(
             tame_index::IndexUrl::crates_io(None, None, None)?,
         ))?;
 
         let lock = acquire_cargo_package_lock(lock_timeout)?;
 
-        let client_builder = client.unwrap_or_default();
         // note: this would need to change if rustsec ever adds the capability
         // to query other indices that _might_ not support HTTP/2, but
         // hopefully that would never need to happen
-        let client = client_builder.build().map_err(tame_index::Error::from)?;
-
-        let index = Index::SparseRemote(tame_index::index::AsyncRemoteSparseIndex::new(si, client));
+        let client = ClientBuilder::default()
+            .build()
+            .map_err(tame_index::Error::from)?;
 
         Ok(CachedIndex {
-            index,
+            index: Index::SparseRemote(tame_index::index::AsyncRemoteSparseIndex::new(si, client)),
             cache: Default::default(),
             lock,
         })


### PR DESCRIPTION
Since

- #1621 

the GitHub Actions jobs linting advisories have been getting 503 responses. Set user agent values.

@Turbo87 do you think we could get the rate limits for rustsec-admin bumped?