### PR TITLE
Update latest version number in doc

### DIFF
--- a/cargo-audit/src/lib.rs
+++ b/cargo-audit/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.16.0"
+    html_root_url = "https://docs.rs/cargo-audit/0.22.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Summary ####

The current cargo-audit is at version 0.22.2 [1] as can be seen in the Cargo.toml file

```
$ head cargo-audit/Cargo.toml 
[package]
name         = "cargo-audit"
description  = "Audit Cargo.lock for crates with security vulnerabilities"
version      = "0.22.2"
license      = "Apache-2.0 OR MIT"
homepage     = "https://rustsec.org"
repository   = "https://github.com/rustsec/rustsec"
readme       = "README.md"
categories   = ["development-tools::cargo-plugins"]
keywords     = ["cargo-subcommand", "security", "audit", "vulnerability"]
$ 
```

However the docs continue to point to an older 0.16.0 version which might have old APIs.

[1] https://docs.rs/cargo-audit/0.22.2