### PR TITLE
cvss: round v2 ties half up and floor published scores at zero

### DIFF
--- a/cvss/CHANGELOG.md
+++ b/cvss/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - v2 temporal and environmental ties round half up, matching the reference ([#1662])
+- v2 published scores floor at zero ([#1662])
 
 [#1662]: https://github.com/rustsec/rustsec/pull/1662
 

--- a/cvss/CHANGELOG.md
+++ b/cvss/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- v2 temporal and environmental ties round half up, matching the reference ([#1662])
+
+[#1662]: https://github.com/rustsec/rustsec/pull/1662
+
 ## 2.1.0 (2025-06-06)
 ### Added
 - CVSS 4.0 support ([#1285])

--- a/cvss/src/v2/score.rs
+++ b/cvss/src/v2/score.rs
@@ -20,10 +20,16 @@ impl Score {
         self.0
     }
 
-    /// Round the score up to 1 decimal (`round_to_1_decimal`)
+    /// Round the score to 1 decimal (`round_to_1_decimal`), half up
+    ///
+    /// The reference implementations compute in exact decimal arithmetic and
+    /// round half up, while `f64` products land one ULP below the tie
+    /// (`9.0 * 0.95 == 8.549999…`), so a small epsilon lifts them onto it
+    /// before rounding, the same approach the v4 reference calculator takes.
     #[cfg(feature = "std")]
     pub fn roundup(self) -> Self {
-        let rounded = (self.0 * 10.0).round() / 10.0;
+        const EPSILON: f64 = 1e-6;
+        let rounded = ((self.0 + EPSILON) * 10.0).round() / 10.0;
         Self(rounded)
     }
 
@@ -57,5 +63,20 @@ impl From<Score> for f64 {
 impl From<Score> for Severity {
     fn from(score: Score) -> Self {
         score.severity()
+    }
+}
+
+#[cfg(all(feature = "std", test))]
+mod tests {
+    use super::Score;
+
+    #[test]
+    fn roundup_epsilon_magnitude() {
+        // One ULP below a tie lifts over it, which is the epsilon's purpose.
+        assert_eq!(Score::new(9.0 * 0.95).roundup().value(), 8.6);
+        // 5e-6 below the tie, beyond the documented 1e-6 epsilon, so it stays down.
+        // No corpus vector lands in that band, so only this case notices a constant that is
+        // too large, like the 10e-6 the v4 module once had.
+        assert_eq!(Score::new(8.549_995).roundup().value(), 8.5);
     }
 }

--- a/cvss/src/v2/vector.rs
+++ b/cvss/src/v2/vector.rs
@@ -401,6 +401,34 @@ mod tests {
         (a - b).abs() < 0.0001
     }
 
+    /// The reference implementations compute in exact decimal arithmetic and
+    /// round ties half up; `9.0 * 0.95` must round to 8.6, not stay at the
+    /// `f64` product one ULP below the tie.
+    #[test]
+    fn temporal_tie_rounds_half_up() {
+        let v = "AV:N/AC:L/Au:S/C:C/I:C/A:C/E:F/RL:U/RC:C";
+        let cvss = Vector::from_str(v).expect("parse vector");
+        assert!(approx_eq(cvss.score().value(), 9.0));
+        assert!(
+            approx_eq(cvss.temporal_score().value(), 8.6),
+            "temporal expected 8.6, got {}",
+            cvss.temporal_score().value()
+        );
+    }
+
+    /// The environmental equation hits the same ties through its collateral
+    /// damage and target distribution factors.
+    #[test]
+    fn environmental_tie_rounds_half_up() {
+        let v = "AV:N/AC:M/Au:N/C:C/I:C/A:P/RL:TF/RC:UC/CDP:MH/TD:M/IR:L/AR:H";
+        let cvss = Vector::from_str(v).expect("parse vector");
+        assert!(
+            approx_eq(cvss.environmental_score().value(), 6.2),
+            "environmental expected 6.2, got {}",
+            cvss.environmental_score().value()
+        );
+    }
+
     #[test]
     fn spec_cve_2002_0392() {
         // See https://www.first.org/cvss/v2/guide (Section 3.3.1 worked

--- a/cvss/src/v2/vector.rs
+++ b/cvss/src/v2/vector.rs
@@ -82,7 +82,10 @@ impl Vector {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn score(&self) -> Score {
-        self.base_score_internal(self.impact())
+        Score::new(f64::max(
+            self.base_score_internal(self.impact()).value(),
+            0.0,
+        ))
     }
 
     /// Internal calculation of Base CVSS that takes impact as parameter.
@@ -139,7 +142,7 @@ impl Vector {
         let score =
             (adjusted_temporal.value() + (10.0 - adjusted_temporal.value()) * cdp_score) * td_score;
 
-        Score::new(score).roundup()
+        Score::new(f64::max(Score::new(score).roundup().value(), 0.0))
     }
 
     /// Calculate Adjusted Impact: modified impact score based on
@@ -170,7 +173,10 @@ impl Vector {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn temporal_score(&self) -> Score {
-        self.temporal_score_internal(self.impact())
+        Score::new(f64::max(
+            self.temporal_score_internal(self.impact()).value(),
+            0.0,
+        ))
     }
 
     /// Internal calculation of Temporal CVSS that takes impact as parameter.
@@ -413,6 +419,34 @@ mod tests {
             approx_eq(cvss.temporal_score().value(), 8.6),
             "temporal expected 8.6, got {}",
             cvss.temporal_score().value()
+        );
+    }
+
+    /// The reference implementation floors the three published scores at
+    /// zero, and only those: the adjusted-temporal intermediate inside the
+    /// environmental equation stays unclamped, so a negative adjusted base
+    /// still lowers the collateral-damage term.
+    #[test]
+    fn published_scores_clamp_at_zero_but_intermediates_do_not() {
+        // Adjusted base is -0.2 here; with CDP:ND the environmental score
+        // clamps to 0.0.
+        let v = "AV:L/AC:H/Au:M/C:N/I:N/A:P/E:H/RL:ND/TD:H/CR:L/IR:H/AR:L";
+        let cvss = Vector::from_str(v).expect("parse vector");
+        assert!(
+            approx_eq(cvss.environmental_score().value(), 0.0),
+            "environmental expected 0.0, got {}",
+            cvss.environmental_score().value()
+        );
+
+        // Same negative adjusted base, but CDP:MH: the unclamped -0.2 feeds
+        // (AT + (10 - AT) * CDP) * TD = (-0.2 + 10.2 * 0.4) * 1.0 = 3.88 → 3.9.
+        // A clamped intermediate would give 4.0.
+        let v = "AV:L/AC:H/Au:M/C:N/I:P/A:N/E:F/RL:TF/RC:UR/CDP:MH/TD:ND/CR:H/IR:L/AR:L";
+        let cvss = Vector::from_str(v).expect("parse vector");
+        assert!(
+            approx_eq(cvss.environmental_score().value(), 3.9),
+            "environmental expected 3.9, got {}",
+            cvss.environmental_score().value()
         );
     }
 


### PR DESCRIPTION
cvss2.py computes in exact decimal arithmetic and rounds `ROUND_HALF_UP`; the crate computes in f64, where products like `9.0 * 0.95` sit one ULP below the tie and round down.
Corpus impact: 856 temporal/environmental values (837 a tenth low, 19 at -0.2); base scores are unaffected.

- `Score::roundup` lifts ties over the boundary before rounding, the same epsilon approach the official CVSS v4 reference calculator takes (`EPSILON = Math.pow(10, -6)` in cvss40.js); closes 833 of the 856. cvss2.py itself needs no epsilon, its decimals are exact.
- The three published scores (base, temporal, environmental) floor at zero; the adjusted-temporal intermediate inside the environmental equation stays unclamped, like the reference (the remaining 23).
- Unit tests pin the epsilon magnitude from both sides (a tie one ULP below 8.55 lifts, a value 5e-6 below stays down) and the floor-vs-intermediate distinction (3.9, not 4.0).