### PR TITLE
admin: use fs-err in web command

### DIFF
--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fs::{self, File},
     io, iter,
     ops::Deref,
     path::{Path, PathBuf},
@@ -17,6 +16,7 @@ use atom_syndication::{
 };
 use chrono::{Duration, NaiveDate, Utc};
 use comrak::markdown_to_html;
+use fs_err::{self as fs, File};
 use rustsec::advisory::{Category, Id};
 use rustsec::osv::OsvAdvisory;
 use rustsec::repository::git::GitModificationTimes;


### PR DESCRIPTION
Since

- https://github.com/rustsec/advisory-db/pull/3056

publish-web runs in the advisory-db repo are failing:

```
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Location: admin/src/web.rs:148
```

https://github.com/rustsec/advisory-db/actions/runs/29903300729/job/88868756540

Try to improve error messages by leveraging the fs-err dependency we already have anyway.