### PR TITLE
cvss: fix wrong CVSS version in error messages

### DIFF
--- a/cvss/src/error.rs
+++ b/cvss/src/error.rs
@@ -82,7 +82,7 @@ pub enum Error {
     #[cfg(feature = "v4")]
     /// Invalid nomenclature for CVSSv4.
     InvalidNomenclatureV4 {
-        /// Unknown CBSSv4 nomenclature.
+        /// Unknown CVSSv4 nomenclature.
         nomenclature: String,
     },
 
@@ -120,7 +120,7 @@ impl fmt::Display for Error {
             Self::InvalidMetric { metric_type, value } => {
                 write!(
                     f,
-                    "invalid CVSSv4 {} ({}) metric: `{}`",
+                    "invalid CVSSv3 {} ({}) metric: `{}`",
                     metric_type.name(),
                     metric_type.description(),
                     value


### PR DESCRIPTION
## Summary

- Fix "invalid CVSSv**X**" message to correct reflect 3 instead of 4

InvalidMetric is defined at line 26 to store CVSSv3 Metric type

```
 25     /// Invalid metric for CVSSv3.                                              
 26     InvalidMetric {                                                             
 27         /// The metric that was invalid.                                        
 28         metric_type: v3::metric::MetricType,                                    
 29                                                                                 
 30         /// The value that was provided which is invalid.                       
 31         value: String,                                                          
 32     },           
 ```
However the display at line 120 incorrectly says "CVSSv4"

```
120             Self::InvalidMetric { metric_type, value } => {                     
121                 write!(                                                         
122                     f,                                                          
123                     "invalid CVSSv4 {} ({}) metric: `{}`",                      
124                     metric_type.name(),                                         
125                     metric_type.description(),                                  
126                     value                                                       
127                 )                                                               
128             }         
```



- Additionally a minor typo fix
  "CBSSv4" → "CVSSv4".

