### PR TITLE
admin: embed static assets in binary (again)

### DIFF
--- a/admin/src/web.rs
+++ b/admin/src/web.rs
@@ -545,22 +545,18 @@ fn render_feed(output_path: &Path, advisories: &[AdvisoryData]) {
     feed.write_to(file).unwrap();
 }
 
+/// Copies all the static assets to the output folder
+///
+/// For production, we build the site in the advisory-db publish-web GitHub Actions workflow.
+/// Embed the static assets in the binary so we can just copy them into the output folder.
 fn copy_static_assets(output_folder: &Path) -> Result<(), io::Error> {
-    let static_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/web/static");
-    copy_dir_recursive(&static_dir, output_folder)
-}
-
-fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), io::Error> {
-    fs::create_dir_all(dst)?;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let path = entry.path();
-        let target = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            copy_dir_recursive(&path, &target)?;
-        } else {
-            fs::copy(&path, &target)?;
+    for (path, bytes) in STATIC_ASSETS {
+        let path = output_folder.join(path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
         }
+
+        fs::write(&path, bytes)?;
     }
 
     Ok(())
@@ -639,5 +635,128 @@ impl Deref for AdvisoryData {
 
     fn deref(&self) -> &Self::Target {
         &self.advisory
+    }
+}
+
+const STATIC_ASSETS: &[(&str, &[u8])] = &[
+    ("favicon.ico", include_bytes!("web/static/favicon.ico")),
+    (
+        "favicon-16x16.png",
+        include_bytes!("web/static/favicon-16x16.png"),
+    ),
+    (
+        "favicon-32x32.png",
+        include_bytes!("web/static/favicon-32x32.png"),
+    ),
+    ("css/basic.css", include_bytes!("web/static/css/basic.css")),
+    (
+        "css/highlight.css",
+        include_bytes!("web/static/css/highlight.css"),
+    ),
+    ("css/index.css", include_bytes!("web/static/css/index.css")),
+    ("js/search.js", include_bytes!("web/static/js/search.js")),
+    (
+        "img/debian-logo.svg",
+        include_bytes!("web/static/img/debian-logo.svg"),
+    ),
+    (
+        "img/external-link.svg",
+        include_bytes!("web/static/img/external-link.svg"),
+    ),
+    (
+        "img/github-logo-dark.svg",
+        include_bytes!("web/static/img/github-logo-dark.svg"),
+    ),
+    (
+        "img/github-logo-light.svg",
+        include_bytes!("web/static/img/github-logo-light.svg"),
+    ),
+    (
+        "img/osv-logo-dark.svg",
+        include_bytes!("web/static/img/osv-logo-dark.svg"),
+    ),
+    (
+        "img/osv-logo-light.svg",
+        include_bytes!("web/static/img/osv-logo-light.svg"),
+    ),
+    (
+        "img/rustsec-logo-dark.svg",
+        include_bytes!("web/static/img/rustsec-logo-dark.svg"),
+    ),
+    (
+        "img/rustsec-logo-light.svg",
+        include_bytes!("web/static/img/rustsec-logo-light.svg"),
+    ),
+    (
+        "img/rustsec-logo-square.svg",
+        include_bytes!("web/static/img/rustsec-logo-square.svg"),
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io;
+    use std::path::{Path, PathBuf};
+
+    use super::STATIC_ASSETS;
+
+    #[test]
+    fn static_assets() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/web/static");
+        let seen = check_dir(&root, None).unwrap();
+        assert_eq!(STATIC_ASSETS.len(), seen, "not all static assets were seen");
+    }
+
+    fn check_dir(dir: &Path, sub: Option<&Path>) -> Result<usize, io::Error> {
+        println!(
+            "\n\nChecking static assets in {} (sub {:?})",
+            dir.display(),
+            sub
+        );
+        let mut seen = 0;
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if entry.file_type()?.is_dir() {
+                let inner = dir.join(&path);
+                let Some(file_name) = path.file_name() else {
+                    continue;
+                };
+
+                let sub = Some(match sub {
+                    Some(sub) => sub.join(file_name),
+                    None => PathBuf::from(file_name),
+                });
+                seen += check_dir(&inner, sub.as_deref())?;
+                continue;
+            }
+
+            println!("Checking static asset: {}", path.display());
+            let Some(file_name) = path.file_name() else {
+                continue;
+            };
+
+            let rel_path = match sub {
+                Some(sub) => sub.join(file_name),
+                None => PathBuf::from(file_name),
+            };
+
+            let Some(rel_path_str) = rel_path.to_str() else {
+                continue;
+            };
+
+            println!("Relative path: {rel_path_str}");
+            let Some((_, expected_bytes)) = STATIC_ASSETS.iter().find(|(p, _)| *p == rel_path_str)
+            else {
+                panic!("static asset missing from STATIC_ASSETS: {rel_path_str}");
+            };
+
+            let actual_bytes = fs::read(&path)?;
+            assert_eq!(&actual_bytes, expected_bytes);
+            seen += 1;
+        }
+
+        Ok(seen)
     }
 }


### PR DESCRIPTION
So my earlier PR was wrong:

- https://github.com/rustsec/rustsec/pull/1639

When deploying the site, the publish-web workflow in the advisory-db repo generates the site. It usually works without a full checkout, instead using `cargo install` to install the `rustsec-admin` binary directly from a commit in this repo.

As such, embed the assets in the binary again, but do it without any dependencies. Adds a test to make sure that all the files in `web/static` are in the binary, with the filenames mapped to the correct contents.