### PR TITLE
cargo-lock: replace gumdrop with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
@@ -173,7 +173,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -415,7 +415,7 @@ dependencies = [
  "rustsec",
  "serde",
  "serde_json",
- "syn 2.0.119",
+ "syn",
  "tempfile",
  "thiserror",
  "toml 1.1.2+spec-1.1.0",
@@ -425,7 +425,7 @@ dependencies = [
 name = "cargo-lock"
 version = "11.0.1"
 dependencies = [
- "gumdrop",
+ "clap",
  "petgraph",
  "semver",
  "serde",
@@ -519,7 +519,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -751,7 +751,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -762,7 +762,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -784,7 +784,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -823,7 +823,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -833,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -869,7 +869,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1904,26 +1904,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gumdrop"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc700f989d2f6f0248546222d9b4258f5b02a171a431f8285a81c08142629e3"
-dependencies = [
- "gumdrop_derive",
-]
-
-[[package]]
-name = "gumdrop_derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f9bd3449d77e7831a18abfb7ba2f99ee813dfd15b8c2167c9a54ba20aa99d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,7 +2291,7 @@ checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2356,7 +2336,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2375,7 +2355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2482,7 +2462,7 @@ checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -3258,7 +3238,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -3411,17 +3391,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -3448,7 +3417,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -3514,7 +3483,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -3777,7 +3746,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -3998,7 +3967,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4110,7 +4079,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4121,7 +4090,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4276,7 +4245,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
@@ -4297,7 +4266,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
@@ -4337,7 +4306,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ cvss = { version = "3.0", path = "./cvss" }
 display-error-chain = "0.2.0"
 fs-err = "3"
 gix = { version = "0.85", default-features = false, features = ["sha1"] }
-gumdrop = "0.8"
 home = "0.5"
 object = { version = "0.39", default-features = false, features = ["read", "wasm"] }
 once_cell = "1.15.0"

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -16,7 +16,7 @@ name = "cargo-lock"
 required-features = ["cli"]
 
 [dependencies]
-gumdrop = { workspace = true, optional = true }
+clap = { workspace = true, features = ["derive"], optional = true }
 petgraph = { workspace = true, optional = true }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["serde_derive"] }
@@ -24,7 +24,7 @@ toml = { workspace = true }
 url = { workspace = true }
 
 [features]
-cli = ["gumdrop", "dependency-tree"]
+cli = ["dep:clap", "dependency-tree"]
 dependency-tree = ["petgraph"]
 
 [package.metadata.docs.rs]

--- a/cargo-lock/src/main.rs
+++ b/cargo-lock/src/main.rs
@@ -9,7 +9,7 @@ use cargo_lock::{
     dependency::graph::EdgeDirection,
     package::{self},
 };
-use gumdrop::Options;
+use clap::Parser;
 use petgraph::graph::NodeIndex;
 use std::{
     env, fs, io,
@@ -19,38 +19,36 @@ use std::{
 };
 
 /// `cargo lock` subcommands
-#[derive(Debug, Options)]
+#[derive(Debug, Parser)]
+#[command(name = "cargo-lock")]
 enum Command {
-    /// The `cargo lock list` subcommand
-    #[options(help = "list packages in Cargo.lock")]
+    /// List packages in Cargo.lock
     List(ListCmd),
 
-    /// The `cargo lock translate` subcommand
-    #[options(help = "translate a Cargo.lock file")]
+    /// Translate a Cargo.lock file
     Translate(TranslateCmd),
 
-    /// The `cargo lock tree` subcommand
-    #[options(help = "print a dependency tree for the given dependency")]
+    /// Print a dependency tree for the given dependency
     Tree(TreeCmd),
 }
 
 /// The `cargo lock list` subcommand
-#[derive(Debug, Default, Options)]
+#[derive(Debug, Parser)]
 struct ListCmd {
-    /// Input `Cargo.lock` file
-    #[options(short = "f", help = "input Cargo.lock file")]
+    /// Input Cargo.lock file
+    #[arg(short, long)]
     file: Option<PathBuf>,
 
-    /// Get information for a specific package
-    #[options(short = "p", help = "get information for a single package")]
+    /// Get information for a single package
+    #[arg(short, long)]
     package: Option<package::Name>,
 
-    /// List dependencies as part of the output
-    #[options(short = "d", help = "show dependencies for each package")]
+    /// Show dependencies for each package
+    #[arg(short, long)]
     dependencies: bool,
 
-    /// Show package sources in list
-    #[options(short = "s", help = "show package sources in listing")]
+    /// Show package sources in listing
+    #[arg(short, long)]
     sources: bool,
 }
 
@@ -84,18 +82,18 @@ impl ListCmd {
 }
 
 /// The `cargo lock translate` subcommand
-#[derive(Debug, Options)]
+#[derive(Debug, Parser)]
 struct TranslateCmd {
-    /// Input `Cargo.lock` file
-    #[options(short = "f", help = "input Cargo.lock file to translate")]
+    /// Input Cargo.lock file to translate
+    #[arg(short, long)]
     file: Option<PathBuf>,
 
-    /// Output `Cargo.lock` file
-    #[options(short = "o", help = "output Cargo.lock file (default STDOUT)")]
+    /// Output Cargo.lock file (default STDOUT)
+    #[arg(short, long)]
     output: Option<PathBuf>,
 
-    /// Cargo.lock format version to translate to
-    #[options(short = "v", help = "Cargo.lock resolve version to output")]
+    /// Cargo.lock resolve version to output
+    #[arg(short, long)]
     version: Option<ResolveVersion>,
 }
 
@@ -125,34 +123,21 @@ impl TranslateCmd {
 }
 
 /// The `cargo lock tree` subcommand
-#[derive(Debug, Options)]
+#[derive(Debug, Parser)]
 struct TreeCmd {
-    /// Input `Cargo.lock` file
-    #[options(
-        short = "f",
-        long = "file",
-        help = "input Cargo.lock file to translate"
-    )]
+    /// Input Cargo.lock file to translate
+    #[arg(short, long)]
     file: Option<PathBuf>,
 
     /// Show exact package identities (checksums or specific source versions) when available
-    #[options(
-        short = "x",
-        long = "exact",
-        help = "show exact package identies (checksums or specific source versions) when available"
-    )]
+    #[arg(short = 'x', long)]
     exact: bool,
 
-    // Show inverse dependencies rather than forward dependencies
-    #[options(
-        short = "i",
-        long = "invert",
-        help = "show inverse dependencies _on_ a package, rather than forward dependencies _of_ a package"
-    )]
+    /// Show inverse dependencies _on_ a package, rather than forward dependencies _of_ a package
+    #[arg(short, long = "invert")]
     inverse: bool,
 
-    /// Dependencies names or hashes to draw a tree for
-    #[options(free, help = "dependency names or hashes to draw trees for")]
+    /// Dependency names or hashes to draw trees for
     dependencies: Vec<String>,
 }
 
@@ -255,37 +240,19 @@ fn load_lockfile(path: &Option<PathBuf>) -> Lockfile {
 fn main() {
     let mut args = env::args().collect::<Vec<_>>();
 
-    // Remove leading arguments (bin and potential `lock`)
-    if !args.is_empty() {
-        args.remove(0);
-
-        if args.first().map(AsRef::as_ref) == Some("lock") {
-            args.remove(0);
-        }
+    // Remove the `lock` argument inserted by `cargo` when invoked as `cargo lock`
+    if args.get(1).map(String::as_str) == Some("lock") {
+        args.remove(1);
     }
 
     // If no command is specified, implicitly assume `list`
-    if args.is_empty() || args[0].starts_with('-') {
-        ListCmd::parse_args_default(&args)
-            .unwrap_or_else(|e| {
-                eprintln!("*** error: {}", e);
-                eprintln!("USAGE:");
-                eprintln!("{}", ListCmd::usage());
-                exit(1);
-            })
-            .run();
-        exit(0);
+    if args.len() < 2 || args[1].starts_with('-') {
+        ListCmd::parse_from(&args).run();
+        return;
     }
 
     // ...otherwise parse and run the subcommand
-    let cmd = Command::parse_args_default(&args).unwrap_or_else(|e| {
-        eprintln!("*** error: {}", e);
-        eprintln!("USAGE:");
-        eprintln!("{}", Command::usage());
-        exit(1);
-    });
-
-    match cmd {
+    match Command::parse_from(&args) {
         Command::List(list) => list.run(),
         Command::Translate(translate) => translate.run(),
         Command::Tree(tree) => tree.run(),


### PR DESCRIPTION
gumdrop was last released 4 years ago, and we're already using clap for the other stuff.

(With help from Claude.)