### PR TITLE
Reject duplicate metrics in CVSSv3 parser

### DIFF
--- a/cvss/src/error.rs
+++ b/cvss/src/error.rs
@@ -48,6 +48,12 @@ pub enum Error {
         metric_type: v2::MetricType,
     },
 
+    /// Metric is duplicated for CVSSv3.
+    DuplicateMetricV3 {
+        /// Prefix which is doubled.
+        metric_type: v3::metric::MetricType,
+    },
+
     #[cfg(feature = "v2")]
     /// Missing metric for CVSS v2.0.
     MissingMandatoryMetricV2 {
@@ -141,6 +147,14 @@ impl fmt::Display for Error {
                 write!(
                     f,
                     "duplicate CVSSv2 {} ({}) metric",
+                    metric_type.name(),
+                    metric_type.description(),
+                )
+            }
+            Self::DuplicateMetricV3 { metric_type } => {
+                write!(
+                    f,
+                    "duplicate CVSSv3 {} ({}) metric",
                     metric_type.name(),
                     metric_type.description(),
                 )

--- a/cvss/src/v3/base.rs
+++ b/cvss/src/v3/base.rs
@@ -277,19 +277,31 @@ impl FromStr for Base {
             ..Default::default()
         };
 
+        fn get_value<T: FromStr<Err = Error>>(
+            metric_type: MetricType,
+            current_val: Option<T>,
+            new_val: &str,
+        ) -> Result<Option<T>> {
+            let parsed = T::from_str(new_val)?;
+            if current_val.is_some() {
+                return Err(Error::DuplicateMetricV3 { metric_type });
+            }
+            Ok(Some(parsed))
+        }
+
         for &component in components {
             let id = component.0.to_ascii_uppercase();
             let value = component.1.to_ascii_uppercase();
 
             match id.parse::<MetricType>()? {
-                MetricType::AV => metrics.av = Some(value.parse()?),
-                MetricType::AC => metrics.ac = Some(value.parse()?),
-                MetricType::PR => metrics.pr = Some(value.parse()?),
-                MetricType::UI => metrics.ui = Some(value.parse()?),
-                MetricType::S => metrics.s = Some(value.parse()?),
-                MetricType::C => metrics.c = Some(value.parse()?),
-                MetricType::I => metrics.i = Some(value.parse()?),
-                MetricType::A => metrics.a = Some(value.parse()?),
+                MetricType::AV => metrics.av = get_value(MetricType::AV, metrics.av, &value)?,
+                MetricType::AC => metrics.ac = get_value(MetricType::AC, metrics.ac, &value)?,
+                MetricType::PR => metrics.pr = get_value(MetricType::PR, metrics.pr, &value)?,
+                MetricType::UI => metrics.ui = get_value(MetricType::UI, metrics.ui, &value)?,
+                MetricType::S => metrics.s = get_value(MetricType::S, metrics.s, &value)?,
+                MetricType::C => metrics.c = get_value(MetricType::C, metrics.c, &value)?,
+                MetricType::I => metrics.i = get_value(MetricType::I, metrics.i, &value)?,
+                MetricType::A => metrics.a = get_value(MetricType::A, metrics.a, &value)?,
             }
         }
 

--- a/cvss/tests/base.rs
+++ b/cvss/tests/base.rs
@@ -247,3 +247,9 @@ fn low_scope_changed() {
     assert_eq!(&base.to_string(), cvss_for_low_scope_changed);
     assert_eq!(base.score().value(), 1.8);
 }
+
+#[test]
+fn duplicate_metric_rejected() {
+    let vector_with_dup = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/AV:L";
+    assert!(cvss::v3::Base::from_str(vector_with_dup).is_err());
+}


### PR DESCRIPTION
### Summary ###

The v2 and v4 parsers detect and reject duplicate metrics with `DuplicateMetricV2` / `DuplicateMetricV4` errors, this is done via a `get_value` helper that checks if the slot is already occupied or used.

### Issue ###

The v3 parser is missing this and at the moment silently overwrites the earlier value with the later one.

Eg, parsing `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/AV:L` succeeds and uses `AV:L` (the duplicate AV), producing a score of 5.0 instead of the expected 6.1 from `AV:N` (the first AV).

### Fix ###

Current PR is adding:

- A `DuplicateMetricV3` error variant (very similar to the v2/v4 pattern) for V3
- A `get_value` helper (very similar to the existing helpers in `v2/vector.rs` and `v4/vector.rs`) for V3
- A test to verify that duplicate metrics are rejected when running v3

No fmt or clippy errors or warning

```
$ cargo fmt --all -- --check
$ 
$ cargo clippy -p cvss -- -D warnings
    Checking cvss v3.0.0 (/Users/gkamathe/rustsec/cvss)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
$ 
```

Test added is passing as well


```
$ cargo test -p cvss --features v3,std -- duplicate_metric_rejected --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.04s
     Running unittests src/lib.rs (target/debug/deps/cvss-2d20fff1de528278)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s

     Running tests/base.rs (target/debug/deps/base-2a045c7cd7367cf4)

running 1 test
test duplicate_metric_rejected ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 27 filtered out; finished in 0.00s

<< snip >>

$ 
```