### PR TITLE
cvss: align EPSILON with its documented value

### DIFF
--- a/cvss/src/v4/score.rs
+++ b/cvss/src/v4/score.rs
@@ -153,7 +153,7 @@ impl Score {
     #[cfg(feature = "std")]
     pub(crate) fn round_v4(value: f64) -> f64 {
         let value = f64::clamp(value, 0.0, 10.0);
-        const EPSILON: f64 = 10e-6;
+        const EPSILON: f64 = 1e-6;
         ((value + EPSILON) * 10.).round() / 10.
     }
 
@@ -217,6 +217,18 @@ mod tests {
         // 8.6 - 7.15 = 1.4499999999999993 (float) => 1.5
         assert_eq!(Score::round_v4(8.6 - 7.15), 1.5);
         assert_eq!(Score::round_v4(5.12345), 5.1);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn round_v4_epsilon_magnitude() {
+        // 5e-6 below the tie — more than the documented 10**-6 epsilon, so it stays down.
+        // No corpus vector lands in that band, so only this case notices a constant that is
+        // too large: the previous 10e-6 (= 1e-5) lifted it to 8.6.
+        assert_eq!(Score::round_v4(8.549_995), 8.5);
+        // Scores clamp to the 0.0..=10.0 range before rounding.
+        assert_eq!(Score::round_v4(-0.5), 0.0);
+        assert_eq!(Score::round_v4(10.7), 10.0);
     }
 
     #[test]


### PR DESCRIPTION
The comment transcribes Red Hat's Python rounding with EPSILON = 10**-6, but the constant read 10e-6, which is 1e-5. No observable change: the full Red Hat corpora (vectors_base4, vectors_modified4, vectors_random4 — 578,224 vectors) score identically under either value, since interpolated scores sit far closer to the ties than either epsilon.