### PR TITLE
rustsec: lint against bare usernames in advisory Markdown

### DIFF
--- a/admin/src/commands/lint.rs
+++ b/admin/src/commands/lint.rs
@@ -19,6 +19,8 @@ pub struct LintCmd {
         help = "filesystem path to the RustSec advisory DB git repo"
     )]
     path: Vec<PathBuf>,
+    #[arg(short, long, help = "enable verbose output")]
+    verbose: bool,
 }
 
 impl Runnable for LintCmd {
@@ -49,7 +51,7 @@ impl Runnable for LintCmd {
             repo_path.display()
         );
 
-        let invalid_advisory_count = linter.lint().unwrap_or_else(|e| {
+        let invalid_advisory_count = linter.lint(self.verbose).unwrap_or_else(|e| {
             status_err!("{}", display_err_with_source(&e));
             exit(1);
         });

--- a/admin/src/linter.rs
+++ b/admin/src/linter.rs
@@ -55,7 +55,7 @@ impl Linter {
     }
 
     /// Lint the loaded database
-    pub fn lint(mut self) -> Result<usize, Error> {
+    pub fn lint(mut self, verbose: bool) -> Result<usize, Error> {
         for collection in COLLECTIONS {
             let crate_entries = read_dir_sorted(self.repo_path.join(collection.as_str()))?;
             let mut advisories = Vec::with_capacity(crate_entries.len());
@@ -73,7 +73,7 @@ impl Linter {
 
                 for advisory_entry in read_dir_sorted(crate_dir)? {
                     let advisory_path = advisory_entry.path();
-                    advisories.push(self.lint_advisory(*collection, &advisory_path)?);
+                    advisories.push(self.lint_advisory(*collection, &advisory_path, verbose)?);
                 }
             }
 
@@ -91,6 +91,7 @@ impl Linter {
         &mut self,
         collection: Collection,
         advisory_path: &Path,
+        verbose: bool,
     ) -> Result<Advisory, Error> {
         if !advisory_path.is_file() {
             fail!(
@@ -104,18 +105,19 @@ impl Linter {
         let advisory = Advisory::load_file(advisory_path)?;
         let lint_result = rustsec::advisory::Linter::lint_file(advisory_path)?;
         if lint_result.errors().is_empty() {
-            status_ok!("Linted", "ok: {}", advisory_path.display());
-        } else {
-            self.invalid_advisories += 1;
-
-            status_err!(
-                "{} contained the following lint errors:",
-                advisory_path.display()
-            );
-
-            for error in lint_result.errors() {
-                println!("  - {error}");
+            if verbose {
+                status_ok!("Linted", "ok: {}", advisory_path.display());
             }
+            return Ok(advisory);
+        }
+
+        self.invalid_advisories += 1;
+        status_err!(
+            "{} contained the following lint errors:",
+            advisory_path.display()
+        );
+        for error in lint_result.errors() {
+            println!("  - {error}");
         }
 
         Ok(advisory)

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -64,6 +64,50 @@ impl Linter {
             errors: vec![],
         };
 
+        // Lint against user mentions to avoid spamming
+        if advisory_parts.markdown.contains("@") {
+            let front_matter_lines = advisory_parts.front_matter.lines().count();
+            for (i, line) in advisory_parts.markdown.lines().enumerate() {
+                let mut found = None;
+                for (pi, part) in line.split_inclusive("@").enumerate() {
+                    if pi == 0 {
+                        continue;
+                    }
+
+                    if !part.starts_with(|s: char| s.is_ascii_alphanumeric()) {
+                        continue;
+                    }
+
+                    let Some(username) = part.split_whitespace().next() else {
+                        continue;
+                    };
+
+                    if username.contains(['.', '@', '`']) {
+                        continue;
+                    }
+
+                    found = Some(username.trim_end_matches([')']));
+                    break;
+                }
+
+                let Some(user) = found else {
+                    continue;
+                };
+
+                linter.errors.push(Error {
+                    kind: ErrorKind::Malformed,
+                    section: Some("markdown"),
+                    message: Some(
+                        format!(
+                            "bare @{user} in advisory on line {} (use explicit link to avoid spam)",
+                            front_matter_lines + 4 + i
+                        )
+                        .into(),
+                    ),
+                });
+            }
+        }
+
         linter.lint_advisory(&front_matter, draft);
         Ok(linter)
     }

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use std::{fmt, path::Path};
 
 use super::{Advisory, Category, parts};
+use crate::advisory::Informational;
 use crate::advisory::license::License;
 use crate::fs;
 
@@ -143,7 +144,7 @@ impl Linter {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("category", other.to_string()),
                                     section: Some("advisory"),
-                                    message: Some("unknown category".into()),
+                                    message: Some(format!("unknown category {other:?}").into()),
                                 });
                             }
                         }
@@ -163,11 +164,13 @@ impl Linter {
                             .as_ref()
                             .expect("parsed informational");
 
-                        if informational.is_other() {
+                        if let Informational::Other(key) = informational {
                             self.errors.push(Error {
                                 kind: ErrorKind::value("informational", informational.as_str()),
                                 section: Some("advisory"),
-                                message: Some("unknown informational advisory type".into()),
+                                message: Some(
+                                    format!("unknown informational advisory type {key:?}").into(),
+                                ),
                             });
                         }
                     }
@@ -218,7 +221,7 @@ impl Linter {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("license", l.to_string()),
                                     section: Some("advisory"),
-                                    message: Some("unknown license".into()),
+                                    message: Some(format!("unknown license {l:?}").into()),
                                 });
                             }
                         }

--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -3,11 +3,13 @@
 //!
 //! This is run in CI at the time advisories are submitted.
 
+use std::borrow::Cow;
+use std::str::FromStr;
+use std::{fmt, path::Path};
+
 use super::{Advisory, Category, parts};
 use crate::advisory::license::License;
 use crate::fs;
-use std::str::FromStr;
-use std::{fmt, path::Path};
 
 /// Lint information about a particular advisory
 #[derive(Debug)]
@@ -105,14 +107,16 @@ impl Linter {
                             self.errors.push(Error {
                                 kind: ErrorKind::value("id", value.to_string()),
                                 section: Some("advisory"),
-                                message: Some("advisory ID draft status does not match file name"),
+                                message: Some(
+                                    "advisory ID draft status does not match file name".into(),
+                                ),
                             });
                         }
                         if self.advisory.metadata.id.is_other() {
                             self.errors.push(Error {
                                 kind: ErrorKind::value("id", value.to_string()),
                                 section: Some("advisory"),
-                                message: Some("unknown advisory ID type"),
+                                message: Some("unknown advisory ID type".into()),
                             });
                         } else if let Some(y1) = self.advisory.metadata.id.year() {
                             // Exclude CVE IDs, since the year from CVE ID may not match the report date
@@ -123,7 +127,7 @@ impl Linter {
                                             kind: ErrorKind::value("id", value.to_string()),
                                             section: Some("advisory"),
                                             message: Some(
-                                                "year in advisory ID does not match date",
+                                                "year in advisory ID does not match date".into(),
                                             ),
                                         });
                                     }
@@ -139,7 +143,7 @@ impl Linter {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("category", other.to_string()),
                                     section: Some("advisory"),
-                                    message: Some("unknown category"),
+                                    message: Some("unknown category".into()),
                                 });
                             }
                         }
@@ -147,7 +151,9 @@ impl Linter {
                     "collection" => self.errors.push(Error {
                         kind: ErrorKind::Malformed,
                         section: Some("advisory"),
-                        message: Some("collection shouldn't be explicit; inferred by location"),
+                        message: Some(
+                            "collection shouldn't be explicit; inferred by location".into(),
+                        ),
                     }),
                     "informational" => {
                         let informational = self
@@ -161,7 +167,7 @@ impl Linter {
                             self.errors.push(Error {
                                 kind: ErrorKind::value("informational", informational.as_str()),
                                 section: Some("advisory"),
-                                message: Some("unknown informational advisory type"),
+                                message: Some("unknown informational advisory type".into()),
                             });
                         }
                     }
@@ -172,7 +178,7 @@ impl Linter {
                             self.errors.push(Error {
                                 kind: ErrorKind::value("url", value.to_string()),
                                 section: Some("advisory"),
-                                message: Some("URL must start with https://"),
+                                message: Some("URL must start with https://".into()),
                             });
                         }
                     }
@@ -184,7 +190,7 @@ impl Linter {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("date", value.to_string()),
                                     section: Some("advisory"),
-                                    message: Some("year in advisory ID does not match date"),
+                                    message: Some("year in advisory ID does not match date".into()),
                                 });
                             }
                         } else {
@@ -197,7 +203,8 @@ impl Linter {
                                 kind: ErrorKind::Malformed,
                                 section: Some("metadata"),
                                 message: Some(
-                                    "Field `yanked` is deprecated, use `withdrawn` field instead",
+                                    "field `yanked` is deprecated, use `withdrawn` field instead"
+                                        .into(),
                                 ),
                             });
                         }
@@ -211,7 +218,7 @@ impl Linter {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("license", l.to_string()),
                                     section: Some("advisory"),
-                                    message: Some("Unknown license"),
+                                    message: Some("unknown license".into()),
                                 });
                             }
                         }
@@ -229,7 +236,7 @@ impl Linter {
             self.errors.push(Error {
                 kind: ErrorKind::Malformed,
                 section: Some("advisory"),
-                message: Some("expected table"),
+                message: Some("expected table".into()),
             });
         }
     }
@@ -265,7 +272,9 @@ impl Linter {
                                 self.errors.push(Error {
                                     kind: ErrorKind::value("functions", function.to_string()),
                                     section: Some("affected"),
-                                    message: Some("function path must start with crate name"),
+                                    message: Some(
+                                        "function path must start with crate name".into(),
+                                    ),
                                 });
                             }
                         }
@@ -292,7 +301,7 @@ pub struct Error {
     section: Option<&'static str>,
 
     /// Message about why it's invalid
-    message: Option<&'static str>,
+    message: Option<Cow<'static, str>>,
 }
 
 impl Error {

--- a/rustsec/tests/linter.rs
+++ b/rustsec/tests/linter.rs
@@ -57,7 +57,7 @@ fn invalid_example() {
     let invalid_category = lint.errors()[0].to_string();
     assert_eq!(
         invalid_category,
-        "invalid value `invalid-category` for key `category` in [advisory]: unknown category"
+        "invalid value `invalid-category` for key `category` in [advisory]: unknown category \"invalid-category\""
     );
 
     // explicit `collection` is disallowed


### PR DESCRIPTION
Fixes

- https://github.com/rustsec/advisory-db/issues/3046

@taiki-e sorry for the notification flood. Do you think the last commit here would be sufficient?

Have you tested that the explicit links don't trigger notifications?