### PR TITLE
cvss: add unit tests for v3 Score methods

### DIFF
--- a/cvss/src/v3/score.rs
+++ b/cvss/src/v3/score.rs
@@ -69,3 +69,28 @@ impl From<Score> for Severity {
         score.severity()
     }
 }
+
+#[cfg(all(feature = "std", test))]
+mod tests {
+    use super::Score;
+    use crate::severity::Severity;
+
+    #[test]
+    fn roundup_exact_tenth_unchanged() {
+        assert_eq!(Score::new(4.0).roundup().value(), 4.0);
+    }
+
+    #[test]
+    fn roundup_rounds_up() {
+        assert_eq!(Score::new(4.01).roundup().value(), 4.1);
+    }
+
+    #[test]
+    fn severity_boundaries() {
+        assert_eq!(Score::new(0.0).severity(), Severity::None);
+        assert_eq!(Score::new(0.1).severity(), Severity::Low);
+        assert_eq!(Score::new(4.0).severity(), Severity::Medium);
+        assert_eq!(Score::new(7.0).severity(), Severity::High);
+        assert_eq!(Score::new(9.0).severity(), Severity::Critical);
+    }
+}


### PR DESCRIPTION
### Summary ###

The v2 and v4 `Score` types both have unit tests for their rounding behavior. 
The v3 `Score` had none, so this adds some basic coverage.


### Test Results ###

```
$ cargo test -p cvss v3::score::tests -- --skip redhat
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running unittests src/lib.rs (target/debug/deps/cvss-adfb28e630120690)

running 3 tests
test v3::score::tests::roundup_exact_tenth_unchanged ... ok
test v3::score::tests::roundup_rounds_up ... ok
test v3::score::tests::severity_boundaries ... ok
$
```