### PR TITLE
cargo-lock: bump version to 11.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "11.0.1"
+version = "11.1.0"
 dependencies = [
  "clap",
  "petgraph",

--- a/cargo-lock/Cargo.toml
+++ b/cargo-lock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "cargo-lock"
 description  = "Self-contained Cargo.lock parser with optional dependency graph analysis"
-version      = "11.0.1"
+version      = "11.1.0"
 license      = "Apache-2.0 OR MIT"
 readme       = "README.md"
 homepage     = "https://rustsec.org"


### PR DESCRIPTION
Will just publish this to deal with the cargo-semver-checks noise.

Includes:

- #1650 
- #1633
- #1532 