### PR TITLE
cvss: check all three v2 scores across all Red Hat corpora

### DIFF
--- a/cvss/src/v2/vector.rs
+++ b/cvss/src/v2/vector.rs
@@ -561,4 +561,45 @@ mod tests {
             environmental
         );
     }
+
+    #[test]
+    fn spec_cve_2003_0062() {
+        // See https://www.first.org/cvss/v2/guide (Section 3.3.3 worked
+        // example): the local, high-complexity case, with CDP:H/TD:H for the
+        // guide's upper environmental value.
+        let v = "AV:L/AC:H/Au:N/C:C/I:C/A:C/E:POC/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:M";
+        let cvss = Vector::from_str(v).expect("parse vector");
+
+        let base = cvss.score().value();
+        let impact = cvss.impact().roundup().value();
+        let exploitability = cvss.exploitability().roundup().value();
+        let temporal = cvss.temporal_score().value();
+        let environmental = cvss.environmental_score().value();
+
+        assert!(
+            approx_eq(base, 6.2),
+            "base score expected 6.2, got {}",
+            base
+        );
+        assert!(
+            approx_eq(impact, 10.0),
+            "impact expected 10.0, got {}",
+            impact
+        );
+        assert!(
+            approx_eq(exploitability, 1.9),
+            "exploitability expected 1.9, got {}",
+            exploitability
+        );
+        assert!(
+            approx_eq(temporal, 4.9),
+            "temporal expected 4.9, got {}",
+            temporal
+        );
+        assert!(
+            approx_eq(environmental, 7.5),
+            "environmental expected 7.5, got {}",
+            environmental
+        );
+    }
 }

--- a/cvss/tests/redhat-v2.rs
+++ b/cvss/tests/redhat-v2.rs
@@ -13,25 +13,65 @@ fn cvss_v2_random() {
     run_tests_from_file("vectors_random2");
 }
 
+#[test]
+fn cvss_v2_calculator() {
+    run_tests_from_file("vectors_calculator2");
+}
+
+#[test]
+fn cvss_v2_cvsslib() {
+    run_tests_from_file("vectors_cvsslib2");
+}
+
 // Run the test set from Red Hat's Security Python implementation: https://github.com/RedHatProductSecurity/cvss
+// Every line carries a "(base, temporal, environmental)" triple; all three scores are
+// checked. The Python implementation reports None when a vector carries no metrics of the
+// respective group, so those entries assert nothing about the group.
 fn run_tests_from_file(name: &str) {
     let content = fs::read_to_string(format!("tests/cvss-redhat/tests/{}", name)).unwrap();
     for l in content.lines() {
         let parts = l.split(" - ").collect::<Vec<&str>>();
         let vector = parts[0];
-        if vector.len() > 44 {
-            // more than base, skip
-            continue;
-        }
-        // "(base, _, _)"
-        let score = parts[1].split(',').next().unwrap().trim_start_matches('(');
+        let scores = parts[1]
+            .trim_start_matches('(')
+            .trim_end_matches(')')
+            .split(',')
+            .map(|s| {
+                let s = s.trim();
+                (s != "None").then(|| s.parse::<f64>().unwrap())
+            })
+            .collect::<Vec<Option<f64>>>();
+        let [base, temporal, environmental] = scores[..] else {
+            panic!("malformed score triple: {}", l);
+        };
+        let base = base.expect("the base score is always present");
 
         let cvss = Vector::from_str(vector).unwrap();
         // Test correct serialization.
         assert_eq!(cvss.to_string(), parts[0]);
         assert!(cvss.score().value() >= 0.0);
         assert!(cvss.score().value() <= 10.0);
-        let diff: f64 = cvss.score().value() - score.parse::<f64>().unwrap();
-        assert!(diff.abs() < 0.0001);
+        assert!(
+            (cvss.score().value() - base).abs() < 0.0001,
+            "base {} for {}",
+            cvss.score().value(),
+            vector
+        );
+        if let Some(temporal) = temporal {
+            assert!(
+                (cvss.temporal_score().value() - temporal).abs() < 0.0001,
+                "temporal {} for {}",
+                cvss.temporal_score().value(),
+                vector
+            );
+        }
+        if let Some(environmental) = environmental {
+            assert!(
+                (cvss.environmental_score().value() - environmental).abs() < 0.0001,
+                "environmental {} for {}",
+                cvss.environmental_score().value(),
+                vector
+            );
+        }
     }
 }


### PR DESCRIPTION
The harness ran Red Hat's vectors but compared only the base score of each triple, and it skipped every vector string longer than 44 characters; in vectors_random2 that skips 99,358 of the 100,000 vectors, and the 642 short vectors that remain carry temporal metrics that were never asserted. Now every (base, temporal, environmental) triple is asserted in full (None entries, vectors without metrics of the group, assert nothing), and the two corpus files the harness never read join: vectors_calculator2 and vectors_cvsslib2.

The v2 guide's third worked example (CVE-2003-0062, the AV:L/AC:H corner) completes the Section 3.3 set.
This is the harness through which the #1662 divergences surfaced.