### PR TITLE
platforms: adapt code generation to clippy::use_self

### DIFF
--- a/platforms-data-gen/src/enums.rs
+++ b/platforms-data-gen/src/enums.rs
@@ -8,6 +8,11 @@ pub(crate) fn distinct_values(key: &str, info: &[HashMap<String, String>]) -> BT
 }
 
 #[must_use]
+pub(crate) fn self_variant_name(value: &str) -> String {
+    format!("Self::{}", to_enum_variant_name(value))
+}
+
+#[must_use]
 pub(crate) fn enumify_value(key: &str, value: &str) -> String {
     format!("{}::{}", to_enum_name(key), to_enum_variant_name(value))
 }

--- a/platforms-data-gen/src/write.rs
+++ b/platforms-data-gen/src/write.rs
@@ -157,7 +157,7 @@ impl {enum_name} {{
         match self {{"
     )?;
     for raw_string in &raw_strings {
-        let variant = enumify_value(key, raw_string);
+        let variant = self_variant_name(raw_string);
         //                       Os::Android => "android",
         writeln!(out, "            {variant} => \"{raw_string}\",")?;
     }
@@ -180,7 +180,7 @@ impl FromStr for {enum_name} {{
         let result = match name {{"
     )?;
     for raw_string in &raw_strings {
-        let variant = enumify_value(key, raw_string);
+        let variant = self_variant_name(raw_string);
         //                            "android" => Os::Android,
         writeln!(out, "            \"{raw_string}\" => {variant},")?;
     }

--- a/platforms-data-gen/templates/bits_footer.rs
+++ b/platforms-data-gen/templates/bits_footer.rs
@@ -6,9 +6,9 @@ impl TryFrom<u8> for PointerWidth {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            64 => Ok(PointerWidth::U64),
-            32 => Ok(PointerWidth::U32),
-            16 => Ok(PointerWidth::U16),
+            64 => Ok(Self::U64),
+            32 => Ok(Self::U32),
+            16 => Ok(Self::U16),
             _ => Err("Invalid pointer width!"),
         }
     }


### PR DESCRIPTION
My previous changes did not account for the platforms code generation setup:

- #1634