### PR TITLE
admin: drop usage of RustEmbed to copy static files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,40 +2991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.118",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "sha2",
- "walkdir",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,7 +3147,6 @@ dependencies = [
  "fs-err",
  "gix",
  "once_cell",
- "rust-embed",
  "rustsec",
  "serde",
  "serde_json",
@@ -3337,17 +3302,6 @@ checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
  "digest",
  "sha1",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ petgraph = "0.8.2"
 platforms = { version = "4", path = "./platforms" }
 quitters = { version = "0.1.0", path = "./quitters" }
 regex = { version = "1.10.6", default-features = false }
-rust-embed = { version = "8.5.0", features = ["deterministic-timestamps"] }
 rustc-demangle = "0.1"
 rustsec = { version = "0.34", path = "./rustsec" }
 semver = "1.0.23"

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -23,7 +23,6 @@ display-error-chain = { workspace = true }
 fs-err = { workspace = true }
 tame-index = { workspace = true, features = ["sparse"] }
 gix = { workspace = true, optional = true }
-rust-embed = { workspace = true }
 rustsec = { workspace = true, features = ["osv-export"] }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }

--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, File},
-    iter,
+    io, iter,
     ops::Deref,
     path::{Path, PathBuf},
     str::FromStr,
@@ -17,7 +17,6 @@ use atom_syndication::{
 };
 use chrono::{Duration, NaiveDate, Utc};
 use comrak::markdown_to_html;
-use rust_embed::RustEmbed;
 use rustsec::advisory::{Category, Id};
 use rustsec::osv::OsvAdvisory;
 use rustsec::repository::git::GitModificationTimes;
@@ -146,7 +145,7 @@ pub fn render_advisories(output_folder: PathBuf) {
     }
 
     // Copy all the static assets.
-    copy_static_assets(&output_folder);
+    copy_static_assets(&output_folder).unwrap();
 
     // Render the index.html (/) page.
     let index_template = IndexTemplate;
@@ -546,22 +545,25 @@ fn render_feed(output_path: &Path, advisories: &[AdvisoryData]) {
     feed.write_to(file).unwrap();
 }
 
-#[derive(RustEmbed)]
-#[folder = "src/web/static/"]
-struct StaticAsset;
+fn copy_static_assets(output_folder: &Path) -> Result<(), io::Error> {
+    let static_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/web/static");
+    copy_dir_recursive(&static_dir, output_folder)
+}
 
-fn copy_static_assets(output_folder: &Path) {
-    for file in StaticAsset::iter() {
-        let asset_path = PathBuf::from(file.as_ref());
-
-        // If the asset is in a folder, e.g. css/. Make the directory first.
-        if let Some(containing_folder) = asset_path.parent() {
-            fs::create_dir_all(output_folder.join(containing_folder)).unwrap();
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), io::Error> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&path, &target)?;
+        } else {
+            fs::copy(&path, &target)?;
         }
-
-        let asset = StaticAsset::get(file.as_ref()).unwrap();
-        fs::write(output_folder.join(file.as_ref()), asset.data).unwrap();
     }
+
+    Ok(())
 }
 
 #[allow(unreachable_pub)] // Askama's macros get this wrong?


### PR DESCRIPTION
This originates from https://github.com/rustsec/rustsec/commit/7dc5382133bbfee8cf4d238d01f0f7f025ed14c7 but I can't find much rationale for it (it seems to be from a precursor separate `admin` repo which no longer exists).

Since we're just copying the assets when `admin web` is invoked, there doesn't seem to be a need to actually embed anything in any binary, and this drags in a bunch of dependencies that we don't really need.

(Despite enabling `deterministic-timestamps`, it seems the files were just copied normally without adjusting file times. I think there might be some benefit to do so but `fs::set_times()` is [unstable](https://github.com/rust-lang/rust/issues/147455) and it doesn't feel like we're deploying often enough that it's going to make a sizable difference.)

Motivated by #1637 adding even more dependencies we don't need.