### PR TITLE
Update url to point to correct cve.org

### DIFF
--- a/rustsec/CHANGELOG.md
+++ b/rustsec/CHANGELOG.md
@@ -192,7 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the experimental check for the presence of a signature on the advisory-db repository. It only verified the presence of a signature without checking for any particular key, so it provided no additional security. ([#816])
 - Fixed a build failure with certain dependency versions on recent compilers due to failing type inference ([#836])
 
-[CVE-2023-22742]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-22742
+[CVE-2023-22742]: https://www.cve.org/CVERecord?id=CVE-2023-22742
 [#816]: https://github.com/rustsec/rustsec/pull/816
 [#831]: https://github.com/rustsec/rustsec/pull/831
 [#836]: https://github.com/rustsec/rustsec/pull/836

--- a/rustsec/src/advisory/id.rs
+++ b/rustsec/src/advisory/id.rs
@@ -95,10 +95,7 @@ impl Id {
                     Some(format!("https://rustsec.org/advisories/{}", self.string))
                 }
             }
-            IdKind::Cve => Some(format!(
-                "https://cve.mitre.org/cgi-bin/cvename.cgi?name={}",
-                self.string
-            )),
+            IdKind::Cve => Some(format!("https://www.cve.org/CVERecord?id={}", self.string)),
             IdKind::Ghsa => Some(format!("https://github.com/advisories/{}", self.string)),
             IdKind::Talos => Some(format!(
                 "https://www.talosintelligence.com/reports/{}",
@@ -280,7 +277,7 @@ mod tests {
         assert_eq!(cve_id.year().unwrap(), 2017);
         assert_eq!(
             cve_id.url().unwrap(),
-            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1000168"
+            "https://www.cve.org/CVERecord?id=CVE-2017-1000168"
         );
         assert_eq!(cve_id.numerical_part().unwrap(), 1000168);
     }

--- a/rustsec/src/osv/advisory.rs
+++ b/rustsec/src/osv/advisory.rs
@@ -346,7 +346,7 @@ fn guess_url_kind(url: &Url) -> OsvReferenceKind {
     if (str.contains("://github.com/") || str.contains("://gitlab.")) && str.contains("/issues/") {
         OsvReferenceKind::REPORT
     // the check for "/advisories/" matches both RustSec and GHSA URLs
-    } else if str.contains("/advisories/") || str.contains("://cve.mitre.org/") {
+    } else if str.contains("/advisories/") || str.contains("://www.cve.org/") {
         OsvReferenceKind::ADVISORY
     } else if str.contains("://crates.io/crates/") {
         OsvReferenceKind::PACKAGE


### PR DESCRIPTION
### Summary ###

The CVE Program transitioned from cve.mitre.org to www.cve.org in 2021 [1].

> Upon completion of the phased transition, the CVE.MITRE.ORG website will be archived and retired.

As of now the older `cve.mitre.org` links are re-directed to current and active `cve.org` links, but its best to replace them in code given the announcement.

### Additional information ###

Here are other places like Ubuntu CVE trackers [2] where the URL related changes have been done.


[1] https://www.cve.org/Media/News/item/news/2021/09/29/Welcome-to-the-New-CVE

[2] https://code.launchpad.net/~eslerm/ubuntu-cve-tracker/+git/ubuntu-cve-tracker/+merge/463170
