### PR TITLE
implement std::error::Error for linter::Error

### DIFF
--- a/rustsec/src/advisory/linter.rs
+++ b/rustsec/src/advisory/linter.rs
@@ -409,6 +409,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 /// Lint errors
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]


### PR DESCRIPTION
### Summary ###

I see all other error types implements `std::error::Error`

The only exceptions were the advisory linter present in the `rustsec/src/advisory/linter.rs` file for both `Error`

```
bash-3.2$ grep -irn "impl std::error::Error for Error {" *
admin/src/error.rs:61:impl std::error::Error for Error {
cargo-audit/src/error.rs:111:impl std::error::Error for Error {
cargo-lock/src/error.rs:54:impl std::error::Error for Error {}
cvss/src/error.rs:219:impl std::error::Error for Error {}
platforms/src/error.rs:16:impl std::error::Error for Error {}
rustsec/src/error.rs:94:impl std::error::Error for Error {
bash-3.2$ 
```

So added the same as part of this PR, no behavior change is introduced.


