### PR TITLE
Report in JSON which warnings --deny promotes to errors

### DIFF
--- a/cargo-audit/src/presenter.rs
+++ b/cargo-audit/src/presenter.rs
@@ -18,6 +18,7 @@ use rustsec::{
 };
 #[cfg(feature = "binary-scanning")]
 use rustsec::{advisory::affected::FunctionPath, binary_scanning::BinaryReport};
+use serde::Serialize;
 
 #[cfg(feature = "binary-scanning")]
 use crate::binary_scanning::SymbolSet;
@@ -42,6 +43,38 @@ pub struct Presenter {
     /// Binary contents for affected-function analysis
     #[cfg(feature = "binary-scanning")]
     binary_contents: Option<Vec<u8>>,
+}
+
+/// A report as it is written in JSON.
+///
+/// The report itself is flattened in, so every key an existing consumer reads
+/// stays exactly where it was; `warning_summary` is added alongside it.
+#[derive(Serialize)]
+struct JsonReport<'a> {
+    #[serde(flatten)]
+    report: &'a rustsec::Report,
+
+    /// What `--deny` made of the warnings above.
+    warning_summary: WarningSummary<'a>,
+}
+
+/// How the configured `deny` options apply to the warnings in a report.
+///
+/// The terminal output already says whether a warning was denied or allowed
+/// -- "1 denied warning found!" versus "1 allowed warning found" -- and the
+/// process exits non-zero for a denied one. This carries the same fact into
+/// the JSON, which otherwise comes out byte-identical whether `--deny` was
+/// given or not.
+#[derive(Serialize)]
+struct WarningSummary<'a> {
+    /// Number of warnings the `deny` configuration promotes to errors.
+    denied: u64,
+
+    /// Number of warnings it leaves as warnings.
+    allowed: u64,
+
+    /// The `deny` options in effect, from `--deny` or `[output] deny`.
+    deny: &'a [DenyOption],
 }
 
 impl Presenter {
@@ -119,8 +152,18 @@ impl Presenter {
     ) {
         match self.config.format {
             OutputFormat::Json => {
+                let (denied, allowed) = self.count_warnings(report);
+                let json_report = JsonReport {
+                    report,
+                    warning_summary: WarningSummary {
+                        denied,
+                        allowed,
+                        deny: &self.config.deny,
+                    },
+                };
+
                 let mut stdout = io::stdout().lock();
-                serde_json::to_writer(&mut stdout, &report).unwrap();
+                serde_json::to_writer(&mut stdout, &json_report).unwrap();
                 // End with a newline as a terminator/separator. Another json report may follow.
                 writeln!(&mut stdout).unwrap();
                 return;


### PR DESCRIPTION
Refs #376. @Shnatsel — you said [a PR would be welcome](https://github.com/rustsec/rustsec/issues/376#issuecomment-1818119364); this is one shape of it, and I'd rather check the shape with you than assume.

First, what current `main` actually does. The MCVE from the issue (`cpuid-bool = "0.2"`):

| run | exit | JSON body |
| --- | --- | --- |
| `cargo audit --json` | 0 | `vulnerabilities.found: false`, `warnings.unmaintained: 1` |
| `cargo audit --deny warnings --json` | **1** | **byte-identical** |

So the *exit code* is already correct — `should_exit_with_failure` counts denied warnings regardless of output format. What's missing is that the JSON says nothing about it. The terminal output distinguishes the two cases (`error: 1 denied warning found!` versus `warning: 1 allowed warning found`); the JSON doesn't, so a consumer that parses it — [audit-check](https://github.com/actions-rs/audit-check), which is the consequence the issue names — can't tell a denied warning from an allowed one.

This carries that same fact across. `warning_summary` is added next to the existing keys:

```json
"warning_summary": { "denied": 1, "allowed": 0, "deny": ["warnings", "unmaintained", "unsound", "yanked"] }
```

with `"denied": 0, "allowed": 1, "deny": []` when nothing is denied. The numbers come from the existing `count_warnings`, so the JSON and the terminal summary line can't drift apart. The `deny` list is there because the issue asks specifically for the `.cargo/audit.toml` route to work, and a consumer may want to know *why* something was denied — that case is covered and produces `deny: ["unmaintained", "unsound", "yanked"]`.

The report is `#[serde(flatten)]`-ed into the wrapper, so **every pre-existing key stays exactly where it was** — verified by comparing the two JSON bodies key by key. Terminal and SARIF output are untouched.

**On the shape.** The issue says it expects the warning "to be promoted to an error in the json", i.e. moved into `vulnerabilities`. I didn't do that, because `Warning` and `Vulnerability` are different types and moving denied warnings would change what every existing `--json` consumer sees, including ones that don't set `deny` at all. An additive key can't break anyone. If you'd rather have the promotion — or a per-warning `"denied": true` instead of a summary — say which and I'll redo it; the change is small either way.

`cargo build`, `cargo fmt --check`, `cargo clippy` (0 warnings, same as the clean tree) and `cargo test -p cargo-audit` are all green.

AI-assisted (LLM used for drafting); the runs above are mine.
